### PR TITLE
Fix mixed line endings and other formatting

### DIFF
--- a/lapce-data/src/container.rs
+++ b/lapce-data/src/container.rs
@@ -1,4 +1,3 @@
-
 use druid::{Point, Size};
 
 pub struct ChildState {

--- a/lapce-data/src/explorer.rs
+++ b/lapce-data/src/explorer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/lapce-data/src/theme.rs
+++ b/lapce-data/src/theme.rs
@@ -1,4 +1,3 @@
-
 pub struct OldLapceTheme {}
 
 impl OldLapceTheme {

--- a/lapce-rpc/src/stdio.rs
+++ b/lapce-rpc/src/stdio.rs
@@ -60,7 +60,7 @@ pub(crate) fn make_io_threads(
 pub struct IoThreads {
     #[allow(dead_code)]
     reader: thread::JoinHandle<io::Result<()>>,
-    
+
     #[allow(dead_code)]
     writer: thread::JoinHandle<io::Result<()>>,
 }

--- a/lapce-ui/src/activity.rs
+++ b/lapce-ui/src/activity.rs
@@ -1,4 +1,4 @@
-use druid::{
+use druid::{
     BoxConstraints, Command, Cursor, Env, Event, EventCtx, LayoutCtx, LifeCycle,
     LifeCycleCtx, PaintCtx, Point, RenderContext, Size, Target, UpdateCtx, Widget,
 };

--- a/lapce-ui/src/container.rs
+++ b/lapce-ui/src/container.rs
@@ -1,4 +1,3 @@
-
 use druid::{Point, Size};
 
 pub struct ChildState {

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use druid::{

--- a/lapce-ui/src/theme.rs
+++ b/lapce-ui/src/theme.rs
@@ -1,4 +1,3 @@
-
 pub struct OldLapceTheme {}
 
 impl OldLapceTheme {


### PR DESCRIPTION
Some files begin with a `\n`, but otherwise use `\r\n` as the newline character. This causes `rustfmt` to get confused and reformat the whole file with `\n`, generating huge diffs. This PR is intended to fix this issue.