### PR TITLE
Allow console output on windows debug builds

### DIFF
--- a/lapce-ui/src/bin/lapce.rs
+++ b/lapce-ui/src/bin/lapce.rs
@@ -1,4 +1,4 @@
-#![windows_subsystem = "windows"]
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use lapce_ui::app;
 


### PR DESCRIPTION
This PR disabled the windows subsystem attribute in debug builds, enabling console output for debug purposes.