### PR TITLE
Adding a snapcraft.yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 lib/
 target/
 core/languages/
+
+prime/
+*.snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,71 @@
+name: lapce # you probably want to 'snapcraft register <name>'
+base: core20 # the base snap is the execution environment for this snap
+# version:  git # just for humans, typically '1.2+git' or '1.3.2'
+version:  git # just for humans, typically '1.2+git' or '1.3.2'
+license:  Apache-2.0
+summary: Lightning-fast and Powerful Code Editor Open source # 79 char long summary
+description: |
+  A modern open source code editor in Rust
+  Native GUI and Rust powered performance, we as developers know what you need for an essential tool like a code editor. Write code with joy in Lapce. 
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  lapce:
+    # command: target/release/lapce
+    command: bin/lapce
+    # extensions: [gnome-3-38]
+    extensions: [kde-neon]
+    plugs:
+      - home
+      - opengl
+      - x11
+      - network
+    
+
+parts:
+  lapce:
+    plugin: rust
+    source: .
+    build-packages:
+      - squid-deb-proxy-client
+      - libjsoncpp1
+      - libarchive13
+      - libuv1
+      - librhash0
+      - pkgconf
+      - libfreetype-dev
+      - librust-expat-sys-dev
+      - fontconfig
+      - libfontconfig1
+      - libfontconfig1-dev
+      - libxcb-render-util0
+      - libxcb-render-util0-dev
+      - libxcb-render0
+      - libxcb-render0-dev
+      - libxcb-shape0
+      - libxcb-shape0-dev
+      - libxcb-xfixes0
+      - libxcb-xfixes0-dev
+      - libxcb-xkb-dev
+      - libxcb-xkb1
+      - libxkbcommon0
+      - libxkbcommon-x11-dev
+      - libxkbcommon-dev
+    stage-packages:
+      - libfreetype6
+      - libpng16-16
+      # - libfontconfig1
+      # - libxcb-render0
+      # - libxcb-shape0
+      # - libxcb-xfixes0
+      - libxcb1
+      - libx11-6
+      - libx11-xcb1
+      - libxcursor-dev
+      - libxrandr2
+      - libxi6
+      - ibus-gtk
+      - libibus-1.0-5
+      - cmake

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: lapce # you probably want to 'snapcraft register <name>'
+name: dm-lapce # you probably want to 'snapcraft register <name>'
 base: core20 # the base snap is the execution environment for this snap
 # version:  git # just for humans, typically '1.2+git' or '1.3.2'
 version:  git # just for humans, typically '1.2+git' or '1.3.2'


### PR DESCRIPTION
Hi, I wanted to add an official distribution of Lapce text editor as snap package. So we will be able to distribute software across multiple Linux distribution simultaneously via https://snapcraft.io/.

I have tested this snapcraft.yaml file locally. And it's working fine.

I have referred to following guides on preparing this configuration file.
https://snapcraft.io/docs/snapcraft-overview
https://snapcraft.io/docs/rust-applications
https://snapcraft.io/docs/creating-a-snap

Also, I have used `apt-file search` command extensively to find the dependencies.