### PR TITLE
Fix some places where completion would remain when it should not

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -537,7 +537,7 @@ impl LapceEditorBufferData {
         Ok(())
     }
 
-    fn cancel_completion(&mut self) {
+    pub fn cancel_completion(&mut self) {
         let completion = Arc::make_mut(&mut self.completion);
         completion.cancel();
     }
@@ -1025,6 +1025,8 @@ impl LapceEditorBufferData {
                 }
             }
         }
+
+        self.update_completion(ctx);
     }
 
     fn check_selection_history(&mut self) {
@@ -3430,6 +3432,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                 let proxy = self.proxy.clone();
                 let buffer = self.buffer_mut();
                 if let Some(delta) = buffer.do_undo(proxy) {
+                    self.update_completion(ctx);
                     self.jump_to_nearest_delta(&delta);
                     self.update_diagnositcs_offset(&delta);
                 }
@@ -3439,6 +3442,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                 let proxy = self.proxy.clone();
                 let buffer = self.buffer_mut();
                 if let Some(delta) = buffer.do_redo(proxy) {
+                    self.update_completion(ctx);
                     self.jump_to_nearest_delta(&delta);
                     self.update_diagnositcs_offset(&delta);
                 }
@@ -3641,6 +3645,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                 let selection =
                     selection.apply_delta(&delta, true, InsertDrift::Default);
                 self.set_cursor_after_change(selection);
+                self.cancel_completion();
             }
             LapceCommand::ClipboardCopy => {
                 let data = self

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -2392,9 +2392,11 @@ impl LapceEditor {
         match mouse_event.button {
             MouseButton::Left => {
                 self.left_click(ctx, mouse_event, editor_data, config);
+                editor_data.cancel_completion();
             }
             MouseButton::Right => {
                 self.right_click(ctx, editor_data, mouse_event, config);
+                editor_data.cancel_completion();
             }
             MouseButton::Middle => {}
             _ => (),


### PR DESCRIPTION
This fixes minor issues where completion would remain when clicking in the editor, and when cutting/pasting text.  
I'm sure more of the commands have this issue, and should cancel/update completion within them, but this PR does it for a few common commands.  
