### PR TITLE
refactor: fixed typo in app

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -15,7 +15,7 @@ pub fn build_window(data: &LapceWindowData) -> impl Widget<LapceData> {
     LapceWindowNew::new(data).lens(LapceWindowLens(data.window_id))
 }
 
-pub fn lanuch() {
+pub fn launch() {
     let mut log_dispatch = fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(

--- a/core/src/bin/lapce.rs
+++ b/core/src/bin/lapce.rs
@@ -3,5 +3,5 @@
 use lapce_core::app;
 
 pub fn main() {
-    app::lanuch();
+    app::launch();
 }


### PR DESCRIPTION
- renamed method "lanuch" to "launch"