### PR TITLE
Add icon when file has not been saved

### DIFF
--- a/icons/unsaved.svg
+++ b/icons/unsaved.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <circle r="4" cy="8" cx="8" fill="#424242"/>
+</svg>

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -7,6 +7,7 @@ use crate::buffer::{matching_pair_direction, Buffer};
 use crate::command::CommandExecuted;
 use crate::completion::{CompletionData, CompletionStatus, Snippet};
 use crate::config::{Config, LapceTheme};
+use crate::data::EditorTabChild;
 use crate::data::{
     EditorDiagnostic, InlineFindDirection, LapceEditorData, LapceMainSplitData,
     LapceTabData, PanelData, PanelKind, RegisterData, SplitContent,
@@ -4759,6 +4760,29 @@ impl TabRect {
                             .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND),
                     ),
                 );
+            }
+        }
+
+        // Only display dirty icon if focus is not on tab bar, so that the close svg can be shown
+        if !(ctx.is_hot() && self.rect.contains(mouse_pos)) {
+            // See if any of the children are dirty
+            let is_dirty = match &editor_tab.children[i] {
+                EditorTabChild::Editor(editor_id) => {
+                    let buffer = data.main_split.editor_buffer(*editor_id);
+                    buffer.dirty
+                }
+            };
+
+            if is_dirty {
+                let svg = get_svg("unsaved.svg").unwrap();
+                ctx.draw_svg(
+                    &svg,
+                    self.close_rect.inflate(-4.0, -4.0),
+                    Some(
+                        data.config
+                            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND),
+                    ),
+                )
             }
         }
     }


### PR DESCRIPTION
This displays a circle icon when the file is not saved, making it easier to know what needs to be saved and what doesn't that you have open.  
![image](https://user-images.githubusercontent.com/13157904/158899106-1a8796be-775c-4333-8512-1a844cb67a79.png)
Similar to vscode, if you hover over the tab the dot-icon is replaced with the close-icon.  
  
Note that this does not add any alert when closing a file that has not been saved, which is a feature that should also be added.