### PR TITLE
Set msrv as 1.58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "lapce"
 version = "0.0.9"
 authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
+rust-version = "1.58"
 resolver = "2"
 
 [dependencies]


### PR DESCRIPTION
Close #58 

If the version of `rustc` is lower than 1.58, it will give a hint like this:
```
cannot be built because it requires rustc 1.58 or newer, while the currently active rustc version is 1.57.0
```