### PR TITLE
refactor: fixed typo in app

### DIFF
--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -15,7 +15,7 @@ pub fn build_window(data: &LapceWindowData) -> impl Widget<LapceData> {
     LapceWindowNew::new(data).lens(LapceWindowLens(data.window_id))
 }
 
-pub fn lanuch() {
+pub fn launch() {
     let mut log_dispatch = fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(

--- a/lapce-ui/src/bin/lapce.rs
+++ b/lapce-ui/src/bin/lapce.rs
@@ -3,5 +3,5 @@
 use lapce_ui::app;
 
 pub fn main() {
-    app::lanuch();
+    app::launch();
 }


### PR DESCRIPTION
- renamed method "lanuch" to "launch"