### PR TITLE
Close the tab by clicking middle mouse button

### DIFF
--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -90,6 +90,17 @@ impl LapceEditorTabHeaderContent {
                 ));
                 return;
             }
+
+            if mouse_event.button.is_middle()
+                && tab_rect.rect.contains(mouse_event.pos)
+            {
+                ctx.submit_command(Command::new(
+                    LAPCE_UI_COMMAND,
+                    LapceUICommand::EditorTabRemove(i, true, true),
+                    Target::Widget(self.widget_id),
+                ));
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
Add support for closing tab by clicking middle mouse button. This is the default behavior of vscode, firefox and chrome. But feel free to reject it, since it's just a small tweak.