### PR TITLE
fixed broken build

### DIFF
--- a/core/src/palette.rs
+++ b/core/src/palette.rs
@@ -333,7 +333,7 @@ impl PaletteItemContent {
             ),
             PaletteItemContent::SshHost(user, host) => (
                 None,
-                format!("{user}@{host}"),
+                format!("{}@{}",user,host),
                 indices.to_vec(),
                 "".to_string(),
                 vec![],
@@ -897,7 +897,7 @@ impl PaletteViewData {
                     user.to_string(),
                     host.to_string(),
                 ),
-                filter_text: format!("{user}@{host}"),
+                filter_text: format!("{}@{}",user,host),
                 score: 0,
                 indices: vec![],
             })

--- a/core/src/proxy.rs
+++ b/core/src/proxy.rs
@@ -236,7 +236,7 @@ impl LapceProxy {
                         .ok_or(anyhow!("can't find config dir"))?
                         .join(format!("lapce-proxy-{}", VERSION));
                     if !local_proxy_file.exists() {
-                        let url = format!("https://github.com/lapce/lapce/releases/download/v{VERSION}/lapce-proxy-linux.gz");
+                        let url = format!("https://github.com/lapce/lapce/releases/download/v{}/lapce-proxy-linux.gz",VERSION);
                         let mut resp =
                             reqwest::blocking::get(url).expect("request failed");
                         let mut out = std::fs::File::create(&local_proxy_file)
@@ -260,7 +260,7 @@ impl LapceProxy {
                     let mut cmd = cmd.creation_flags(0x08000000);
                     cmd.args(ssh_args)
                         .arg(&local_proxy_file)
-                        .arg(format!("{user}@{host}:~/.lapce/lapce-proxy-{VERSION}"))
+                        .arg(format!("{}@{}:~/.lapce/lapce-proxy-{}",user,host,VERSION))
                         .output()?;
 
                     let mut cmd = Command::new("ssh");

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -293,7 +293,7 @@ impl Widget<LapceTabData> for SearchContent {
                 if i >= min {
                     let mut text_layout = ctx
                         .text()
-                        .new_text_layout(format!("{line_number}: {line}"))
+                        .new_text_layout(format!("{}: {}",line_number,line))
                         .font(FontFamily::SYSTEM_UI, 13.0)
                         .text_color(
                             data.config

--- a/core/src/title.rs
+++ b/core/src/title.rs
@@ -132,11 +132,11 @@ impl Widget<LapceWindowData> for Title {
             LapceWorkspaceType::RemoteSSH(_, host) => {
                 let text = match *tab.proxy_status {
                     ProxyStatus::Connecting => {
-                        format!("Connecting to SSH: {host} ...")
+                        format!("Connecting to SSH: {} ...",host)
                     }
-                    ProxyStatus::Connected => format!("SSH: {host}"),
+                    ProxyStatus::Connected => format!("SSH: {}",host),
                     ProxyStatus::Disconnected => {
-                        format!("Disconnected SSH: {host}")
+                        format!("Disconnected SSH: {}",host)
                     }
                 };
                 let text_layout = ctx


### PR DESCRIPTION
When I tried to build sources, (`cargo build --release`), the following errors showed up: [screenshot](https://imgur.com/a/Wr0rNG4). 

The problem was using named variables on `format!` macro without naming them on the macro's arguments. The solution was simply specify the variables on macro's args, and use them on the order they're passed in.

This patch fixed the errors for me.

Greetings.