### PR TITLE
Fuzzy filtering related cleanups

### DIFF
--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -423,14 +423,11 @@ impl CompletionData {
                 }
             })
             .collect();
-        items.sort_by(|a, b| match b.score.cmp(&a.score) {
-            Ordering::Less => Ordering::Less,
-            Ordering::Greater => Ordering::Greater,
-            Ordering::Equal => match b.label_score.cmp(&a.label_score) {
-                Ordering::Less => Ordering::Less,
-                Ordering::Greater => Ordering::Greater,
-                Ordering::Equal => a.item.label.len().cmp(&b.item.label.len()),
-            },
+        items.sort_by(|a, b| {
+            b.score
+                .cmp(&a.score)
+                .then_with(|| b.label_score.cmp(&a.label_score))
+                .then_with(|| a.item.label.len().cmp(&b.item.label.len()))
         });
         self.filtered_items = Arc::new(items);
     }

--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -404,7 +404,9 @@ impl CompletionData {
                     self.matcher.fuzzy_indices(filter_text, &self.input)
                 {
                     if shift > 0 {
-                        indices = indices.iter().map(|i| i + shift).collect();
+                        for idx in indices.iter_mut() {
+                            *idx += shift;
+                        }
                     }
                     let mut item = i.clone();
                     item.score = score;

--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -410,8 +410,8 @@ impl CompletionData {
                     item.score = score;
                     item.label_score = score;
                     item.indices = indices;
-                    if let Some((score, _)) =
-                        self.matcher.fuzzy_indices(&i.item.label, &self.input)
+                    if let Some(score) =
+                        self.matcher.fuzzy_match(&i.item.label, &self.input)
                     {
                         item.label_score = score;
                     }


### PR DESCRIPTION
 - Use `fuzzy_match` where the indexes are not used
 - Remove unnecessary copying