### PR TITLE
Implement ability to load themes from folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,7 @@ dependencies = [
  "structdesc",
  "strum",
  "strum_macros",
+ "thiserror",
  "threadpool",
  "tinyfiledialogs",
  "toml",

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -35,6 +35,7 @@ jsonrpc-lite = "0.5.0"
 bit-vec = "0.5.0"
 parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
 include_dir = "0.6.0"
+thiserror = "1.0"
 anyhow = "1.0.32"
 strum = "0.19"
 strum_macros = "0.19"


### PR DESCRIPTION
This adds the ability to load `.toml` themes from a folder (the same folder that `settings.toml` resides in) named `themes`. The name of the theme is the same as its filename but with out the `.toml` extension, note that this means it is case-sensitive on platforms where case-sensitivity matters.  
Example (bad) theme I threw together:  
![image](https://user-images.githubusercontent.com/13157904/159061735-17498239-9612-4791-845a-b6067e126bc9.png)

I added a `Themes` structure because that felt more reasonable for a `load_theme` function to be on, and allows adding more later on rather than putting them on `Config`. I also added a type alias `Theme` to make it more clear what the hashmap is in places that use themes.