### PR TITLE
Keymap parsing and keypress handling improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bit-vec 0.5.1",
+ "bitflags",
  "cc",
  "chrono",
  "config",

--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -1,0 +1,157 @@
+# --------------------------------- General --------------------------------------------
+
+[[keymaps]]
+key = "F1"
+command = "palette.command"
+
+[[keymaps]]
+key = ":"
+command = "palette.command"
+mode = "n"
+
+[[keymaps]]
+key = "space"
+command = "toggle_code_lens"
+mode = "nv"
+
+# --------------------------------- Basic editing ---------------------------------------
+
+[[keymaps]]
+key = "alt+up"
+command = "move_line_up"
+mode = "i"
+
+[[keymaps]]
+key = "alt+down"
+command = "move_line_down"
+mode = "i"
+
+# ------------------------------------ Multi cursor -------------------------------------
+
+[[keymaps]]
+key = "alt+I"
+command = "insert_cursor_end_of_line"
+mode = "i"
+
+# ------------------------------------ ------------ -------------------------------------
+
+[[keymaps]]
+key = "ctrl+m"
+command = "list.select"
+when = "list_focus"
+
+[[keymaps]]
+key = "enter"
+command = "list.select"
+when = "list_focus"
+
+[[keymaps]]
+key = "ctrl+p"
+command = "list.previous"
+when = "list_focus"
+
+[[keymaps]]
+key = "up"
+command = "list.previous"
+when = "list_focus"
+
+[[keymaps]]
+key = "ctrl+n"
+command = "list.next"
+when = "list_focus"
+
+[[keymaps]]
+key = "down"
+command = "list.next"
+when = "list_focus"
+
+[[keymaps]]
+key = "o"
+command = "list.expand"
+when = "list_focus"
+mode = "n"
+
+[[keymaps]]
+key = "/"
+command = "palette.line"
+mode = "n"
+
+[[keymaps]]
+key = "esc"
+command = "palette.cancel"
+when = "palette_focus"
+
+[[keymaps]]
+key = "esc"
+command = "code_actions.cancel"
+when = "code_actions_focus"
+
+[[keymaps]]
+key = "ctrl+b"
+command = "left"
+mode = "i"
+
+[[keymaps]]
+key = "ctrl+f"
+command = "right"
+mode = "i"
+
+[[keymaps]]
+key = "right"
+command = "right"
+
+[[keymaps]]
+key = "left"
+command = "left"
+
+[[keymaps]]
+key = "up"
+command = "up"
+when = "!list_focus"
+
+[[keymaps]]
+key = "down"
+command = "down"
+when = "!list_focus"
+
+[[keymaps]]
+key = "ctrl+u"
+command = "delete_to_beginning_of_line"
+mode = "i"
+
+[[keymaps]]
+key = "ctrl+h"
+command = "delete_backward"
+mode = "i"
+
+[[keymaps]]
+key = "ctrl+w"
+command = "delete_word_backward"
+mode = "i"
+
+[[keymaps]]
+key = "backspace"
+command = "delete_backward"
+mode = "i"
+
+[[keymaps]]
+key = "esc"
+command = "normal_mode"
+mode = "iv"
+
+[[keymaps]]
+key = "enter"
+command = "insert_new_line"
+mode = "i"
+when = "!list_focus"
+
+[[keymaps]]
+key = "tab"
+command = "insert_tab"
+mode = "i"
+
+[[keymaps]]
+key = "ctrl+m"
+command = "insert_new_line"
+mode = "i"
+when = "!list_focus"

--- a/defaults/keymaps-linux.toml
+++ b/defaults/keymaps-linux.toml
@@ -9,22 +9,8 @@ key = "Ctrl+P"
 command = "palette.command"
 
 [[keymaps]]
-key = "F1"
-command = "palette.command"
-
-[[keymaps]]
-key = ":"
-command = "palette.command"
-mode = "n"
-
-[[keymaps]]
 key = "ctrl+,"
 command = "open_settings"
-
-[[keymaps]]
-key = "space"
-command = "toggle_code_lens"
-mode = "nv"
 
 [[keymaps]]
 key = "ctrl+e"
@@ -48,16 +34,6 @@ key = "ctrl+v"
 command = "clipboard_paste"
 mode = "i"
 
-[[keymaps]]
-key = "alt+up"
-command = "move_line_up"
-mode = "i"
-
-[[keymaps]]
-key = "alt+down"
-command = "move_line_down"
-mode = "i"
-
 # ------------------------------------ Multi cursor -------------------------------------
 
 [[keymaps]]
@@ -68,11 +44,6 @@ mode = "i"
 [[keymaps]]
 key = "alt+ctrl+down"
 command = "insert_cursor_below"
-mode = "i"
-
-[[keymaps]]
-key = "alt+I"
-command = "insert_cursor_end_of_line"
 mode = "i"
 
 [[keymaps]]
@@ -103,131 +74,12 @@ mode = "i"
 # ------------------------------------ ------------ -------------------------------------
 
 [[keymaps]]
-key = "ctrl+m"
-command = "list.select"
-when = "list_focus"
-
-[[keymaps]]
-key = "enter"
-command = "list.select"
-when = "list_focus"
-
-[[keymaps]]
-key = "ctrl+p"
-command = "list.previous"
-when = "list_focus"
-
-[[keymaps]]
-key = "up"
-command = "list.previous"
-when = "list_focus"
-
-[[keymaps]]
-key = "ctrl+n"
-command = "list.next"
-when = "list_focus"
-
-[[keymaps]]
-key = "down"
-command = "list.next"
-when = "list_focus"
-
-[[keymaps]]
-key = "o"
-command = "list.expand"
-when = "list_focus"
-mode = "n"
-
-[[keymaps]]
-key = "/"
-command = "palette.line"
-mode = "n"
-
-[[keymaps]]
 key = "alt+o"
 command = "palette.symbol"
 
 [[keymaps]]
 key = "ctrl+s"
 command = "save"
-
-[[keymaps]]
-key = "esc"
-command = "palette.cancel"
-when = "palette_focus"
-
-[[keymaps]]
-key = "esc"
-command = "code_actions.cancel"
-when = "code_actions_focus"
-
-[[keymaps]]
-key = "ctrl+b"
-command = "left"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+f"
-command = "right"
-mode = "i"
-
-[[keymaps]]
-key = "right"
-command = "right"
-
-[[keymaps]]
-key = "left"
-command = "left"
-
-[[keymaps]]
-key = "up"
-command = "up"
-
-[[keymaps]]
-key = "down"
-command = "down"
-
-[[keymaps]]
-key = "ctrl+u"
-command = "delete_to_beginning_of_line"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+h"
-command = "delete_backward"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+w"
-command = "delete_word_backward"
-mode = "i"
-
-[[keymaps]]
-key = "backspace"
-command = "delete_backward"
-mode = "i"
-
-[[keymaps]]
-key = "esc"
-command = "normal_mode"
-mode = "iv"
-
-[[keymaps]]
-key = "enter"
-command = "insert_new_line"
-mode = "i"
-when = "!list_focus"
-
-[[keymaps]]
-key = "tab"
-command = "insert_tab"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+m"
-command = "insert_new_line"
-mode = "i"
-when = "!list_focus"
 
 [[keymaps]]
 key = "tab"

--- a/defaults/keymaps-macos.toml
+++ b/defaults/keymaps-macos.toml
@@ -9,15 +9,6 @@ key = "meta+P"
 command = "palette.command"
 
 [[keymaps]]
-key = "F1"
-command = "palette.command"
-
-[[keymaps]]
-key = ":"
-command = "palette.command"
-mode = "n"
-
-[[keymaps]]
 key = "meta+,"
 command = "open_settings"
 
@@ -48,11 +39,6 @@ command = "show_code_actions"
 mode = "n"
 
 [[keymaps]]
-key = "space"
-command = "toggle_code_lens"
-mode = "nv"
-
-[[keymaps]]
 key = "meta+e"
 command = "toggle_code_lens"
 mode = "i"
@@ -72,16 +58,6 @@ command = "clipboard_copy"
 key = "meta+v"
 command = "clipboard_paste"
 
-[[keymaps]]
-key = "alt+up"
-command = "move_line_up"
-mode = "i"
-
-[[keymaps]]
-key = "alt+down"
-command = "move_line_down"
-mode = "i"
-
 # ------------------------------------ Multi cursor -------------------------------------
 
 [[keymaps]]
@@ -92,11 +68,6 @@ mode = "i"
 [[keymaps]]
 key = "alt+meta+down"
 command = "insert_cursor_below"
-mode = "i"
-
-[[keymaps]]
-key = "alt+I"
-command = "insert_cursor_end_of_line"
 mode = "i"
 
 [[keymaps]]
@@ -127,47 +98,6 @@ mode = "i"
 # ------------------------------------ ------------ -------------------------------------
 
 [[keymaps]]
-key = "ctrl+m"
-command = "list.select"
-when = "list_focus"
-
-[[keymaps]]
-key = "enter"
-command = "list.select"
-when = "list_focus"
-
-[[keymaps]]
-key = "ctrl+p"
-command = "list.previous"
-when = "list_focus"
-
-[[keymaps]]
-key = "up"
-command = "list.previous"
-when = "list_focus"
-
-[[keymaps]]
-key = "ctrl+n"
-command = "list.next"
-when = "list_focus"
-
-[[keymaps]]
-key = "down"
-command = "list.next"
-when = "list_focus"
-
-[[keymaps]]
-key = "o"
-command = "list.expand"
-when = "list_focus"
-mode = "n"
-
-[[keymaps]]
-key = "/"
-command = "palette.line"
-mode = "n"
-
-[[keymaps]]
 key = "meta+o"
 command = "palette.symbol"
 
@@ -176,89 +106,9 @@ key = "meta+s"
 command = "save"
 
 [[keymaps]]
-key = "esc"
-command = "palette.cancel"
-when = "palette_focus"
-
-[[keymaps]]
-key = "esc"
-command = "code_actions.cancel"
-when = "code_actions_focus"
-
-[[keymaps]]
-key = "ctrl+b"
-command = "left"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+f"
-command = "right"
-mode = "i"
-
-[[keymaps]]
-key = "right"
-command = "right"
-
-[[keymaps]]
-key = "left"
-command = "left"
-
-[[keymaps]]
-key = "up"
-command = "up"
-when = "!list_focus"
-
-[[keymaps]]
-key = "down"
-command = "down"
-when = "!list_focus"
-
-[[keymaps]]
-key = "ctrl+u"
-command = "delete_to_beginning_of_line"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+h"
-command = "delete_backward"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+w"
-command = "delete_word_backward"
-mode = "i"
-
-[[keymaps]]
-key = "backspace"
-command = "delete_backward"
-mode = "i"
-
-[[keymaps]]
-key = "esc"
-command = "normal_mode"
-mode = "iv"
-
-[[keymaps]]
 key = "meta+j"
 command = "normal_mode"
 mode = "ivt"
-
-[[keymaps]]
-key = "enter"
-command = "insert_new_line"
-mode = "i"
-when = "!list_focus"
-
-[[keymaps]]
-key = "tab"
-command = "insert_tab"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+m"
-command = "insert_new_line"
-mode = "i"
-when = "!list_focus"
 
 [[keymaps]]
 key = "ctrl+x"

--- a/defaults/keymaps-windows.toml
+++ b/defaults/keymaps-windows.toml
@@ -9,22 +9,8 @@ key = "Ctrl+P"
 command = "palette.command"
 
 [[keymaps]]
-key = "F1"
-command = "palette.command"
-
-[[keymaps]]
-key = ":"
-command = "palette.command"
-mode = "n"
-
-[[keymaps]]
 key = "ctrl+,"
 command = "open_settings"
-
-[[keymaps]]
-key = "space"
-command = "toggle_code_lens"
-mode = "nv"
 
 [[keymaps]]
 key = "ctrl+e"
@@ -48,16 +34,6 @@ key = "ctrl+v"
 command = "clipboard_paste"
 mode = "i"
 
-[[keymaps]]
-key = "alt+up"
-command = "move_line_up"
-mode = "i"
-
-[[keymaps]]
-key = "alt+down"
-command = "move_line_down"
-mode = "i"
-
 # ------------------------------------ Multi cursor -------------------------------------
 
 [[keymaps]]
@@ -68,11 +44,6 @@ mode = "i"
 [[keymaps]]
 key = "alt+ctrl+down"
 command = "insert_cursor_below"
-mode = "i"
-
-[[keymaps]]
-key = "alt+I"
-command = "insert_cursor_end_of_line"
 mode = "i"
 
 [[keymaps]]
@@ -103,131 +74,12 @@ mode = "i"
 # ------------------------------------ ------------ -------------------------------------
 
 [[keymaps]]
-key = "ctrl+m"
-command = "list.select"
-when = "list_focus"
-
-[[keymaps]]
-key = "enter"
-command = "list.select"
-when = "list_focus"
-
-[[keymaps]]
-key = "ctrl+p"
-command = "list.previous"
-when = "list_focus"
-
-[[keymaps]]
-key = "up"
-command = "list.previous"
-when = "list_focus"
-
-[[keymaps]]
-key = "ctrl+n"
-command = "list.next"
-when = "list_focus"
-
-[[keymaps]]
-key = "down"
-command = "list.next"
-when = "list_focus"
-
-[[keymaps]]
-key = "o"
-command = "list.expand"
-when = "list_focus"
-mode = "n"
-
-[[keymaps]]
-key = "/"
-command = "palette.line"
-mode = "n"
-
-[[keymaps]]
 key = "alt+o"
 command = "palette.symbol"
 
 [[keymaps]]
 key = "ctrl+s"
 command = "save"
-
-[[keymaps]]
-key = "esc"
-command = "palette.cancel"
-when = "palette_focus"
-
-[[keymaps]]
-key = "esc"
-command = "code_actions.cancel"
-when = "code_actions_focus"
-
-[[keymaps]]
-key = "ctrl+b"
-command = "left"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+f"
-command = "right"
-mode = "i"
-
-[[keymaps]]
-key = "right"
-command = "right"
-
-[[keymaps]]
-key = "left"
-command = "left"
-
-[[keymaps]]
-key = "up"
-command = "up"
-
-[[keymaps]]
-key = "down"
-command = "down"
-
-[[keymaps]]
-key = "ctrl+u"
-command = "delete_to_beginning_of_line"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+h"
-command = "delete_backward"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+w"
-command = "delete_word_backward"
-mode = "i"
-
-[[keymaps]]
-key = "backspace"
-command = "delete_backward"
-mode = "i"
-
-[[keymaps]]
-key = "esc"
-command = "normal_mode"
-mode = "iv"
-
-[[keymaps]]
-key = "enter"
-command = "insert_new_line"
-mode = "i"
-when = "!list_focus"
-
-[[keymaps]]
-key = "tab"
-command = "insert_tab"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+m"
-command = "insert_new_line"
-mode = "i"
-when = "!list_focus"
 
 [[keymaps]]
 key = "tab"

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
 
 [dependencies]
+bitflags = "1"
 chrono = "0.4.19"
 log = "0.4.14"
 fern = "0.6.0"

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -628,8 +628,7 @@ impl KeyPressData {
                         current_keymaps.remove(index);
                     }
                     for i in 1..keymap.key.len() + 1 {
-                        let key = keymap.key[..i].to_vec();
-                        if let Some(keymaps) = keymaps.get_mut(&key) {
+                        if let Some(keymaps) = keymaps.get_mut(&keymap.key[..i]) {
                             if let Some(index) = keymaps.iter().position(is_keymap) {
                                 keymaps.remove(index);
                             }

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -607,7 +607,10 @@ impl KeyPressData {
         for toml_keymap in toml_keymaps {
             let keymap = match Self::get_keymap(toml_keymap, modal) {
                 Ok(keymap) => keymap,
-                Err(_) => continue,
+                Err(err) => {
+                    log::error!("Could not parse keymap: {err}");
+                    continue;
+                }
             };
 
             let (command, bind) = match keymap.command.strip_prefix('-') {

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -1155,7 +1155,7 @@ impl KeyPressData {
 
             // Custom key name mappings
             "esc" => Escape,
-            "space" => druid::KbKey::Character(" ".to_string()),
+            "space" => Character(" ".to_string()),
             "bs" => Backspace,
             "up" => ArrowUp,
             "down" => ArrowDown,

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -23,6 +23,8 @@ use crate::command::{
 use crate::config::{Config, LapceTheme};
 use crate::{command::LapceCommand, state::Mode};
 
+const DEFAULT_KEYMAPS_COMMON: &str =
+    include_str!("../../defaults/keymaps-common.toml");
 const DEFAULT_KEYMAPS_WINDOWS: &str =
     include_str!("../../defaults/keymaps-windows.toml");
 const DEFAULT_KEYMAPS_MACOS: &str =
@@ -831,14 +833,15 @@ impl KeyPressData {
         IndexMap<Vec<KeyPress>, Vec<KeyMap>>,
         IndexMap<String, Vec<KeyMap>>,
     )> {
-        let mut keymaps_str = if std::env::consts::OS == "macos" {
+        let mut keymaps_str = DEFAULT_KEYMAPS_COMMON.to_string();
+
+        keymaps_str += if std::env::consts::OS == "macos" {
             DEFAULT_KEYMAPS_MACOS
         } else if std::env::consts::OS == "linux" {
             DEFAULT_KEYMAPS_LINUX
         } else {
             DEFAULT_KEYMAPS_WINDOWS
-        }
-        .to_string();
+        };
 
         if let Some(path) = Self::file() {
             if let Ok(content) = std::fs::read_to_string(path) {

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -619,21 +619,18 @@ impl KeyPressData {
                         keymaps.entry(key).or_default().push(keymap.clone());
                     }
                 } else {
-                    if let Some(index) = current_keymaps.iter().position(|k| {
+                    let is_keymap = |k: &KeyMap| -> bool {
                         k.when == keymap.when
                             && k.modes == keymap.modes
                             && k.key == keymap.key
-                    }) {
+                    };
+                    if let Some(index) = current_keymaps.iter().position(is_keymap) {
                         current_keymaps.remove(index);
                     }
                     for i in 1..keymap.key.len() + 1 {
                         let key = keymap.key[..i].to_vec();
                         if let Some(keymaps) = keymaps.get_mut(&key) {
-                            if let Some(index) = keymaps.iter().position(|k| {
-                                k.when == keymap.when
-                                    && k.modes == keymap.modes
-                                    && k.key == keymap.key
-                            }) {
+                            if let Some(index) = keymaps.iter().position(is_keymap) {
                                 keymaps.remove(index);
                             }
                         }

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -126,7 +126,7 @@ impl KeyPress {
             if i < keys_len - 1 {
                 let text_layout = ctx
                     .text()
-                    .new_text_layout("+".to_string())
+                    .new_text_layout("+")
                     .font(FontFamily::SYSTEM_UI, 13.0)
                     .text_color(
                         config

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -611,20 +611,12 @@ impl KeyPressData {
                     None => (keymap.command.clone(), true),
                 };
 
-                if !command_keymaps.contains_key(&command) {
-                    command_keymaps.insert(command.clone(), vec![]);
-                }
-                let current_keymaps = command_keymaps.get_mut(&command).unwrap();
+                let current_keymaps = command_keymaps.entry(command).or_default();
                 if bind {
                     current_keymaps.push(keymap.clone());
                     for i in 1..keymap.key.len() + 1 {
                         let key = keymap.key[..i].to_vec();
-                        match keymaps.get_mut(&key) {
-                            Some(keymaps) => keymaps.push(keymap.clone()),
-                            None => {
-                                keymaps.insert(key, vec![keymap.clone()]);
-                            }
-                        }
+                        keymaps.entry(key).or_default().push(keymap.clone());
                     }
                 } else {
                     if let Some(index) = current_keymaps.iter().position(|k| {

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -606,12 +606,11 @@ impl KeyPressData {
         let mut command_keymaps: IndexMap<String, Vec<KeyMap>> = IndexMap::new();
         for toml_keymap in toml_keymaps {
             if let Ok(keymap) = Self::get_keymap(toml_keymap, modal) {
-                let mut command = keymap.command.clone();
-                let mut bind = true;
-                if command.starts_with('-') {
-                    command = command[1..].to_string();
-                    bind = false;
-                }
+                let (command, bind) = match keymap.command.strip_prefix('-') {
+                    Some(cmd) => (cmd.to_string(), false),
+                    None => (keymap.command.clone(), true),
+                };
+
                 if !command_keymaps.contains_key(&command) {
                     command_keymaps.insert(command.clone(), vec![]);
                 }

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -1257,6 +1257,8 @@ keymaps = [
 ]
         "###;
         let (keymaps, _) = KeyPressData::keymaps_from_str(keymaps, true).unwrap();
+
+        // Lower case modifiers
         let keypress = KeyPressData::get_keypress("ctrl+w");
         assert_eq!(keymaps.get(&keypress).unwrap().len(), 4);
 
@@ -1272,6 +1274,23 @@ keymaps = [
         let keypress = KeyPressData::get_keypress("end");
         assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
 
+        // Upper case modifiers
+        let keypress = KeyPressData::get_keypress("Ctrl+w");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 4);
+
+        let keypress = KeyPressData::get_keypress("Ctrl+w l");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 2);
+
+        let keypress = KeyPressData::get_keypress("Ctrl+w h");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        let keypress = KeyPressData::get_keypress("Ctrl+w l l");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        let keypress = KeyPressData::get_keypress("End");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        // No modifier
         let keypress = KeyPressData::get_keypress("I");
         assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
     }

--- a/lapce-data/src/keypress/keypress.rs
+++ b/lapce-data/src/keypress/keypress.rs
@@ -1,0 +1,464 @@
+use std::fmt::Display;
+
+use druid::{
+    piet::{PietTextLayout, Text, TextLayout, TextLayoutBuilder},
+    FontFamily, Modifiers, PaintCtx, Point, Rect,
+};
+
+use crate::{
+    config::{Config, LapceTheme},
+    keypress::paint_key,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct KeyPress {
+    pub key: druid::KbKey,
+    pub mods: Modifiers,
+}
+
+impl Display for KeyPress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.mods.ctrl() {
+            let _ = f.write_str("Ctrl+");
+        }
+        if self.mods.alt() {
+            let _ = f.write_str("Alt+");
+        }
+        if self.mods.meta() {
+            let _ = f.write_str("Meta+");
+        }
+        if self.mods.shift() {
+            let _ = f.write_str("Shift+");
+        }
+        f.write_str(&self.key.to_string())
+    }
+}
+
+impl KeyPress {
+    pub fn is_char(&self) -> bool {
+        let mut mods = self.mods;
+        mods.set(Modifiers::SHIFT, false);
+        if mods.is_empty() {
+            if let druid::KbKey::Character(_c) = &self.key {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn paint(
+        &self,
+        ctx: &mut PaintCtx,
+        origin: Point,
+        config: &Config,
+    ) -> (Point, Vec<(Option<Rect>, PietTextLayout, Point)>) {
+        let mut origin = origin;
+        let mut keys = Vec::new();
+        if self.mods.ctrl() {
+            keys.push("Ctrl".to_string());
+        }
+        if self.mods.alt() {
+            keys.push("Alt".to_string());
+        }
+        if self.mods.meta() {
+            let keyname = match std::env::consts::OS {
+                "macos" => "Cmd",
+                "windows" => "Win",
+                _ => "Meta",
+            };
+            keys.push(keyname.to_string());
+        }
+        if self.mods.shift() {
+            keys.push("Shift".to_string());
+        }
+        match &self.key {
+            druid::keyboard_types::Key::Character(c) => {
+                if *c == c.to_uppercase()
+                    && c.to_lowercase() != c.to_uppercase()
+                    && !self.mods.shift()
+                {
+                    keys.push("Shift".to_string());
+                }
+                keys.push(c.to_uppercase());
+            }
+            _ => {
+                keys.push(self.key.to_string());
+            }
+        }
+
+        let mut items = Vec::new();
+        let keys_len = keys.len();
+        for (i, key) in keys.iter().enumerate() {
+            let (rect, text_layout, text_layout_pos) =
+                paint_key(ctx, key, origin, config);
+            origin += (rect.width() + 5.0, 0.0);
+
+            items.push((Some(rect), text_layout, text_layout_pos));
+
+            if i < keys_len - 1 {
+                let text_layout = ctx
+                    .text()
+                    .new_text_layout("+")
+                    .font(FontFamily::SYSTEM_UI, 13.0)
+                    .text_color(
+                        config
+                            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+                            .clone(),
+                    )
+                    .build()
+                    .unwrap();
+                let text_size = text_layout.size();
+                let text_layout_pos = origin + (0.0, -(text_size.height / 2.0));
+                items.push((None, text_layout, text_layout_pos));
+                origin += (text_size.width + 5.0, 0.0);
+            }
+        }
+
+        (origin, items)
+    }
+
+    pub fn parse(key: &str) -> Vec<Self> {
+        key.split(' ')
+            .filter_map(|k| {
+                let (modifiers, key) = match k.rsplit_once('+') {
+                    Some(pair) => pair,
+                    None => ("", k),
+                };
+
+                let key = match Self::map_str_to_key(key) {
+                    Some(key) => key,
+                    None => {
+                        // Skip past unrecognized key definitions
+                        log::warn!("Unrecognized key: {key}");
+                        return None;
+                    }
+                };
+
+                let mut mods = Modifiers::default();
+                for part in modifiers.split('+') {
+                    match part.to_lowercase().as_ref() {
+                        "ctrl" => mods.set(Modifiers::CONTROL, true),
+                        "meta" => mods.set(Modifiers::META, true),
+                        "shift" => mods.set(Modifiers::SHIFT, true),
+                        "alt" => mods.set(Modifiers::ALT, true),
+                        _ => (),
+                    }
+                }
+
+                Some(KeyPress { mods, key })
+            })
+            .collect()
+    }
+
+    /// Convert a piece of text representing a key in a keymaps file to the actual key
+    /// Returns `None` if it was not able to find a key with that name
+    fn map_str_to_key(key_part: &str) -> Option<druid::KbKey> {
+        // Checks if it is a character key
+        fn is_key_string(s: &str) -> bool {
+            s.chars().all(|c| !c.is_control())
+                && s.chars().skip(1).all(|c| !c.is_ascii())
+        }
+
+        // Import into scope to reduce noise
+        use druid::keyboard_types::Key::*;
+        Some(match key_part.to_lowercase().as_str() {
+            s if is_key_string(s) => Character(key_part.to_string()),
+            "unidentified" => Unidentified,
+            "alt" => Alt,
+            "altgraph" => AltGraph,
+            "capslock" => CapsLock,
+            "control" => Control,
+            "fn" => Fn,
+            "fnlock" => FnLock,
+            "meta" => Meta,
+            "numlock" => NumLock,
+            "scrolllock" => ScrollLock,
+            "shift" => Shift,
+            "symbol" => Symbol,
+            "symbollock" => SymbolLock,
+            "hyper" => Hyper,
+            "super" => Super,
+            "enter" => Enter,
+            "tab" => Tab,
+            "arrowdown" => ArrowDown,
+            "arrowleft" => ArrowLeft,
+            "arrowright" => ArrowRight,
+            "arrowup" => ArrowUp,
+            "end" => End,
+            "home" => Home,
+            "pagedown" => PageDown,
+            "pageup" => PageUp,
+            "backspace" => Backspace,
+            "clear" => Clear,
+            "copy" => Copy,
+            "crsel" => CrSel,
+            "cut" => Cut,
+            "delete" => Delete,
+            "eraseeof" => EraseEof,
+            "exsel" => ExSel,
+            "insert" => Insert,
+            "paste" => Paste,
+            "redo" => Redo,
+            "undo" => Undo,
+            "accept" => Accept,
+            "again" => Again,
+            "attn" => Attn,
+            "cancel" => Cancel,
+            "contextmenu" => ContextMenu,
+            "escape" => Escape,
+            "execute" => Execute,
+            "find" => Find,
+            "help" => Help,
+            "pause" => Pause,
+            "play" => Play,
+            "props" => Props,
+            "select" => Select,
+            "zoomin" => ZoomIn,
+            "zoomout" => ZoomOut,
+            "brightnessdown" => BrightnessDown,
+            "brightnessup" => BrightnessUp,
+            "eject" => Eject,
+            "logoff" => LogOff,
+            "power" => Power,
+            "poweroff" => PowerOff,
+            "printscreen" => PrintScreen,
+            "hibernate" => Hibernate,
+            "standby" => Standby,
+            "wakeup" => WakeUp,
+            "allcandidates" => AllCandidates,
+            "alphanumeric" => Alphanumeric,
+            "codeinput" => CodeInput,
+            "compose" => Compose,
+            "convert" => Convert,
+            "dead" => Dead,
+            "finalmode" => FinalMode,
+            "groupfirst" => GroupFirst,
+            "grouplast" => GroupLast,
+            "groupnext" => GroupNext,
+            "groupprevious" => GroupPrevious,
+            "modechange" => ModeChange,
+            "nextcandidate" => NextCandidate,
+            "nonconvert" => NonConvert,
+            "previouscandidate" => PreviousCandidate,
+            "process" => Process,
+            "singlecandidate" => SingleCandidate,
+            "hangulmode" => HangulMode,
+            "hanjamode" => HanjaMode,
+            "junjamode" => JunjaMode,
+            "eisu" => Eisu,
+            "hankaku" => Hankaku,
+            "hiragana" => Hiragana,
+            "hiraganakatakana" => HiraganaKatakana,
+            "kanamode" => KanaMode,
+            "kanjimode" => KanjiMode,
+            "katakana" => Katakana,
+            "romaji" => Romaji,
+            "zenkaku" => Zenkaku,
+            "zenkakuhankaku" => ZenkakuHankaku,
+            "f1" => F1,
+            "f2" => F2,
+            "f3" => F3,
+            "f4" => F4,
+            "f5" => F5,
+            "f6" => F6,
+            "f7" => F7,
+            "f8" => F8,
+            "f9" => F9,
+            "f10" => F10,
+            "f11" => F11,
+            "f12" => F12,
+            "soft1" => Soft1,
+            "soft2" => Soft2,
+            "soft3" => Soft3,
+            "soft4" => Soft4,
+            "channeldown" => ChannelDown,
+            "channelup" => ChannelUp,
+            "close" => Close,
+            "mailforward" => MailForward,
+            "mailreply" => MailReply,
+            "mailsend" => MailSend,
+            "mediaclose" => MediaClose,
+            "mediafastforward" => MediaFastForward,
+            "mediapause" => MediaPause,
+            "mediaplay" => MediaPlay,
+            "mediaplaypause" => MediaPlayPause,
+            "mediarecord" => MediaRecord,
+            "mediarewind" => MediaRewind,
+            "mediastop" => MediaStop,
+            "mediatracknext" => MediaTrackNext,
+            "mediatrackprevious" => MediaTrackPrevious,
+            "new" => New,
+            "open" => Open,
+            "print" => Print,
+            "save" => Save,
+            "spellcheck" => SpellCheck,
+            "key11" => Key11,
+            "key12" => Key12,
+            "audiobalanceleft" => AudioBalanceLeft,
+            "audiobalanceright" => AudioBalanceRight,
+            "audiobassboostdown" => AudioBassBoostDown,
+            "audiobassboosttoggle" => AudioBassBoostToggle,
+            "audiobassboostup" => AudioBassBoostUp,
+            "audiofaderfront" => AudioFaderFront,
+            "audiofaderrear" => AudioFaderRear,
+            "audiosurroundmodenext" => AudioSurroundModeNext,
+            "audiotrebledown" => AudioTrebleDown,
+            "audiotrebleup" => AudioTrebleUp,
+            "audiovolumedown" => AudioVolumeDown,
+            "audiovolumeup" => AudioVolumeUp,
+            "audiovolumemute" => AudioVolumeMute,
+            "microphonetoggle" => MicrophoneToggle,
+            "microphonevolumedown" => MicrophoneVolumeDown,
+            "microphonevolumeup" => MicrophoneVolumeUp,
+            "microphonevolumemute" => MicrophoneVolumeMute,
+            "speechcorrectionlist" => SpeechCorrectionList,
+            "speechinputtoggle" => SpeechInputToggle,
+            "launchapplication1" => LaunchApplication1,
+            "launchapplication2" => LaunchApplication2,
+            "launchcalendar" => LaunchCalendar,
+            "launchcontacts" => LaunchContacts,
+            "launchmail" => LaunchMail,
+            "launchmediaplayer" => LaunchMediaPlayer,
+            "launchmusicplayer" => LaunchMusicPlayer,
+            "launchphone" => LaunchPhone,
+            "launchscreensaver" => LaunchScreenSaver,
+            "launchspreadsheet" => LaunchSpreadsheet,
+            "launchwebbrowser" => LaunchWebBrowser,
+            "launchwebcam" => LaunchWebCam,
+            "launchwordprocessor" => LaunchWordProcessor,
+            "browserback" => BrowserBack,
+            "browserfavorites" => BrowserFavorites,
+            "browserforward" => BrowserForward,
+            "browserhome" => BrowserHome,
+            "browserrefresh" => BrowserRefresh,
+            "browsersearch" => BrowserSearch,
+            "browserstop" => BrowserStop,
+            "appswitch" => AppSwitch,
+            "call" => Call,
+            "camera" => Camera,
+            "camerafocus" => CameraFocus,
+            "endcall" => EndCall,
+            "goback" => GoBack,
+            "gohome" => GoHome,
+            "headsethook" => HeadsetHook,
+            "lastnumberredial" => LastNumberRedial,
+            "notification" => Notification,
+            "mannermode" => MannerMode,
+            "voicedial" => VoiceDial,
+            "tv" => TV,
+            "tv3dmode" => TV3DMode,
+            "tvantennacable" => TVAntennaCable,
+            "tvaudiodescription" => TVAudioDescription,
+            "tvaudiodescriptionmixdown" => TVAudioDescriptionMixDown,
+            "tvaudiodescriptionmixup" => TVAudioDescriptionMixUp,
+            "tvcontentsmenu" => TVContentsMenu,
+            "tvdataservice" => TVDataService,
+            "tvinput" => TVInput,
+            "tvinputcomponent1" => TVInputComponent1,
+            "tvinputcomponent2" => TVInputComponent2,
+            "tvinputcomposite1" => TVInputComposite1,
+            "tvinputcomposite2" => TVInputComposite2,
+            "tvinputhdmi1" => TVInputHDMI1,
+            "tvinputhdmi2" => TVInputHDMI2,
+            "tvinputhdmi3" => TVInputHDMI3,
+            "tvinputhdmi4" => TVInputHDMI4,
+            "tvinputvga1" => TVInputVGA1,
+            "tvmediacontext" => TVMediaContext,
+            "tvnetwork" => TVNetwork,
+            "tvnumberentry" => TVNumberEntry,
+            "tvpower" => TVPower,
+            "tvradioservice" => TVRadioService,
+            "tvsatellite" => TVSatellite,
+            "tvsatellitebs" => TVSatelliteBS,
+            "tvsatellitecs" => TVSatelliteCS,
+            "tvsatellitetoggle" => TVSatelliteToggle,
+            "tvterrestrialanalog" => TVTerrestrialAnalog,
+            "tvterrestrialdigital" => TVTerrestrialDigital,
+            "tvtimer" => TVTimer,
+            "avrinput" => AVRInput,
+            "avrpower" => AVRPower,
+            "colorf0red" => ColorF0Red,
+            "colorf1green" => ColorF1Green,
+            "colorf2yellow" => ColorF2Yellow,
+            "colorf3blue" => ColorF3Blue,
+            "colorf4grey" => ColorF4Grey,
+            "colorf5brown" => ColorF5Brown,
+            "closedcaptiontoggle" => ClosedCaptionToggle,
+            "dimmer" => Dimmer,
+            "displayswap" => DisplaySwap,
+            "dvr" => DVR,
+            "exit" => Exit,
+            "favoriteclear0" => FavoriteClear0,
+            "favoriteclear1" => FavoriteClear1,
+            "favoriteclear2" => FavoriteClear2,
+            "favoriteclear3" => FavoriteClear3,
+            "favoriterecall0" => FavoriteRecall0,
+            "favoriterecall1" => FavoriteRecall1,
+            "favoriterecall2" => FavoriteRecall2,
+            "favoriterecall3" => FavoriteRecall3,
+            "favoritestore0" => FavoriteStore0,
+            "favoritestore1" => FavoriteStore1,
+            "favoritestore2" => FavoriteStore2,
+            "favoritestore3" => FavoriteStore3,
+            "guide" => Guide,
+            "guidenextday" => GuideNextDay,
+            "guidepreviousday" => GuidePreviousDay,
+            "info" => Info,
+            "instantreplay" => InstantReplay,
+            "link" => Link,
+            "listprogram" => ListProgram,
+            "livecontent" => LiveContent,
+            "lock" => Lock,
+            "mediaapps" => MediaApps,
+            "mediaaudiotrack" => MediaAudioTrack,
+            "medialast" => MediaLast,
+            "mediaskipbackward" => MediaSkipBackward,
+            "mediaskipforward" => MediaSkipForward,
+            "mediastepbackward" => MediaStepBackward,
+            "mediastepforward" => MediaStepForward,
+            "mediatopmenu" => MediaTopMenu,
+            "navigatein" => NavigateIn,
+            "navigatenext" => NavigateNext,
+            "navigateout" => NavigateOut,
+            "navigateprevious" => NavigatePrevious,
+            "nextfavoritechannel" => NextFavoriteChannel,
+            "nextuserprofile" => NextUserProfile,
+            "ondemand" => OnDemand,
+            "pairing" => Pairing,
+            "pinpdown" => PinPDown,
+            "pinpmove" => PinPMove,
+            "pinptoggle" => PinPToggle,
+            "pinpup" => PinPUp,
+            "playspeeddown" => PlaySpeedDown,
+            "playspeedreset" => PlaySpeedReset,
+            "playspeedup" => PlaySpeedUp,
+            "randomtoggle" => RandomToggle,
+            "rclowbattery" => RcLowBattery,
+            "recordspeednext" => RecordSpeedNext,
+            "rfbypass" => RfBypass,
+            "scanchannelstoggle" => ScanChannelsToggle,
+            "screenmodenext" => ScreenModeNext,
+            "settings" => Settings,
+            "splitscreentoggle" => SplitScreenToggle,
+            "stbinput" => STBInput,
+            "stbpower" => STBPower,
+            "subtitle" => Subtitle,
+            "teletext" => Teletext,
+            "videomodenext" => VideoModeNext,
+            "wink" => Wink,
+            "zoomtoggle" => ZoomToggle,
+
+            // Custom key name mappings
+            "esc" => Escape,
+            "space" => Character(" ".to_string()),
+            "bs" => Backspace,
+            "up" => ArrowUp,
+            "down" => ArrowDown,
+            "right" => ArrowRight,
+            "left" => ArrowLeft,
+            "del" => Delete,
+
+            _ => return None,
+        })
+    }
+}

--- a/lapce-data/src/keypress/keypress.rs
+++ b/lapce-data/src/keypress/keypress.rs
@@ -135,8 +135,8 @@ impl KeyPress {
                 };
 
                 let mut mods = Modifiers::default();
-                for part in modifiers.split('+') {
-                    match part.to_lowercase().as_ref() {
+                for part in modifiers.to_lowercase().split('+') {
+                    match part {
                         "ctrl" => mods.set(Modifiers::CONTROL, true),
                         "meta" => mods.set(Modifiers::META, true),
                         "shift" => mods.set(Modifiers::SHIFT, true),

--- a/lapce-data/src/keypress/keypress.rs
+++ b/lapce-data/src/keypress/keypress.rs
@@ -141,7 +141,7 @@ impl KeyPress {
                         "meta" => mods.set(Modifiers::META, true),
                         "shift" => mods.set(Modifiers::SHIFT, true),
                         "alt" => mods.set(Modifiers::ALT, true),
-                        _ => (),
+                        other => log::warn!("Invalid key modifier: {}", other),
                     }
                 }
 

--- a/lapce-data/src/keypress/loader.rs
+++ b/lapce-data/src/keypress/loader.rs
@@ -1,0 +1,175 @@
+use anyhow::{anyhow, Result};
+use indexmap::IndexMap;
+use toml;
+
+use crate::{
+    keypress::{get_modes, KeyMap, KeyPress},
+    state::Mode,
+};
+
+pub struct KeyMapLoader {
+    keymaps: IndexMap<Vec<KeyPress>, Vec<KeyMap>>,
+    command_keymaps: IndexMap<String, Vec<KeyMap>>,
+}
+
+impl KeyMapLoader {
+    pub fn new() -> Self {
+        Self {
+            keymaps: Default::default(),
+            command_keymaps: Default::default(),
+        }
+    }
+
+    pub fn load_from_str<'a>(
+        &'a mut self,
+        s: &str,
+        modal: bool,
+    ) -> Result<&'a mut Self> {
+        let toml_keymaps: toml::Value = toml::from_str(s)?;
+        let toml_keymaps = toml_keymaps
+            .get("keymaps")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| anyhow!("no keymaps"))?;
+
+        for toml_keymap in toml_keymaps {
+            let keymap = match Self::get_keymap(toml_keymap, modal) {
+                Ok(keymap) => keymap,
+                Err(err) => {
+                    log::error!("Could not parse keymap: {err}");
+                    continue;
+                }
+            };
+
+            let (command, bind) = match keymap.command.strip_prefix('-') {
+                Some(cmd) => (cmd.to_string(), false),
+                None => (keymap.command.clone(), true),
+            };
+
+            let current_keymaps = self.command_keymaps.entry(command).or_default();
+            if bind {
+                current_keymaps.push(keymap.clone());
+                for i in 1..keymap.key.len() + 1 {
+                    let key = keymap.key[..i].to_vec();
+                    self.keymaps.entry(key).or_default().push(keymap.clone());
+                }
+            } else {
+                let is_keymap = |k: &KeyMap| -> bool {
+                    k.when == keymap.when
+                        && k.modes == keymap.modes
+                        && k.key == keymap.key
+                };
+                if let Some(index) = current_keymaps.iter().position(is_keymap) {
+                    current_keymaps.remove(index);
+                }
+                for i in 1..keymap.key.len() + 1 {
+                    if let Some(keymaps) = self.keymaps.get_mut(&keymap.key[..i]) {
+                        if let Some(index) = keymaps.iter().position(is_keymap) {
+                            keymaps.remove(index);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(self)
+    }
+
+    pub fn finalize(
+        self,
+    ) -> (
+        IndexMap<Vec<KeyPress>, Vec<KeyMap>>,
+        IndexMap<String, Vec<KeyMap>>,
+    ) {
+        let Self {
+            keymaps: map,
+            command_keymaps: command_map,
+        } = self;
+
+        (map, command_map)
+    }
+
+    fn get_keymap(toml_keymap: &toml::Value, modal: bool) -> Result<KeyMap> {
+        let key = toml_keymap
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("no key in keymap"))?;
+
+        let modes = get_modes(toml_keymap);
+        if !modal && !modes.is_empty() && !modes.contains(&Mode::Insert) {
+            return Err(anyhow!(""));
+        }
+
+        Ok(KeyMap {
+            key: KeyPress::parse(key),
+            modes: get_modes(toml_keymap),
+            when: toml_keymap
+                .get("when")
+                .and_then(|w| w.as_str())
+                .map(|w| w.to_string()),
+            command: toml_keymap
+                .get("command")
+                .and_then(|c| c.as_str())
+                .map(|w| w.trim().to_string())
+                .unwrap_or_else(|| "".to_string()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keymap() {
+        let keymaps = r###"
+keymaps = [
+    { key = "ctrl+w l l", command = "right", when = "n" },
+    { key = "ctrl+w l", command = "right", when = "n" },
+    { key = "ctrl+w h", command = "left", when = "n" },
+    { key = "ctrl+w",   command = "left", when = "n" },
+    { key = "End", command = "line_end", when = "n" },
+    { key = "I", command = "insert_first_non_blank", when = "n" },
+]
+        "###;
+        let mut loader = KeyMapLoader::new();
+        loader.load_from_str(keymaps, true).unwrap();
+
+        let (keymaps, _) = loader.finalize();
+
+        // Lower case modifiers
+        let keypress = KeyPress::parse("ctrl+w");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 4);
+
+        let keypress = KeyPress::parse("ctrl+w l");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 2);
+
+        let keypress = KeyPress::parse("ctrl+w h");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        let keypress = KeyPress::parse("ctrl+w l l");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        let keypress = KeyPress::parse("end");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        // Upper case modifiers
+        let keypress = KeyPress::parse("Ctrl+w");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 4);
+
+        let keypress = KeyPress::parse("Ctrl+w l");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 2);
+
+        let keypress = KeyPress::parse("Ctrl+w h");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        let keypress = KeyPress::parse("Ctrl+w l l");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        let keypress = KeyPress::parse("End");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+
+        // No modifier
+        let keypress = KeyPress::parse("I");
+        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
+    }
+}

--- a/lapce-data/src/keypress/loader.rs
+++ b/lapce-data/src/keypress/loader.rs
@@ -106,7 +106,7 @@ impl KeyMapLoader {
 
         Ok(Some(KeyMap {
             key: KeyPress::parse(key),
-            modes: get_modes(toml_keymap),
+            modes,
             when: toml_keymap
                 .get("when")
                 .and_then(|w| w.as_str())

--- a/lapce-data/src/keypress/loader.rs
+++ b/lapce-data/src/keypress/loader.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 
 use crate::{
     keypress::{get_modes, keypress::KeyPress, KeyMap},
-    state::Mode,
+    state::Modes,
 };
 
 pub struct KeyMapLoader {
@@ -99,7 +99,7 @@ impl KeyMapLoader {
 
         let modes = get_modes(toml_keymap);
         // If not using modal editing, remove keymaps that only make sense in modal.
-        if !modal && !modes.is_empty() && !modes.contains(&Mode::Insert) {
+        if !modal && !modes.is_empty() && !modes.contains(Modes::INSERT) {
             log::debug!("Keymap ignored: {}", key);
             return Ok(None);
         }

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -352,10 +352,8 @@ impl KeyPressData {
             KeymapMatch::None => {
                 self.pending_keypress.clear();
                 if focus.get_mode() == Mode::Insert {
-                    let mut keypress = keypress.clone();
-                    keypress.mods.set(Modifiers::SHIFT, false);
                     if let KeymapMatch::Full(command) =
-                        self.match_keymap(&[keypress], focus)
+                        self.match_keymap(std::slice::from_ref(&keypress), focus)
                     {
                         if let Ok(cmd) = LapceCommand::from_str(&command) {
                             if cmd.move_command(None).is_some() {

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -305,6 +305,8 @@ impl KeyPressData {
         focus: &mut T,
         env: &Env,
     ) -> bool {
+        log::info!("Keypress: {key_event:?}");
+
         if key_event.key == druid::KbKey::Shift {
             let mut mods = key_event.mods;
             mods.set(Modifiers::SHIFT, false);
@@ -312,6 +314,8 @@ impl KeyPressData {
                 return false;
             }
         }
+
+        // We are removing Shift modifier since the character is already upper case.
         let mut mods = key_event.mods;
         if let druid::KbKey::Character(_) = &key_event.key {
             mods.set(Modifiers::SHIFT, false);

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -370,7 +370,6 @@ impl KeyPressData {
 
         if mode != Mode::Insert
             && mode != Mode::Terminal
-            && !focus.expect_char()
             && self.handle_count(focus, &keypress)
         {
             return false;
@@ -378,9 +377,7 @@ impl KeyPressData {
 
         self.count = None;
 
-        let mut mods = keypress.mods;
-        mods.set(Modifiers::SHIFT, false);
-        if mods.is_empty() {
+        if keypress.mods.is_empty() {
             if let druid::KbKey::Character(c) = &key_event.key {
                 focus.receive_char(ctx, c);
                 return true;

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -156,7 +156,7 @@ pub struct KeyPressData {
 
     count: Option<usize>,
 
-    event_sink: Arc<ExtEventSink>,
+    event_sink: ExtEventSink,
 }
 
 impl KeyPressData {
@@ -174,7 +174,7 @@ impl KeyPressData {
             filtered_commands_with_keymap: Arc::new(Vec::new()),
             filtered_commands_without_keymap: Arc::new(Vec::new()),
             count: None,
-            event_sink: Arc::new(event_sink),
+            event_sink,
         };
         keypress.load_commands();
         keypress

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -1,9 +1,8 @@
-use std::fmt::Display;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use druid::piet::{PietTextLayout, Text, TextLayout, TextLayoutBuilder};
 use druid::{Command, KbKey};
 use druid::{
@@ -16,12 +15,18 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use toml;
 
+mod keypress;
+mod loader;
+
 use crate::command::{
     lapce_internal_commands, CommandExecuted, CommandTarget, LapceCommandNew,
     LapceUICommand, LAPCE_NEW_COMMAND, LAPCE_UI_COMMAND,
 };
 use crate::config::{Config, LapceTheme};
+use crate::keypress::loader::KeyMapLoader;
 use crate::{command::LapceCommand, state::Mode};
+
+pub use keypress::KeyPress;
 
 const DEFAULT_KEYMAPS_COMMON: &str =
     include_str!("../../../defaults/keymaps-common.toml");
@@ -38,114 +43,6 @@ enum KeymapMatch {
     Multiple(Vec<String>),
     Prefix,
     None,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct KeyPress {
-    pub key: druid::KbKey,
-    pub mods: Modifiers,
-}
-
-impl Display for KeyPress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.mods.ctrl() {
-            let _ = f.write_str("Ctrl+");
-        }
-        if self.mods.alt() {
-            let _ = f.write_str("Alt+");
-        }
-        if self.mods.meta() {
-            let _ = f.write_str("Meta+");
-        }
-        if self.mods.shift() {
-            let _ = f.write_str("Shift+");
-        }
-        f.write_str(&self.key.to_string())
-    }
-}
-
-impl KeyPress {
-    pub fn is_char(&self) -> bool {
-        let mut mods = self.mods;
-        mods.set(Modifiers::SHIFT, false);
-        if mods.is_empty() {
-            if let druid::KbKey::Character(_c) = &self.key {
-                return true;
-            }
-        }
-        false
-    }
-
-    pub fn paint(
-        &self,
-        ctx: &mut PaintCtx,
-        origin: Point,
-        config: &Config,
-    ) -> (Point, Vec<(Option<Rect>, PietTextLayout, Point)>) {
-        let mut origin = origin;
-        let mut keys = Vec::new();
-        if self.mods.ctrl() {
-            keys.push("Ctrl".to_string());
-        }
-        if self.mods.alt() {
-            keys.push("Alt".to_string());
-        }
-        if self.mods.meta() {
-            let keyname = match std::env::consts::OS {
-                "macos" => "Cmd",
-                "windows" => "Win",
-                _ => "Meta",
-            };
-            keys.push(keyname.to_string());
-        }
-        if self.mods.shift() {
-            keys.push("Shift".to_string());
-        }
-        match &self.key {
-            druid::keyboard_types::Key::Character(c) => {
-                if *c == c.to_uppercase()
-                    && c.to_lowercase() != c.to_uppercase()
-                    && !self.mods.shift()
-                {
-                    keys.push("Shift".to_string());
-                }
-                keys.push(c.to_uppercase());
-            }
-            _ => {
-                keys.push(self.key.to_string());
-            }
-        }
-
-        let mut items = Vec::new();
-        let keys_len = keys.len();
-        for (i, key) in keys.iter().enumerate() {
-            let (rect, text_layout, text_layout_pos) =
-                paint_key(ctx, key, origin, config);
-            origin += (rect.width() + 5.0, 0.0);
-
-            items.push((Some(rect), text_layout, text_layout_pos));
-
-            if i < keys_len - 1 {
-                let text_layout = ctx
-                    .text()
-                    .new_text_layout("+")
-                    .font(FontFamily::SYSTEM_UI, 13.0)
-                    .text_color(
-                        config
-                            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
-                            .clone(),
-                    )
-                    .build()
-                    .unwrap();
-                let text_size = text_layout.size();
-                let text_layout_pos = origin + (0.0, -(text_size.height / 2.0));
-                items.push((None, text_layout, text_layout_pos));
-                origin += (text_size.width + 5.0, 0.0);
-            }
-        }
-
-        (origin, items)
-    }
 }
 
 pub fn paint_key(
@@ -588,91 +485,7 @@ impl KeyPressData {
                 && self.check_condition(&condition[and_indics[0].0 + 2..], check)
         }
     }
-}
 
-pub struct KeyMapLoader {
-    keymaps: IndexMap<Vec<KeyPress>, Vec<KeyMap>>,
-    command_keymaps: IndexMap<String, Vec<KeyMap>>,
-}
-
-impl KeyMapLoader {
-    pub fn new() -> Self {
-        Self {
-            keymaps: Default::default(),
-            command_keymaps: Default::default(),
-        }
-    }
-
-    pub fn load_from_str<'a>(
-        &'a mut self,
-        s: &str,
-        modal: bool,
-    ) -> Result<&'a mut Self> {
-        let toml_keymaps: toml::Value = toml::from_str(s)?;
-        let toml_keymaps = toml_keymaps
-            .get("keymaps")
-            .and_then(|v| v.as_array())
-            .ok_or_else(|| anyhow!("no keymaps"))?;
-
-        for toml_keymap in toml_keymaps {
-            let keymap = match Self::get_keymap(toml_keymap, modal) {
-                Ok(keymap) => keymap,
-                Err(err) => {
-                    log::error!("Could not parse keymap: {err}");
-                    continue;
-                }
-            };
-
-            let (command, bind) = match keymap.command.strip_prefix('-') {
-                Some(cmd) => (cmd.to_string(), false),
-                None => (keymap.command.clone(), true),
-            };
-
-            let current_keymaps = self.command_keymaps.entry(command).or_default();
-            if bind {
-                current_keymaps.push(keymap.clone());
-                for i in 1..keymap.key.len() + 1 {
-                    let key = keymap.key[..i].to_vec();
-                    self.keymaps.entry(key).or_default().push(keymap.clone());
-                }
-            } else {
-                let is_keymap = |k: &KeyMap| -> bool {
-                    k.when == keymap.when
-                        && k.modes == keymap.modes
-                        && k.key == keymap.key
-                };
-                if let Some(index) = current_keymaps.iter().position(is_keymap) {
-                    current_keymaps.remove(index);
-                }
-                for i in 1..keymap.key.len() + 1 {
-                    if let Some(keymaps) = self.keymaps.get_mut(&keymap.key[..i]) {
-                        if let Some(index) = keymaps.iter().position(is_keymap) {
-                            keymaps.remove(index);
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(self)
-    }
-
-    pub fn finalize(
-        self,
-    ) -> (
-        IndexMap<Vec<KeyPress>, Vec<KeyMap>>,
-        IndexMap<String, Vec<KeyMap>>,
-    ) {
-        let Self {
-            keymaps: map,
-            command_keymaps: command_map,
-        } = self;
-
-        (map, command_map)
-    }
-}
-
-impl KeyPressData {
     fn get_file_array() -> Option<toml::value::Array> {
         let path = Self::file()?;
         let content = std::fs::read(&path).ok()?;
@@ -884,462 +697,6 @@ impl KeyPressData {
     }
 }
 
-impl KeyPress {
-    /// Convert a piece of text representing a key in a keymaps file to the actual key
-    /// Returns `None` if it was not able to find a key with that name
-    fn map_str_to_key(key_part: &str) -> Option<druid::KbKey> {
-        // Checks if it is a character key
-        fn is_key_string(s: &str) -> bool {
-            s.chars().all(|c| !c.is_control())
-                && s.chars().skip(1).all(|c| !c.is_ascii())
-        }
-
-        // Import into scope to reduce noise
-        use druid::keyboard_types::Key::*;
-        Some(match key_part.to_lowercase().as_str() {
-            s if is_key_string(s) => Character(key_part.to_string()),
-            "unidentified" => Unidentified,
-            "alt" => Alt,
-            "altgraph" => AltGraph,
-            "capslock" => CapsLock,
-            "control" => Control,
-            "fn" => Fn,
-            "fnlock" => FnLock,
-            "meta" => Meta,
-            "numlock" => NumLock,
-            "scrolllock" => ScrollLock,
-            "shift" => Shift,
-            "symbol" => Symbol,
-            "symbollock" => SymbolLock,
-            "hyper" => Hyper,
-            "super" => Super,
-            "enter" => Enter,
-            "tab" => Tab,
-            "arrowdown" => ArrowDown,
-            "arrowleft" => ArrowLeft,
-            "arrowright" => ArrowRight,
-            "arrowup" => ArrowUp,
-            "end" => End,
-            "home" => Home,
-            "pagedown" => PageDown,
-            "pageup" => PageUp,
-            "backspace" => Backspace,
-            "clear" => Clear,
-            "copy" => Copy,
-            "crsel" => CrSel,
-            "cut" => Cut,
-            "delete" => Delete,
-            "eraseeof" => EraseEof,
-            "exsel" => ExSel,
-            "insert" => Insert,
-            "paste" => Paste,
-            "redo" => Redo,
-            "undo" => Undo,
-            "accept" => Accept,
-            "again" => Again,
-            "attn" => Attn,
-            "cancel" => Cancel,
-            "contextmenu" => ContextMenu,
-            "escape" => Escape,
-            "execute" => Execute,
-            "find" => Find,
-            "help" => Help,
-            "pause" => Pause,
-            "play" => Play,
-            "props" => Props,
-            "select" => Select,
-            "zoomin" => ZoomIn,
-            "zoomout" => ZoomOut,
-            "brightnessdown" => BrightnessDown,
-            "brightnessup" => BrightnessUp,
-            "eject" => Eject,
-            "logoff" => LogOff,
-            "power" => Power,
-            "poweroff" => PowerOff,
-            "printscreen" => PrintScreen,
-            "hibernate" => Hibernate,
-            "standby" => Standby,
-            "wakeup" => WakeUp,
-            "allcandidates" => AllCandidates,
-            "alphanumeric" => Alphanumeric,
-            "codeinput" => CodeInput,
-            "compose" => Compose,
-            "convert" => Convert,
-            "dead" => Dead,
-            "finalmode" => FinalMode,
-            "groupfirst" => GroupFirst,
-            "grouplast" => GroupLast,
-            "groupnext" => GroupNext,
-            "groupprevious" => GroupPrevious,
-            "modechange" => ModeChange,
-            "nextcandidate" => NextCandidate,
-            "nonconvert" => NonConvert,
-            "previouscandidate" => PreviousCandidate,
-            "process" => Process,
-            "singlecandidate" => SingleCandidate,
-            "hangulmode" => HangulMode,
-            "hanjamode" => HanjaMode,
-            "junjamode" => JunjaMode,
-            "eisu" => Eisu,
-            "hankaku" => Hankaku,
-            "hiragana" => Hiragana,
-            "hiraganakatakana" => HiraganaKatakana,
-            "kanamode" => KanaMode,
-            "kanjimode" => KanjiMode,
-            "katakana" => Katakana,
-            "romaji" => Romaji,
-            "zenkaku" => Zenkaku,
-            "zenkakuhankaku" => ZenkakuHankaku,
-            "f1" => F1,
-            "f2" => F2,
-            "f3" => F3,
-            "f4" => F4,
-            "f5" => F5,
-            "f6" => F6,
-            "f7" => F7,
-            "f8" => F8,
-            "f9" => F9,
-            "f10" => F10,
-            "f11" => F11,
-            "f12" => F12,
-            "soft1" => Soft1,
-            "soft2" => Soft2,
-            "soft3" => Soft3,
-            "soft4" => Soft4,
-            "channeldown" => ChannelDown,
-            "channelup" => ChannelUp,
-            "close" => Close,
-            "mailforward" => MailForward,
-            "mailreply" => MailReply,
-            "mailsend" => MailSend,
-            "mediaclose" => MediaClose,
-            "mediafastforward" => MediaFastForward,
-            "mediapause" => MediaPause,
-            "mediaplay" => MediaPlay,
-            "mediaplaypause" => MediaPlayPause,
-            "mediarecord" => MediaRecord,
-            "mediarewind" => MediaRewind,
-            "mediastop" => MediaStop,
-            "mediatracknext" => MediaTrackNext,
-            "mediatrackprevious" => MediaTrackPrevious,
-            "new" => New,
-            "open" => Open,
-            "print" => Print,
-            "save" => Save,
-            "spellcheck" => SpellCheck,
-            "key11" => Key11,
-            "key12" => Key12,
-            "audiobalanceleft" => AudioBalanceLeft,
-            "audiobalanceright" => AudioBalanceRight,
-            "audiobassboostdown" => AudioBassBoostDown,
-            "audiobassboosttoggle" => AudioBassBoostToggle,
-            "audiobassboostup" => AudioBassBoostUp,
-            "audiofaderfront" => AudioFaderFront,
-            "audiofaderrear" => AudioFaderRear,
-            "audiosurroundmodenext" => AudioSurroundModeNext,
-            "audiotrebledown" => AudioTrebleDown,
-            "audiotrebleup" => AudioTrebleUp,
-            "audiovolumedown" => AudioVolumeDown,
-            "audiovolumeup" => AudioVolumeUp,
-            "audiovolumemute" => AudioVolumeMute,
-            "microphonetoggle" => MicrophoneToggle,
-            "microphonevolumedown" => MicrophoneVolumeDown,
-            "microphonevolumeup" => MicrophoneVolumeUp,
-            "microphonevolumemute" => MicrophoneVolumeMute,
-            "speechcorrectionlist" => SpeechCorrectionList,
-            "speechinputtoggle" => SpeechInputToggle,
-            "launchapplication1" => LaunchApplication1,
-            "launchapplication2" => LaunchApplication2,
-            "launchcalendar" => LaunchCalendar,
-            "launchcontacts" => LaunchContacts,
-            "launchmail" => LaunchMail,
-            "launchmediaplayer" => LaunchMediaPlayer,
-            "launchmusicplayer" => LaunchMusicPlayer,
-            "launchphone" => LaunchPhone,
-            "launchscreensaver" => LaunchScreenSaver,
-            "launchspreadsheet" => LaunchSpreadsheet,
-            "launchwebbrowser" => LaunchWebBrowser,
-            "launchwebcam" => LaunchWebCam,
-            "launchwordprocessor" => LaunchWordProcessor,
-            "browserback" => BrowserBack,
-            "browserfavorites" => BrowserFavorites,
-            "browserforward" => BrowserForward,
-            "browserhome" => BrowserHome,
-            "browserrefresh" => BrowserRefresh,
-            "browsersearch" => BrowserSearch,
-            "browserstop" => BrowserStop,
-            "appswitch" => AppSwitch,
-            "call" => Call,
-            "camera" => Camera,
-            "camerafocus" => CameraFocus,
-            "endcall" => EndCall,
-            "goback" => GoBack,
-            "gohome" => GoHome,
-            "headsethook" => HeadsetHook,
-            "lastnumberredial" => LastNumberRedial,
-            "notification" => Notification,
-            "mannermode" => MannerMode,
-            "voicedial" => VoiceDial,
-            "tv" => TV,
-            "tv3dmode" => TV3DMode,
-            "tvantennacable" => TVAntennaCable,
-            "tvaudiodescription" => TVAudioDescription,
-            "tvaudiodescriptionmixdown" => TVAudioDescriptionMixDown,
-            "tvaudiodescriptionmixup" => TVAudioDescriptionMixUp,
-            "tvcontentsmenu" => TVContentsMenu,
-            "tvdataservice" => TVDataService,
-            "tvinput" => TVInput,
-            "tvinputcomponent1" => TVInputComponent1,
-            "tvinputcomponent2" => TVInputComponent2,
-            "tvinputcomposite1" => TVInputComposite1,
-            "tvinputcomposite2" => TVInputComposite2,
-            "tvinputhdmi1" => TVInputHDMI1,
-            "tvinputhdmi2" => TVInputHDMI2,
-            "tvinputhdmi3" => TVInputHDMI3,
-            "tvinputhdmi4" => TVInputHDMI4,
-            "tvinputvga1" => TVInputVGA1,
-            "tvmediacontext" => TVMediaContext,
-            "tvnetwork" => TVNetwork,
-            "tvnumberentry" => TVNumberEntry,
-            "tvpower" => TVPower,
-            "tvradioservice" => TVRadioService,
-            "tvsatellite" => TVSatellite,
-            "tvsatellitebs" => TVSatelliteBS,
-            "tvsatellitecs" => TVSatelliteCS,
-            "tvsatellitetoggle" => TVSatelliteToggle,
-            "tvterrestrialanalog" => TVTerrestrialAnalog,
-            "tvterrestrialdigital" => TVTerrestrialDigital,
-            "tvtimer" => TVTimer,
-            "avrinput" => AVRInput,
-            "avrpower" => AVRPower,
-            "colorf0red" => ColorF0Red,
-            "colorf1green" => ColorF1Green,
-            "colorf2yellow" => ColorF2Yellow,
-            "colorf3blue" => ColorF3Blue,
-            "colorf4grey" => ColorF4Grey,
-            "colorf5brown" => ColorF5Brown,
-            "closedcaptiontoggle" => ClosedCaptionToggle,
-            "dimmer" => Dimmer,
-            "displayswap" => DisplaySwap,
-            "dvr" => DVR,
-            "exit" => Exit,
-            "favoriteclear0" => FavoriteClear0,
-            "favoriteclear1" => FavoriteClear1,
-            "favoriteclear2" => FavoriteClear2,
-            "favoriteclear3" => FavoriteClear3,
-            "favoriterecall0" => FavoriteRecall0,
-            "favoriterecall1" => FavoriteRecall1,
-            "favoriterecall2" => FavoriteRecall2,
-            "favoriterecall3" => FavoriteRecall3,
-            "favoritestore0" => FavoriteStore0,
-            "favoritestore1" => FavoriteStore1,
-            "favoritestore2" => FavoriteStore2,
-            "favoritestore3" => FavoriteStore3,
-            "guide" => Guide,
-            "guidenextday" => GuideNextDay,
-            "guidepreviousday" => GuidePreviousDay,
-            "info" => Info,
-            "instantreplay" => InstantReplay,
-            "link" => Link,
-            "listprogram" => ListProgram,
-            "livecontent" => LiveContent,
-            "lock" => Lock,
-            "mediaapps" => MediaApps,
-            "mediaaudiotrack" => MediaAudioTrack,
-            "medialast" => MediaLast,
-            "mediaskipbackward" => MediaSkipBackward,
-            "mediaskipforward" => MediaSkipForward,
-            "mediastepbackward" => MediaStepBackward,
-            "mediastepforward" => MediaStepForward,
-            "mediatopmenu" => MediaTopMenu,
-            "navigatein" => NavigateIn,
-            "navigatenext" => NavigateNext,
-            "navigateout" => NavigateOut,
-            "navigateprevious" => NavigatePrevious,
-            "nextfavoritechannel" => NextFavoriteChannel,
-            "nextuserprofile" => NextUserProfile,
-            "ondemand" => OnDemand,
-            "pairing" => Pairing,
-            "pinpdown" => PinPDown,
-            "pinpmove" => PinPMove,
-            "pinptoggle" => PinPToggle,
-            "pinpup" => PinPUp,
-            "playspeeddown" => PlaySpeedDown,
-            "playspeedreset" => PlaySpeedReset,
-            "playspeedup" => PlaySpeedUp,
-            "randomtoggle" => RandomToggle,
-            "rclowbattery" => RcLowBattery,
-            "recordspeednext" => RecordSpeedNext,
-            "rfbypass" => RfBypass,
-            "scanchannelstoggle" => ScanChannelsToggle,
-            "screenmodenext" => ScreenModeNext,
-            "settings" => Settings,
-            "splitscreentoggle" => SplitScreenToggle,
-            "stbinput" => STBInput,
-            "stbpower" => STBPower,
-            "subtitle" => Subtitle,
-            "teletext" => Teletext,
-            "videomodenext" => VideoModeNext,
-            "wink" => Wink,
-            "zoomtoggle" => ZoomToggle,
-
-            // Custom key name mappings
-            "esc" => Escape,
-            "space" => Character(" ".to_string()),
-            "bs" => Backspace,
-            "up" => ArrowUp,
-            "down" => ArrowDown,
-            "right" => ArrowRight,
-            "left" => ArrowLeft,
-            "del" => Delete,
-
-            _ => return None,
-        })
-    }
-}
-
-impl KeyPress {
-    pub fn parse(key: &str) -> Vec<Self> {
-        key.split(' ')
-            .filter_map(|k| {
-                let (modifiers, key) = match k.rsplit_once('+') {
-                    Some(pair) => pair,
-                    None => ("", k),
-                };
-
-                let key = match Self::map_str_to_key(key) {
-                    Some(key) => key,
-                    None => {
-                        // Skip past unrecognized key definitions
-                        log::warn!("Unrecognized key: {key}");
-                        return None;
-                    }
-                };
-
-                let mut mods = Modifiers::default();
-                for part in modifiers.split('+') {
-                    match part.to_lowercase().as_ref() {
-                        "ctrl" => mods.set(Modifiers::CONTROL, true),
-                        "meta" => mods.set(Modifiers::META, true),
-                        "shift" => mods.set(Modifiers::SHIFT, true),
-                        "alt" => mods.set(Modifiers::ALT, true),
-                        _ => (),
-                    }
-                }
-
-                Some(KeyPress { mods, key })
-            })
-            .collect()
-    }
-}
-
-impl KeyMapLoader {
-    fn get_keymap(toml_keymap: &toml::Value, modal: bool) -> Result<KeyMap> {
-        let key = toml_keymap
-            .get("key")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow!("no key in keymap"))?;
-
-        let modes = get_modes(toml_keymap);
-        if !modal && !modes.is_empty() && !modes.contains(&Mode::Insert) {
-            return Err(anyhow!(""));
-        }
-
-        Ok(KeyMap {
-            key: KeyPress::parse(key),
-            modes: get_modes(toml_keymap),
-            when: toml_keymap
-                .get("when")
-                .and_then(|w| w.as_str())
-                .map(|w| w.to_string()),
-            command: toml_keymap
-                .get("command")
-                .and_then(|c| c.as_str())
-                .map(|w| w.trim().to_string())
-                .unwrap_or_else(|| "".to_string()),
-        })
-    }
-}
-
-fn get_modes(toml_keymap: &toml::Value) -> Vec<Mode> {
-    let mut modes = toml_keymap
-        .get("mode")
-        .and_then(|v| v.as_str())
-        .map(|m| {
-            m.chars()
-                .filter_map(|c| match c.to_lowercase().to_string().as_ref() {
-                    "i" => Some(Mode::Insert),
-                    "n" => Some(Mode::Normal),
-                    "v" => Some(Mode::Visual),
-                    "t" => Some(Mode::Terminal),
-                    _ => None,
-                })
-                .collect()
-        })
-        .unwrap_or_else(Vec::new);
-    modes.sort();
-    modes
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_keymap() {
-        let keymaps = r###"
-keymaps = [
-    { key = "ctrl+w l l", command = "right", when = "n" },
-    { key = "ctrl+w l", command = "right", when = "n" },
-    { key = "ctrl+w h", command = "left", when = "n" },
-    { key = "ctrl+w",   command = "left", when = "n" },
-    { key = "End", command = "line_end", when = "n" },
-    { key = "I", command = "insert_first_non_blank", when = "n" },
-]
-        "###;
-        let mut loader = KeyMapLoader::new();
-        loader.load_from_str(keymaps, true).unwrap();
-
-        let (keymaps, _) = loader.finalize();
-
-        // Lower case modifiers
-        let keypress = KeyPress::parse("ctrl+w");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 4);
-
-        let keypress = KeyPress::parse("ctrl+w l");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 2);
-
-        let keypress = KeyPress::parse("ctrl+w h");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
-
-        let keypress = KeyPress::parse("ctrl+w l l");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
-
-        let keypress = KeyPress::parse("end");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
-
-        // Upper case modifiers
-        let keypress = KeyPress::parse("Ctrl+w");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 4);
-
-        let keypress = KeyPress::parse("Ctrl+w l");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 2);
-
-        let keypress = KeyPress::parse("Ctrl+w h");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
-
-        let keypress = KeyPress::parse("Ctrl+w l l");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
-
-        let keypress = KeyPress::parse("End");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
-
-        // No modifier
-        let keypress = KeyPress::parse("I");
-        assert_eq!(keymaps.get(&keypress).unwrap().len(), 1);
-    }
-}
-
 pub struct DefaultKeyPressHandler {}
 
 impl KeyPressFocus for DefaultKeyPressHandler {
@@ -1363,4 +720,24 @@ impl KeyPressFocus for DefaultKeyPressHandler {
     }
 
     fn receive_char(&mut self, _ctx: &mut EventCtx, _c: &str) {}
+}
+
+fn get_modes(toml_keymap: &toml::Value) -> Vec<Mode> {
+    let mut modes = toml_keymap
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .map(|m| {
+            m.chars()
+                .filter_map(|c| match c.to_lowercase().to_string().as_ref() {
+                    "i" => Some(Mode::Insert),
+                    "n" => Some(Mode::Normal),
+                    "v" => Some(Mode::Visual),
+                    "t" => Some(Mode::Terminal),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_else(Vec::new);
+    modes.sort();
+    modes
 }

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -24,13 +24,13 @@ use crate::config::{Config, LapceTheme};
 use crate::{command::LapceCommand, state::Mode};
 
 const DEFAULT_KEYMAPS_COMMON: &str =
-    include_str!("../../defaults/keymaps-common.toml");
+    include_str!("../../../defaults/keymaps-common.toml");
 const DEFAULT_KEYMAPS_WINDOWS: &str =
-    include_str!("../../defaults/keymaps-windows.toml");
+    include_str!("../../../defaults/keymaps-windows.toml");
 const DEFAULT_KEYMAPS_MACOS: &str =
-    include_str!("../../defaults/keymaps-macos.toml");
+    include_str!("../../../defaults/keymaps-macos.toml");
 const DEFAULT_KEYMAPS_LINUX: &str =
-    include_str!("../../defaults/keymaps-linux.toml");
+    include_str!("../../../defaults/keymaps-linux.toml");
 
 #[derive(PartialEq)]
 enum KeymapMatch {

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -194,7 +194,7 @@ impl KeyPressData {
         let mut commands_without_keymap = Vec::new();
         for (_, keymaps) in self.command_keymaps.iter() {
             for keymap in keymaps.iter() {
-                if let Some(_cmd) = self.commands.get(&keymap.command) {
+                if self.commands.get(&keymap.command).is_some() {
                     commands_with_keymap.push(keymap.clone());
                 }
             }

--- a/lapce-ui/src/keymap.rs
+++ b/lapce-ui/src/keymap.rs
@@ -14,7 +14,7 @@ use lapce_data::{
     keypress::{
         paint_key, Alignment, DefaultKeyPressHandler, KeyMap, KeyPress, KeyPressData,
     },
-    state::Mode,
+    state::Modes,
 };
 
 use crate::{editor::LapceEditorView, scroll::LapceScrollNew, split::LapceSplitNew};
@@ -92,7 +92,7 @@ impl LapceKeymap {
                     KeyMap {
                         command: command.cmd.clone(),
                         key: Vec::new(),
-                        modes: Vec::new(),
+                        modes: Modes::empty(),
                         when: None,
                     },
                     Vec::new(),
@@ -326,23 +326,25 @@ impl Widget<LapceTabData> for LapceKeymap {
                         size.width / 2.0 + 10.0,
                         i as f64 * self.line_height + self.line_height / 2.0,
                     );
-                    for mode in keymap.modes.iter() {
-                        let mode = match mode {
-                            Mode::Normal => "Normal",
-                            Mode::Insert => "Insert",
-                            Mode::Visual => "Visual",
-                            Mode::Terminal => "Terminal",
-                        };
-                        let (rect, text_layout, text_layout_pos) =
-                            paint_key(ctx, mode, origin, &data.config);
-                        ctx.draw_text(&text_layout, text_layout_pos);
-                        ctx.stroke(
-                            rect,
-                            data.config
-                                .get_color_unchecked(LapceTheme::LAPCE_BORDER),
-                            1.0,
-                        );
-                        origin += (rect.width() + 5.0, 0.0);
+                    let bits = [
+                        (Modes::INSERT, "Normal"),
+                        (Modes::NORMAL, "Insert"),
+                        (Modes::VISUAL, "Visual"),
+                        (Modes::TERMINAL, "Terminal"),
+                    ];
+                    for (bit, mode) in bits {
+                        if keymap.modes.contains(bit) {
+                            let (rect, text_layout, text_layout_pos) =
+                                paint_key(ctx, mode, origin, &data.config);
+                            ctx.draw_text(&text_layout, text_layout_pos);
+                            ctx.stroke(
+                                rect,
+                                data.config
+                                    .get_color_unchecked(LapceTheme::LAPCE_BORDER),
+                                1.0,
+                            );
+                            origin += (rect.width() + 5.0, 0.0);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
This PR:
 - Adds an empty common keymap file, to allow deduplicating existing default keymaps
 - Cleans up the keymap parsing function to use simpler code and avoid several unnecessary allocations.

These changes came up while trying to figure out the cause of #116 and #185 - I didn't make any progress on that front, but these changes might make the parser code slightly easier to understand. Maybe, hopefully :)