### PR TITLE
Organize modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.58"
 resolver = "2"
 
 [dependencies]
-lapce-ui = { path = "./lapce-ui" }
 lapce-proxy = { path = "./lapce-proxy" }
+lapce-ui = { path = "./lapce-ui" }
 
 [[bin]]
 name = "lapce"
@@ -19,4 +19,4 @@ name = "lapce-proxy"
 path = "lapce-proxy/src/bin/lapce-proxy.rs"
 
 [workspace]
-members = ["lapce-ui", "lapce-proxy", "lapce-rpc", "lapce-data", "lapce-core"]
+members = ["lapce-core", "lapce-data", "lapce-proxy", "lapce-rpc", "lapce-ui"]

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-thiserror = "1.0"
 itertools = "0.10.3"
 serde_json = "1.0"
+thiserror = "1.0"
 tree-sitter = "0.20.6"
-tree-sitter-highlight = "0.20.1"
-tree-sitter-rust = "0.20.0"
 tree-sitter-go = "0.19.1"
+tree-sitter-highlight = "0.20.1"
 tree-sitter-javascript = "0.20.0"
+tree-sitter-rust = "0.20.0"
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -52,7 +52,8 @@ impl LapceLanguage {
         parser
     }
 
-    pub(crate) fn new_highlight_query(&self) -> Query {
+    // TODO: Use or remove
+    pub(crate) fn _new_highlight_query(&self) -> Query {
         let language = self.tree_sitter_language();
         let query = match self {
             LapceLanguage::Rust => tree_sitter_rust::HIGHLIGHT_QUERY,

--- a/lapce-core/src/lens.rs
+++ b/lapce-core/src/lens.rs
@@ -32,7 +32,8 @@ pub struct LensLeaf {
 
 pub struct LensIter<'a> {
     cursor: Cursor<'a, LensInfo>,
-    ix: usize,
+    // TODO: Use or remove
+    _ix: usize,
     end: usize,
 }
 
@@ -64,7 +65,7 @@ impl Lens {
     pub fn iter(&self) -> LensIter {
         LensIter {
             cursor: Cursor::new(&self.0, 0),
-            ix: 0,
+            _ix: 0,
             end: self.len(),
         }
     }
@@ -74,7 +75,7 @@ impl Lens {
 
         LensIter {
             cursor: Cursor::new(&self.0, start),
-            ix: 0,
+            _ix: 0,
             end,
         }
     }
@@ -199,11 +200,11 @@ impl Metric<LensInfo> for LensMetric {
         accum
     }
 
-    fn is_boundary(l: &LensLeaf, offset: usize) -> bool {
+    fn is_boundary(_l: &LensLeaf, _offset: usize) -> bool {
         true
     }
 
-    fn prev(l: &LensLeaf, offset: usize) -> Option<usize> {
+    fn prev(_l: &LensLeaf, offset: usize) -> Option<usize> {
         if offset == 0 {
             None
         } else {

--- a/lapce-core/src/syntax.rs
+++ b/lapce-core/src/syntax.rs
@@ -1,12 +1,11 @@
 use std::{
-    borrow::BorrowMut,
     cell::RefCell,
     collections::{HashMap, HashSet},
     path::Path,
 };
 
 use itertools::Itertools;
-use tree_sitter::{Parser, Point, Query, QueryCursor, Tree};
+use tree_sitter::{Parser, Point, Query, Tree};
 use xi_rope::{Rope, RopeDelta};
 
 use crate::{
@@ -140,7 +139,7 @@ impl Syntax {
             )
         });
 
-        if let Some(tree) = new_tree.as_ref() {
+        if let Some(_tree) = new_tree.as_ref() {
             // QUERY.with(|queries| {
             //     let mut queries = queries.borrow_mut();
             //     queries

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -5,63 +5,63 @@ authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.19"
-log = "0.4.14"
-fern = "0.6.0"
 Inflector = "0.11.4"
-rayon = "1.5.1"
-diff = "0.1.12"
-libloading = "0.7"
-flate2 = "1.0.22"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-hashbrown = "0.11.2"
-sled = "0.34.7"
-base64 = "0.13.0"
 alacritty_terminal = "0.15.0"
+anyhow = "1.0.32"
+base64 = "0.13.0"
+bit-vec = "0.5.0"
+chrono = "0.4.19"
 config = "0.11"
-indexmap = "1.7.0"
-directories = "4.0.1"
-tinyfiledialogs = "3.8.3"
-itertools = "0.10.1"
-unicode-width = "0.1.8"
-unicode-segmentation = "1.7.1"
-im = { version = "15.0.0", features = ["serde"] }
 crossbeam-channel = "0.5.0"
 crossbeam-utils = "0.8.4"
-regex = "1.4.2"
-usvg = "0.14.0"
-jsonrpc-lite = "0.5.0"
-bit-vec = "0.5.0"
-parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
-include_dir = "0.6.0"
-tree-sitter = "0.20.2"
-tree-sitter-highlight = "0.20.1"
-tree-sitter-rust = "0.20.0"
-tree-sitter-go = "0.19.1"
-tree-sitter-javascript = "0.20.0"
-anyhow = "1.0.32"
-strum = "0.19"
-strum_macros = "0.19"
-lazy_static = "1.4.0"
-serde = "1.0"
-serde_json = "1.0"
-notify = "5.0.0-pre.13"
-xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
-xi-unicode = "0.3.0"
-fzyr = "0.1.2"
-fuzzy-matcher = "0.3.7"
-uuid = { version = "0.7.4", features = ["v4"] }
-lsp-types = { version = "0.89.2", features = ["proposed"] }
+diff = "0.1.12"
+directories = "4.0.1"
 druid = { git = "https://github.com/lapce/druid", features = [ "svg", "im", "serde", ] }
-#druid = { path = "../../druid/druid", features = ["svg", "im" , "serde"] }
-toml = { version = "0.5.8", features = ["preserve_order"] }
-structdesc = { git = "https://github.com/lapce/structdesc" }
+fern = "0.6.0"
+flate2 = "1.0.22"
+fuzzy-matcher = "0.3.7"
+fzyr = "0.1.2"
+hashbrown = "0.11.2"
+im = { version = "15.0.0", features = ["serde"] }
+include_dir = "0.6.0"
+indexmap = "1.7.0"
+itertools = "0.10.1"
+jsonrpc-lite = "0.5.0"
 #structdesc = { path = "../../structdesc" }
 lapce-core = { path = "../lapce-core" }
-lapce-rpc = { path = "../lapce-rpc" }
 lapce-proxy = { path = "../lapce-proxy" }
+lapce-rpc = { path = "../lapce-rpc" }
+lazy_static = "1.4.0"
+libloading = "0.7"
+log = "0.4.14"
+lsp-types = { version = "0.89.2", features = ["proposed"] }
+notify = "5.0.0-pre.13"
+parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
+rayon = "1.5.1"
+regex = "1.4.2"
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = "1.0"
+serde_json = "1.0"
+sled = "0.34.7"
+structdesc = { git = "https://github.com/lapce/structdesc" }
+strum = "0.19"
+strum_macros = "0.19"
+tinyfiledialogs = "3.8.3"
+#druid = { path = "../../druid/druid", features = ["svg", "im" , "serde"] }
+toml = { version = "0.5.8", features = ["preserve_order"] }
+tree-sitter = "0.20.2"
+tree-sitter-go = "0.19.1"
+tree-sitter-highlight = "0.20.1"
+tree-sitter-javascript = "0.20.0"
+tree-sitter-rust = "0.20.0"
+unicode-segmentation = "1.7.1"
+unicode-width = "0.1.8"
+usvg = "0.14.0"
+uuid = { version = "0.7.4", features = ["v4"] }
+xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
+xi-unicode = "0.3.0"
 
 [build-dependencies]
-cc = "1"
 anyhow = "1.0.32"
+cc = "1"
 threadpool = "1.0"

--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -1,10 +1,10 @@
 use crossbeam_channel::Sender;
+use druid::PaintCtx;
 use druid::{piet::PietTextLayout, Vec2};
 use druid::{
-    piet::{PietText, Text, TextAttribute, TextLayoutBuilder},
+    piet::{Text, TextAttribute, TextLayoutBuilder},
     Data, EventCtx, ExtEventSink, Target, WidgetId, WindowId,
 };
-use druid::{PaintCtx, Point};
 use language::{new_highlight_config, LapceLanguage};
 use lapce_core::syntax::Syntax;
 use lapce_proxy::dispatch::{BufferHeadResponse, NewBufferResponse};
@@ -27,7 +27,6 @@ use tree_sitter_highlight::{
 };
 use unicode_width::UnicodeWidthChar;
 use xi_rope::{
-    interval::IntervalBounds,
     multiset::Subset,
     rope::Rope,
     spans::{Spans, SpansBuilder},
@@ -237,7 +236,7 @@ impl BufferContent {
         }
     }
 }
-
+#[allow(clippy::type_complexity)]
 #[derive(Clone)]
 pub struct Buffer {
     pub id: BufferId,

--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -1,26 +1,33 @@
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    cmp::{self, Ordering},
+    collections::{BTreeSet, HashMap},
+    ops::Range,
+    path::PathBuf,
+    rc::Rc,
+    str::FromStr,
+    sync::{
+        atomic::{self, AtomicU64},
+        Arc,
+    },
+    thread,
+};
+
 use crossbeam_channel::Sender;
-use druid::PaintCtx;
-use druid::{piet::PietTextLayout, Vec2};
 use druid::{
-    piet::{Text, TextAttribute, TextLayoutBuilder},
-    Data, EventCtx, ExtEventSink, Target, WidgetId, WindowId,
+    piet::{PietTextLayout, Text, TextAttribute, TextLayoutBuilder},
+    Data, EventCtx, ExtEventSink, PaintCtx, Target, Vec2, WidgetId, WindowId,
 };
 use language::{new_highlight_config, LapceLanguage};
 use lapce_core::syntax::Syntax;
 use lapce_proxy::dispatch::{BufferHeadResponse, NewBufferResponse};
-use lsp_types::SemanticTokensLegend;
-use lsp_types::SemanticTokensServerCapabilities;
-use lsp_types::{CodeActionResponse, Position};
+use lsp_types::{
+    CodeActionResponse, Position, SemanticTokensLegend,
+    SemanticTokensServerCapabilities,
+};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
-use std::cmp::{self, Ordering};
-use std::collections::HashMap;
-use std::ops::Range;
-use std::rc::Rc;
-use std::str::FromStr;
-use std::sync::atomic::{self, AtomicU64};
-use std::{borrow::Cow, collections::BTreeSet, path::PathBuf, sync::Arc, thread};
 use tree_sitter::{Node, Tree};
 use tree_sitter_highlight::{
     Highlight, HighlightConfiguration, HighlightEvent, Highlighter,
@@ -34,15 +41,12 @@ use xi_rope::{
 };
 use xi_unicode::EmojiExt;
 
-use crate::config::{Config, LapceTheme};
-use crate::editor::EditorLocationNew;
-use crate::find::FindProgress;
-use crate::language::SCOPES;
 use crate::{
-    command::LapceUICommand,
-    command::LAPCE_UI_COMMAND,
-    find::Find,
-    language,
+    command::{LapceUICommand, LAPCE_UI_COMMAND},
+    config::{Config, LapceTheme},
+    editor::EditorLocationNew,
+    find::{Find, FindProgress},
+    language::{self, SCOPES},
     movement::{ColPosition, LinePosition, Movement, SelRegion, Selection},
     proxy::LapceProxy,
     state::{Counter, Mode},

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -21,8 +21,7 @@ use tree_sitter_highlight::Highlight;
 use xi_rope::{spans::Spans, Rope};
 
 use crate::{
-    buffer::BufferId,
-    buffer::{DiffLines, Style},
+    buffer::{BufferId, DiffLines, Style},
     data::{EditorTabChild, SplitContent},
     editor::EditorLocationNew,
     keypress::{KeyMap, KeyPress},

--- a/lapce-data/src/container.rs
+++ b/lapce-data/src/container.rs
@@ -1,4 +1,3 @@
-
 use druid::{Point, Size};
 
 pub struct ChildState {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -914,11 +914,14 @@ impl LapceTabData {
                                     .as_secs(),
                             };
 
-                            event_sink.submit_command(
+                            if let Err(err) = event_sink.submit_command(
                                 LAPCE_UI_COMMAND,
                                 LapceUICommand::SetWorkspace(workspace),
                                 Target::Auto,
-                            );
+                            ) {
+                                // TODO! Handle or log `err`
+                                todo!()
+                            }
                         }
                     });
                 } else {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -15,7 +15,6 @@ use druid::{
     theme, Color, Command, Data, Env, EventCtx, ExtEventSink, FontFamily, Lens,
     Point, Rect, Size, Target, Vec2, WidgetId, WindowId,
 };
-
 use lapce_proxy::{
     dispatch::{FileDiff, FileNodeItem},
     plugin::PluginDescription,

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -17,7 +17,7 @@ use crate::svg::get_svg;
 use crate::{
     buffer::BufferId,
     command::{LapceCommand, LapceUICommand, LAPCE_UI_COMMAND},
-    movement::{ColPosition, LinePosition, Movement, SelRegion, Selection},
+    movement::{ColPosition, Movement, SelRegion, Selection},
     split::SplitMoveDirection,
     state::Mode,
     state::VisualMode,
@@ -37,10 +37,9 @@ use druid::piet::{
 use druid::Modifiers;
 use druid::{
     kurbo::Line, piet::PietText, Color, Command, Env, EventCtx, FontFamily,
-    PaintCtx, Point, Rect, RenderContext, Size, Target, TextLayout, Vec2, WidgetId,
+    PaintCtx, Point, Rect, RenderContext, Size, Target, Vec2, WidgetId,
 };
 use druid::{Application, ExtEventSink, MouseEvent};
-use lapce_core::lens::Lens;
 use lapce_core::syntax::Syntax;
 use lsp_types::CompletionTextEdit;
 use lsp_types::{
@@ -1669,7 +1668,7 @@ impl LapceEditorBufferData {
         }
     }
 
-    fn paint_gutter_code_lens(&self, ctx: &mut PaintCtx, gutter_width: f64) {
+    fn paint_gutter_code_lens(&self, ctx: &mut PaintCtx, _gutter_width: f64) {
         let rect = ctx.size().to_rect();
         let scroll_offset = self.editor.scroll_offset;
         let empty_lens = Syntax::lens_from_normal_lines(
@@ -1933,7 +1932,8 @@ impl LapceEditorBufferData {
         }
     }
 
-    fn paint_code_lens_line(
+    // TODO: Use or remove
+    fn _paint_code_lens_line(
         &self,
         ctx: &mut PaintCtx,
         line: usize,
@@ -4243,7 +4243,6 @@ impl KeyPressFocus for LapceEditorBufferData {
                     }
                 }
             }
-            LapceCommand::MoveLineUp => {}
             LapceCommand::NextError => {
                 self.next_error(ctx, env);
             }
@@ -4838,7 +4837,8 @@ pub struct HighlightTextLayout {
     pub highlights: Vec<(usize, usize, String)>,
 }
 
-fn get_workspace_edit_changes_edits<'a>(
+// TODO: Use or remove
+fn _get_workspace_edit_changes_edits<'a>(
     url: &Url,
     workspace_edit: &'a WorkspaceEdit,
 ) -> Option<Vec<&'a TextEdit>> {
@@ -4846,7 +4846,8 @@ fn get_workspace_edit_changes_edits<'a>(
     changes.get(url).map(|c| c.iter().collect())
 }
 
-fn get_workspace_edit_document_changes_edits<'a>(
+// TODO: Use or remove
+fn _get_workspace_edit_document_changes_edits<'a>(
     url: &Url,
     workspace_edit: &'a WorkspaceEdit,
 ) -> Option<Vec<&'a TextEdit>> {

--- a/lapce-data/src/explorer.rs
+++ b/lapce-data/src/explorer.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+
+use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/lapce-data/src/explorer.rs
+++ b/lapce-data/src/explorer.rs
@@ -1,19 +1,19 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
-use std::collections::HashMap;
-use std::path::Path;
-use std::path::PathBuf;
-use std::sync::Arc;
-
-use druid::ExtEventSink;
-use druid::{Target, WidgetId};
+use druid::{ExtEventSink, Target, WidgetId};
 
 use include_dir::{include_dir, Dir};
 use lapce_proxy::dispatch::FileNodeItem;
 
-use crate::proxy::LapceProxy;
-use crate::state::LapceWorkspace;
-
-use crate::{command::LapceUICommand, command::LAPCE_UI_COMMAND};
+use crate::{
+    command::{LapceUICommand, LAPCE_UI_COMMAND},
+    proxy::LapceProxy,
+    state::LapceWorkspace,
+};
 
 #[allow(dead_code)]
 const ICONS_DIR: Dir = include_dir!("../icons");

--- a/lapce-data/src/find.rs
+++ b/lapce-data/src/find.rs
@@ -1,6 +1,7 @@
+use std::cmp::{max, min};
+
 use regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
-use std::cmp::{max, min};
 use xi_rope::{
     delta::DeltaRegion,
     find::{find, is_multiline_regex, CaseMatching},

--- a/lapce-data/src/keypress.rs
+++ b/lapce-data/src/keypress.rs
@@ -1,27 +1,24 @@
-use std::fmt::Display;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{fmt::Display, path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, Result};
-use druid::piet::{PietTextLayout, Text, TextLayout, TextLayoutBuilder};
-use druid::{Command, KbKey};
 use druid::{
-    Env, EventCtx, ExtEventSink, FontFamily, KeyEvent, Modifiers, PaintCtx, Point,
-    Rect, RenderContext, Size, Target,
+    piet::{PietTextLayout, Text, TextLayout, TextLayoutBuilder},
+    Command, Env, EventCtx, ExtEventSink, FontFamily, KbKey, KeyEvent, Modifiers,
+    PaintCtx, Point, Rect, RenderContext, Size, Target,
 };
-use fuzzy_matcher::skim::SkimMatcherV2;
-use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use toml;
 
-use crate::command::{
-    lapce_internal_commands, CommandExecuted, CommandTarget, LapceCommandNew,
-    LapceUICommand, LAPCE_NEW_COMMAND, LAPCE_UI_COMMAND,
+use crate::{
+    command::{
+        lapce_internal_commands, CommandExecuted, CommandTarget, LapceCommand,
+        LapceCommandNew, LapceUICommand, LAPCE_NEW_COMMAND, LAPCE_UI_COMMAND,
+    },
+    config::{Config, LapceTheme},
+    state::Mode,
 };
-use crate::config::{Config, LapceTheme};
-use crate::{command::LapceCommand, state::Mode};
 
 const DEFAULT_KEYMAPS_WINDOWS: &str =
     include_str!("../../defaults/keymaps-windows.toml");

--- a/lapce-data/src/language.rs
+++ b/lapce-data/src/language.rs
@@ -1,5 +1,6 @@
-use lazy_static::lazy_static;
 use std::path::Path;
+
+use lazy_static::lazy_static;
 use tree_sitter::Parser;
 use tree_sitter_highlight::HighlightConfiguration;
 

--- a/lapce-data/src/lsp.rs
+++ b/lapce-data/src/lsp.rs
@@ -1,8 +1,9 @@
+use std::{collections::HashMap, io::BufRead, io::Write, process::Child, sync::Arc};
+
 use anyhow::{anyhow, Result};
 use druid::{WidgetId, WindowId};
 use jsonrpc_lite::Id;
 use parking_lot::Mutex;
-use std::{collections::HashMap, io::BufRead, io::Write, process::Child, sync::Arc};
 
 use lsp_types::*;
 use serde_json::Value;

--- a/lapce-data/src/movement.rs
+++ b/lapce-data/src/movement.rs
@@ -1,4 +1,3 @@
-use druid::piet::PietText;
 use serde::{Deserialize, Serialize};
 use xi_rope::{RopeDelta, Transformer};
 

--- a/lapce-data/src/movement.rs
+++ b/lapce-data/src/movement.rs
@@ -1,3 +1,5 @@
+use std::cmp::{max, min};
+
 use serde::{Deserialize, Serialize};
 use xi_rope::{RopeDelta, Transformer};
 
@@ -7,7 +9,6 @@ use crate::{
     data::RegisterData,
     state::{Mode, VisualMode},
 };
-use std::cmp::{max, min};
 
 #[derive(Copy, Clone)]
 pub enum InsertDrift {

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -1,34 +1,32 @@
+use std::{
+    cmp::Ordering, collections::HashSet, path::Path, path::PathBuf, sync::Arc,
+};
+
 use alacritty_terminal::{grid::Dimensions, term::cell::Flags};
 use anyhow::Result;
 use bit_vec::BitVec;
 use crossbeam_channel::{unbounded, Receiver, Sender, TryRecvError};
 use druid::{
-    piet::{Svg, TextAttribute},
-    Command, ExtEventSink, FontFamily, FontWeight, Lens, Modifiers, Target,
-    WidgetId, WindowId,
+    piet::{
+        Svg, Text, TextAttribute, TextLayout as PietTextLayout, TextLayoutBuilder,
+    },
+    Command, Data, Env, EventCtx, ExtEventSink, FontFamily, FontWeight, Lens,
+    Modifiers, PaintCtx, Point, RenderContext, Size, Target, WidgetId, WindowId,
 };
-use druid::{
-    piet::{Text, TextLayout as PietTextLayout, TextLayoutBuilder},
-    Data, Env, EventCtx, PaintCtx, Point, RenderContext, Size,
-};
-use fuzzy_matcher::skim::SkimMatcherV2;
-use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use fzyr::Score;
 use itertools::Itertools;
 use lsp_types::{DocumentSymbolResponse, Location, Position, Range, SymbolKind};
 use serde_json;
-use std::collections::HashSet;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::{cmp::Ordering, path::Path};
 use usvg;
 use uuid::Uuid;
 
 use crate::{
     buffer::BufferContent,
-    command::LAPCE_UI_COMMAND,
-    command::{CommandExecuted, LapceCommand, LAPCE_NEW_COMMAND},
-    command::{LapceCommandNew, LapceUICommand},
+    command::{
+        CommandExecuted, LapceCommand, LapceCommandNew, LapceUICommand,
+        LAPCE_NEW_COMMAND, LAPCE_UI_COMMAND,
+    },
     config::{Config, LapceTheme},
     data::{FocusArea, LapceMainSplitData, LapceTabData, PanelKind},
     editor::EditorLocationNew,
@@ -36,9 +34,7 @@ use crate::{
     keypress::{KeyPressData, KeyPressFocus},
     movement::Movement,
     proxy::LapceProxy,
-    state::LapceWorkspace,
-    state::LapceWorkspaceType,
-    state::Mode,
+    state::{LapceWorkspace, LapceWorkspaceType, Mode},
     svg::{file_svg_new, symbol_svg_new},
     terminal::TerminalSplitData,
 };

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -1,11 +1,14 @@
-use std::collections::HashMap;
-use std::io::BufReader;
+use std::{
+    collections::HashMap,
+    io::BufReader,
+    path::Path,
+    path::PathBuf,
+    process::{Command, Stdio},
+    sync::Arc,
+    thread,
+};
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
-use std::path::Path;
-use std::process::{Command, Stdio};
-use std::thread;
-use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use crossbeam_channel::Receiver;

--- a/lapce-data/src/scroll.rs
+++ b/lapce-data/src/scroll.rs
@@ -1,13 +1,10 @@
-use std::time::Duration;
-use std::time::Instant;
+use std::{time::Duration, time::Instant};
 
 use druid::{
     kurbo::{Affine, Point, Rect, Size, Vec2},
-    Insets, WidgetId,
-};
-use druid::{
-    theme, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, RenderContext, TimerToken, UpdateCtx, Widget, WidgetPod,
+    theme, BoxConstraints, Data, Env, Event, EventCtx, Insets, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, RenderContext, TimerToken, UpdateCtx, Widget, WidgetId,
+    WidgetPod,
 };
 
 use crate::{

--- a/lapce-data/src/signature.rs
+++ b/lapce-data/src/signature.rs
@@ -1,5 +1,4 @@
-use lsp_types::ParameterLabel;
-use lsp_types::SignatureHelp;
+use lsp_types::{ParameterLabel, SignatureHelp};
 
 #[derive(Clone)]
 pub struct SignatureState {

--- a/lapce-data/src/split.rs
+++ b/lapce-data/src/split.rs
@@ -1,6 +1,6 @@
-use crate::keypress::KeyPress;
-
 use serde::{Deserialize, Serialize};
+
+use crate::keypress::KeyPress;
 
 #[derive(Debug)]
 pub enum SplitMoveDirection {

--- a/lapce-data/src/state.rs
+++ b/lapce-data/src/state.rs
@@ -1,11 +1,8 @@
+use std::{fmt::Display, path::PathBuf, sync::atomic, sync::atomic::AtomicU64};
+
 use anyhow::{anyhow, Result};
 use druid::{Color, Modifiers};
-
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
-use std::path::PathBuf;
-use std::sync::atomic;
-use std::sync::atomic::AtomicU64;
 
 #[derive(PartialEq)]
 enum KeymapMatch {

--- a/lapce-data/src/theme.rs
+++ b/lapce-data/src/theme.rs
@@ -1,4 +1,3 @@
-
 pub struct OldLapceTheme {}
 
 impl OldLapceTheme {

--- a/lapce-data/src/window.rs
+++ b/lapce-data/src/window.rs
@@ -1,1 +1,1 @@
-
+// TODO: Use, document empty file ratiolnale or remove

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -5,30 +5,30 @@ authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-regex = "1.5.4"
-grep-searcher = "0.1.8"
+alacritty_terminal = "0.16.0-rc2"
+anyhow = "1.0.32"
+base64 = "0.13.0"
+crossbeam-channel = "0.5.0"
+directories = "4.0.1"
+git2 = { version = "0.13.23", features = ["vendored-openssl"] }
 grep-matcher = "0.1.5"
 grep-regex = "0.1.9"
+grep-searcher = "0.1.8"
+home = "0.5.3"
+hotwatch = "0.4.6"
 ignore = "0.4.18"
+jsonrpc-lite = "0.5.0"
+lapce-rpc = { path = "../lapce-rpc" }
+locale_config = "0.3.0"
+lsp-types = { version = "0.89.2", features = ["proposed"] }
+mio = "0.6.20"
+notify = "5.0.0-pre.13"
+parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
+regex = "1.5.4"
 reqwest = { version = "0.11", features = ["blocking"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.59"
+toml = "0.5.6"
 wasmer = "2.1.1"
 wasmer-wasi = "2.1.1"
-directories = "4.0.1"
-locale_config = "0.3.0"
-base64 = "0.13.0"
-alacritty_terminal = "0.16.0-rc2"
-mio = "0.6.20"
-hotwatch = "0.4.6"
-notify = "5.0.0-pre.13"
-lapce-rpc = { path = "../lapce-rpc" }
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-lsp-types = { version = "0.89.2", features = ["proposed"] }
-parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
-crossbeam-channel = "0.5.0"
-jsonrpc-lite = "0.5.0"
-serde_json = "1.0.59"
-anyhow = "1.0.32"
-home = "0.5.3"
-toml = "0.5.6"
-git2 = { version = "0.13.23", features = ["vendored-openssl"] }

--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -1,13 +1,10 @@
+use std::{
+    borrow::Cow, ffi::OsString, fs, fs::File, io::Read, io::Write, path::Path,
+    path::PathBuf, time::SystemTime,
+};
+
 use anyhow::{anyhow, Result};
 use crossbeam_channel::Sender;
-use std::ffi::OsString;
-use std::fs;
-use std::fs::File;
-use std::io::Read;
-use std::io::Write;
-use std::path::PathBuf;
-use std::{borrow::Cow, path::Path, time::SystemTime};
-
 use lsp_types::*;
 use serde::{Deserialize, Serialize};
 use xi_rope::{interval::IntervalBounds, rope::Rope, RopeDelta};

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -153,6 +153,7 @@ pub enum Notification {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+#[allow(clippy::large_enum_variant)]
 pub enum Request {
     NewBuffer {
         buffer_id: BufferId,
@@ -719,12 +720,10 @@ impl Dispatcher {
                     let local_dispatcher = self.clone();
                     thread::spawn(move || {
                         let mut items = Vec::new();
-                        for result in ignore::Walk::new(workspace) {
-                            if let Ok(path) = result {
-                                if let Some(file_type) = path.file_type() {
-                                    if file_type.is_file() {
-                                        items.push(path.into_path());
-                                    }
+                        for path in ignore::Walk::new(workspace).flatten() {
+                            if let Some(file_type) = path.file_type() {
+                                if file_type.is_file() {
+                                    items.push(path.into_path());
                                 }
                             }
                         }
@@ -751,36 +750,29 @@ impl Dispatcher {
                             .build_literals(&[&pattern])
                         {
                             let mut searcher = SearcherBuilder::new().build();
-                            for result in ignore::Walk::new(workspace) {
-                                if let Ok(path) = result {
-                                    if let Some(file_type) = path.file_type() {
-                                        if file_type.is_file() {
-                                            let path = path.into_path();
-                                            let mut line_matches = Vec::new();
-                                            let _ = searcher.search_path(
-                                                &matcher,
-                                                path.clone(),
-                                                UTF8(|lnum, line| {
-                                                    let mymatch = matcher
-                                                        .find(line.as_bytes())?
-                                                        .unwrap();
-                                                    line_matches.push((
-                                                        lnum,
-                                                        (
-                                                            mymatch.start(),
-                                                            mymatch.end(),
-                                                        ),
-                                                        line.to_string(),
-                                                    ));
-                                                    Ok(true)
-                                                }),
-                                            );
-                                            if !line_matches.is_empty() {
-                                                matches.insert(
-                                                    path.clone(),
-                                                    line_matches,
-                                                );
-                                            }
+                            for path in ignore::Walk::new(workspace).flatten() {
+                                if let Some(file_type) = path.file_type() {
+                                    if file_type.is_file() {
+                                        let path = path.into_path();
+                                        let mut line_matches = Vec::new();
+                                        let _ = searcher.search_path(
+                                            &matcher,
+                                            path.clone(),
+                                            UTF8(|lnum, line| {
+                                                let mymatch = matcher
+                                                    .find(line.as_bytes())?
+                                                    .unwrap();
+                                                line_matches.push((
+                                                    lnum,
+                                                    (mymatch.start(), mymatch.end()),
+                                                    line.to_string(),
+                                                ));
+                                                Ok(true)
+                                            }),
+                                        );
+                                        if !line_matches.is_empty() {
+                                            matches
+                                                .insert(path.clone(), line_matches);
                                         }
                                     }
                                 }

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -1,15 +1,13 @@
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 use std::{
     collections::HashMap,
-    io::BufRead,
-    io::{BufReader, BufWriter, Write},
+    io::{BufRead, BufReader, BufWriter, Write},
     process::{self, Child, ChildStdout, Command, Stdio},
     sync::{mpsc::channel, Arc},
     thread,
     time::Duration,
 };
-
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
 
 use anyhow::{anyhow, Result};
 use jsonrpc_lite::{Id, JsonRpc, Params};
@@ -18,9 +16,10 @@ use lsp_types::*;
 use parking_lot::Mutex;
 use serde_json::{json, to_value, Value};
 
-use crate::buffer::Buffer;
-use crate::buffer::BufferId;
-use crate::dispatch::Dispatcher;
+use crate::{
+    buffer::{Buffer, BufferId},
+    dispatch::Dispatcher,
+};
 
 pub type Callback = Box<dyn Callable>;
 const HEADER_CONTENT_LENGTH: &str = "content-length";

--- a/lapce-proxy/src/plugin.rs
+++ b/lapce-proxy/src/plugin.rs
@@ -27,6 +27,7 @@ pub type PluginName = String;
 #[derive(Clone, Debug, Default)]
 pub struct Counter(usize);
 
+#[allow(clippy::should_implement_trait)]
 impl Counter {
     pub fn next(&mut self) -> usize {
         let n = self.0;

--- a/lapce-proxy/src/plugin.rs
+++ b/lapce-proxy/src/plugin.rs
@@ -1,24 +1,20 @@
 use anyhow::{anyhow, Result};
 use home::home_dir;
 use hotwatch::Hotwatch;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fs;
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::thread;
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    process::Command,
+    thread,
+    time::Duration,
+};
 use toml;
-use wasmer::ChainableNamedResolver;
-use wasmer::ImportObject;
-use wasmer::Store;
-use wasmer::WasmerEnv;
-use wasmer_wasi::Pipe;
-use wasmer_wasi::WasiEnv;
-use wasmer_wasi::WasiState;
+use wasmer::{ChainableNamedResolver, ImportObject, Store, WasmerEnv};
+use wasmer_wasi::{Pipe, WasiEnv, WasiState};
 
 use crate::dispatch::Dispatcher;
 

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -331,6 +331,6 @@ impl State {
 fn set_locale_environment() {
     let locale = locale_config::Locale::global_default()
         .to_string()
-        .replace("-", "_");
+        .replace('-', "_");
     std::env::set_var("LC_ALL", locale + ".UTF-8");
 }

--- a/lapce-rpc/Cargo.toml
+++ b/lapce-rpc/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-parking_lot = "0.11.2"
 anyhow = "1.0.34"
-serde_json = "1.0.59"
-serde = "1.0"
-jsonrpc-lite = "0.5.0"
 crossbeam-channel = "0.5.0"
+jsonrpc-lite = "0.5.0"
+parking_lot = "0.11.2"
+serde = "1.0"
+serde_json = "1.0.59"

--- a/lapce-rpc/src/lib.rs
+++ b/lapce-rpc/src/lib.rs
@@ -1,23 +1,21 @@
 mod parse;
 mod stdio;
 
-use std::collections::HashMap;
-use std::io::stdin;
-use std::io::stdout;
-use std::io::BufReader;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    io::{stdin, stdout, BufReader},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender};
 use parking_lot::Mutex;
-pub use parse::Call;
-pub use parse::RequestId;
-pub use parse::RpcObject;
+pub use parse::{Call, RequestId, RpcObject};
 use serde::de::DeserializeOwned;
-use serde_json::json;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 pub use stdio::stdio_transport;
 

--- a/lapce-rpc/src/stdio.rs
+++ b/lapce-rpc/src/stdio.rs
@@ -60,7 +60,7 @@ pub(crate) fn make_io_threads(
 pub struct IoThreads {
     #[allow(dead_code)]
     reader: thread::JoinHandle<io::Result<()>>,
-    
+
     #[allow(dead_code)]
     writer: thread::JoinHandle<io::Result<()>>,
 }

--- a/lapce-rpc/src/stdio.rs
+++ b/lapce-rpc/src/stdio.rs
@@ -1,10 +1,11 @@
-use anyhow::Result;
-use crossbeam_channel::{Receiver, Sender};
-use serde_json::Value;
 use std::{
     io::{self, BufRead, Write},
     thread,
 };
+
+use anyhow::Result;
+use crossbeam_channel::{Receiver, Sender};
+use serde_json::Value;
 
 pub fn stdio_transport<W, R>(
     mut writer: W,

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -5,63 +5,63 @@ authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.19"
-log = "0.4.14"
-fern = "0.6.0"
 Inflector = "0.11.4"
-rayon = "1.5.1"
-diff = "0.1.12"
-libloading = "0.7"
-flate2 = "1.0.22"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-hashbrown = "0.11.2"
-sled = "0.34.7"
-base64 = "0.13.0"
 alacritty_terminal = "0.15.0"
+anyhow = "1.0.32"
+base64 = "0.13.0"
+bit-vec = "0.5.0"
+chrono = "0.4.19"
 config = "0.11"
-indexmap = "1.7.0"
-directories = "4.0.1"
-tinyfiledialogs = "3.8.3"
-itertools = "0.10.1"
-unicode-width = "0.1.8"
-unicode-segmentation = "1.7.1"
-im = { version = "15.0.0", features = ["serde"] }
 crossbeam-channel = "0.5.0"
 crossbeam-utils = "0.8.4"
-regex = "1.4.2"
-usvg = "0.14.0"
-jsonrpc-lite = "0.5.0"
-bit-vec = "0.5.0"
-parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
-include_dir = "0.6.0"
-tree-sitter = "0.20.2"
-tree-sitter-highlight = "0.20.1"
-tree-sitter-rust = "0.20.0"
-tree-sitter-go = "0.19.1"
-tree-sitter-javascript = "0.20.0"
-anyhow = "1.0.32"
-strum = "0.19"
-strum_macros = "0.19"
-lazy_static = "1.4.0"
-serde = "1.0"
-serde_json = "1.0"
-notify = "5.0.0-pre.13"
-xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
-xi-unicode = "0.3.0"
-fzyr = "0.1.2"
-fuzzy-matcher = "0.3.7"
-uuid = { version = "0.7.4", features = ["v4"] }
-lsp-types = { version = "0.89.2", features = ["proposed"] }
+diff = "0.1.12"
+directories = "4.0.1"
 druid = { git = "https://github.com/lapce/druid", features = [ "svg", "im", "serde", ] }
-#druid = { path = "../../druid/druid", features = ["svg", "im" , "serde"] }
-toml = { version = "0.5.8", features = ["preserve_order"] }
-structdesc = { git = "https://github.com/lapce/structdesc" }
+fern = "0.6.0"
+flate2 = "1.0.22"
+fuzzy-matcher = "0.3.7"
+fzyr = "0.1.2"
+hashbrown = "0.11.2"
+im = { version = "15.0.0", features = ["serde"] }
+include_dir = "0.6.0"
+indexmap = "1.7.0"
+itertools = "0.10.1"
+jsonrpc-lite = "0.5.0"
 #structdesc = { path = "../../structdesc" }
 lapce-data = { path = "../lapce-data" }
-lapce-rpc = { path = "../lapce-rpc" }
 lapce-proxy = { path = "../lapce-proxy" }
+lapce-rpc = { path = "../lapce-rpc" }
+lazy_static = "1.4.0"
+libloading = "0.7"
+log = "0.4.14"
+lsp-types = { version = "0.89.2", features = ["proposed"] }
+notify = "5.0.0-pre.13"
+parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
+rayon = "1.5.1"
+regex = "1.4.2"
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = "1.0"
+serde_json = "1.0"
+sled = "0.34.7"
+structdesc = { git = "https://github.com/lapce/structdesc" }
+strum = "0.19"
+strum_macros = "0.19"
+tinyfiledialogs = "3.8.3"
+#druid = { path = "../../druid/druid", features = ["svg", "im" , "serde"] }
+toml = { version = "0.5.8", features = ["preserve_order"] }
+tree-sitter = "0.20.2"
+tree-sitter-go = "0.19.1"
+tree-sitter-highlight = "0.20.1"
+tree-sitter-javascript = "0.20.0"
+tree-sitter-rust = "0.20.0"
+unicode-segmentation = "1.7.1"
+unicode-width = "0.1.8"
+usvg = "0.14.0"
+uuid = { version = "0.7.4", features = ["v4"] }
+xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
+xi-unicode = "0.3.0"
 
 [build-dependencies]
-cc = "1"
 anyhow = "1.0.32"
+cc = "1"
 threadpool = "1.0"

--- a/lapce-ui/src/activity.rs
+++ b/lapce-ui/src/activity.rs
@@ -1,4 +1,5 @@
-use druid::{
+
+use druid::{
     BoxConstraints, Command, Cursor, Env, Event, EventCtx, LayoutCtx, LifeCycle,
     LifeCycleCtx, PaintCtx, Point, RenderContext, Size, Target, UpdateCtx, Widget,
 };

--- a/lapce-ui/src/container.rs
+++ b/lapce-ui/src/container.rs
@@ -1,4 +1,3 @@
-
 use druid::{Point, Size};
 
 pub struct ChildState {

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use druid::{

--- a/lapce-ui/src/find.rs
+++ b/lapce-ui/src/find.rs
@@ -1,6 +1,5 @@
 use regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
-use std::cmp::{max, min};
 use xi_rope::{
     delta::DeltaRegion,
     find::{find, is_multiline_regex, CaseMatching},

--- a/lapce-ui/src/lsp.rs
+++ b/lapce-ui/src/lsp.rs
@@ -1,3 +1,4 @@
+// TODO: This file is not included in compilation and duplicates `lapce-data::lsp.rs`; Document rationale or remove
 use anyhow::{anyhow, Result};
 use druid::{WidgetId, WindowId};
 use jsonrpc_lite::Id;

--- a/lapce-ui/src/proxy.rs
+++ b/lapce-ui/src/proxy.rs
@@ -1,17 +1,17 @@
-use std::collections::HashMap;
-use std::io::BufReader;
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
-use std::path::Path;
-use std::process::{Command, Stdio};
-use std::thread;
-use std::{path::PathBuf, sync::Arc};
+// TODO: This file is not included in compilation and duplicates `lapce-data::proxy.rs`; Document rationale or remove
+use std::{
+    collections::HashMap,
+    io::BufReader,
+    os::windows::process::CommandExt,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::Arc,
+    thread,
+};
 
 use anyhow::{anyhow, Result};
-use crossbeam_channel::Receiver;
-use crossbeam_channel::Sender;
-use druid::Target;
-use druid::{ExtEventSink, WidgetId};
+use crossbeam_channel::{Receiver, Sender};
+use druid::{ExtEventSink, Target, WidgetId};
 use flate2::read::GzDecoder;
 use lapce_data::{
     buffer::BufferId,
@@ -19,22 +19,18 @@ use lapce_data::{
     config::Config,
     state::{LapceWorkspace, LapceWorkspaceType},
 };
-use lapce_proxy::dispatch::FileDiff;
-use lapce_proxy::dispatch::FileNodeItem;
-use lapce_proxy::dispatch::{DiffInfo, Dispatcher};
-use lapce_proxy::plugin::PluginDescription;
-use lapce_proxy::terminal::TermId;
-use lapce_rpc::RpcHandler;
-use lapce_rpc::{stdio_transport, Callback};
-use lapce_rpc::{ControlFlow, Handler};
-use lsp_types::CompletionItem;
-use lsp_types::Position;
-use lsp_types::ProgressParams;
-use lsp_types::PublishDiagnosticsParams;
+use lapce_proxy::{
+    dispatch::{DiffInfo, Dispatcher, FileDiff, FileNodeItem},
+    plugin::PluginDescription,
+    terminal::TermId,
+};
+use lapce_rpc::{stdio_transport, Callback, ControlFlow, Handler, RpcHandler};
+use lsp_types::{
+    CompletionItem, Position, ProgressParams, PublishDiagnosticsParams,
+};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
-use serde_json::Value;
+use serde_json::{json, Value};
 use xi_rope::RopeDelta;
 
 use crate::terminal::RawTerminal;

--- a/lapce-ui/src/scroll.rs
+++ b/lapce-ui/src/scroll.rs
@@ -1,13 +1,10 @@
-use std::time::Duration;
-use std::time::Instant;
+use std::{time::Duration, time::Instant};
 
 use druid::{
     kurbo::{Affine, Point, Rect, Size, Vec2},
-    Insets, WidgetId,
-};
-use druid::{
-    theme, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, RenderContext, TimerToken, UpdateCtx, Widget, WidgetPod,
+    theme, BoxConstraints, Data, Env, Event, EventCtx, Insets, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, RenderContext, TimerToken, UpdateCtx, Widget, WidgetId,
+    WidgetPod,
 };
 
 use lapce_data::{

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
 use druid::{
     piet::{Text, TextAttribute, TextLayout as PietTextLayout, TextLayoutBuilder},
     BoxConstraints, Command, Cursor, Data, Env, Event, EventCtx, FontFamily,
@@ -11,7 +13,6 @@ use lapce_data::{
     editor::EditorLocationNew,
     split::SplitDirection,
 };
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use crate::{
     editor::LapceEditorView,
@@ -21,6 +22,7 @@ use crate::{
     svg::file_svg_new,
 };
 
+#[allow(clippy::type_complexity)]
 #[derive(Clone)]
 pub struct SearchData {
     pub active: WidgetId,

--- a/lapce-ui/src/signature.rs
+++ b/lapce-ui/src/signature.rs
@@ -1,5 +1,5 @@
-use lsp_types::ParameterLabel;
-use lsp_types::SignatureHelp;
+// TODO: This file duplicates `lapce-data::signature.rs`; Document rationale or remove
+use lsp_types::{ParameterLabel, SignatureHelp};
 
 #[derive(Clone)]
 pub struct SignatureState {

--- a/lapce-ui/src/split.rs
+++ b/lapce-ui/src/split.rs
@@ -1,18 +1,17 @@
+use std::sync::Arc;
+
 use crate::{
     editor::{LapceEditorTab, LapceEditorView},
     svg::logo_svg,
     terminal::LapceTerminalView,
 };
-use std::sync::Arc;
 
 use druid::{
     kurbo::{Line, Rect},
     piet::{PietTextLayout, Text, TextLayout, TextLayoutBuilder},
-    Command, FontFamily, Target, WidgetId,
-};
-use druid::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
-    PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget, WidgetExt, WidgetPod,
+    BoxConstraints, Command, Env, Event, EventCtx, FontFamily, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, Point, RenderContext, Size, Target, UpdateCtx, Widget,
+    WidgetExt, WidgetId, WidgetPod,
 };
 use lapce_data::{
     command::{

--- a/lapce-ui/src/theme.rs
+++ b/lapce-ui/src/theme.rs
@@ -1,4 +1,3 @@
-
 pub struct OldLapceTheme {}
 
 impl OldLapceTheme {

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use druid::{
     kurbo::Line,
     widget::{LensWrap, WidgetExt},
@@ -11,7 +13,6 @@ use lapce_data::{
     data::{LapceTabData, LapceTabLens, LapceWindowData},
     state::LapceWorkspace,
 };
-use std::sync::Arc;
 
 use crate::{
     menu::Menu,


### PR DESCRIPTION
Dedup `use`s, consistently order `std`, deps, `crate`
Organize `Cargo.toml` deps