### PR TITLE
Implement more general closing of modals

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -146,13 +146,8 @@ mode = "n"
 
 [[keymaps]]
 key = "esc"
-command = "palette.cancel"
-when = "palette_focus"
+command = "modal.close"
 
-[[keymaps]]
-key = "esc"
-command = "code_actions.cancel"
-when = "code_actions_focus"
 
 [[keymaps]]
 key = "ctrl+b"

--- a/lapce-data/src/code_action.rs
+++ b/lapce-data/src/code_action.rs
@@ -30,7 +30,10 @@ impl KeyPressFocus for CodeActionData {
     }
 
     fn check_condition(&self, condition: &str) -> bool {
-        matches!(condition, "list_focus" | "code_actions_focus")
+        matches!(
+            condition,
+            "list_focus" | "code_actions_focus" | "modal_focus"
+        )
     }
 
     fn run_command(
@@ -42,7 +45,7 @@ impl KeyPressFocus for CodeActionData {
         _env: &Env,
     ) -> CommandExecuted {
         match command {
-            LapceCommand::CodeActionsCancel => {
+            LapceCommand::ModalClose => {
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
                     LapceUICommand::CancelCodeActions,

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -253,10 +253,10 @@ pub enum LapceCommand {
     SourceControl,
     #[strum(serialize = "source_control.cancel")]
     SourceControlCancel,
-    #[strum(serialize = "code_actions.cancel")]
-    CodeActionsCancel,
-    #[strum(serialize = "palette.cancel")]
-    PaletteCancel,
+    /// This will close a modal, such as the settings window or completion
+    #[strum(message = "Close Modal")]
+    #[strum(serialize = "modal.close")]
+    ModalClose,
     #[strum(serialize = "delete_backward")]
     DeleteBackward,
     #[strum(serialize = "delete_forward")]

--- a/lapce-data/src/menu.rs
+++ b/lapce-data/src/menu.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
-use druid::{Env, EventCtx, Modifiers, Point, WidgetId};
+use druid::{Command, Env, EventCtx, Modifiers, Point, Target, WidgetId};
 
 use crate::{
-    command::{CommandExecuted, LapceCommand, LapceCommandNew},
+    command::{
+        CommandExecuted, LapceCommand, LapceCommandNew, LapceUICommand,
+        LAPCE_UI_COMMAND,
+    },
     keypress::KeyPressFocus,
     state::Mode,
 };
@@ -29,18 +32,27 @@ impl KeyPressFocus for MenuData {
     }
 
     fn check_condition(&self, condition: &str) -> bool {
-        matches!(condition, "list_focus" | "menu_focus")
+        matches!(condition, "list_focus" | "menu_focus" | "modal_focus")
     }
 
     fn run_command(
         &mut self,
-        _ctx: &mut EventCtx,
-        _command: &LapceCommand,
+        ctx: &mut EventCtx,
+        command: &LapceCommand,
         _count: Option<usize>,
         _mods: Modifiers,
         _env: &Env,
     ) -> CommandExecuted {
-        CommandExecuted::No
+        if let LapceCommand::ModalClose = command {
+            ctx.submit_command(Command::new(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::HideMenu,
+                Target::Auto,
+            ));
+            CommandExecuted::Yes
+        } else {
+            CommandExecuted::No
+        }
     }
 
     fn receive_char(&mut self, _ctx: &mut EventCtx, _c: &str) {}

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -462,7 +462,7 @@ impl KeyPressFocus for PaletteViewData {
     }
 
     fn check_condition(&self, condition: &str) -> bool {
-        matches!(condition, "list_focus" | "palette_focus")
+        matches!(condition, "list_focus" | "palette_focus" | "modal_focus")
     }
 
     fn run_command(
@@ -474,7 +474,7 @@ impl KeyPressFocus for PaletteViewData {
         _env: &Env,
     ) -> CommandExecuted {
         match command {
-            LapceCommand::PaletteCancel => {
+            LapceCommand::ModalClose => {
                 self.cancel(ctx);
             }
             LapceCommand::DeleteBackward => {

--- a/lapce-data/src/settings.rs
+++ b/lapce-data/src/settings.rs
@@ -25,6 +25,34 @@ pub struct LapceSettingsPanelData {
     pub settings_split_id: WidgetId,
 }
 
+impl KeyPressFocus for LapceSettingsPanelData {
+    fn get_mode(&self) -> Mode {
+        Mode::Insert
+    }
+
+    fn check_condition(&self, condition: &str) -> bool {
+        matches!(condition, "modal_focus")
+    }
+
+    fn run_command(
+        &mut self,
+        _ctx: &mut EventCtx,
+        command: &LapceCommand,
+        _count: Option<usize>,
+        _mods: Modifiers,
+        _env: &Env,
+    ) -> CommandExecuted {
+        if let LapceCommand::ModalClose = command {
+            self.shown = false;
+            CommandExecuted::Yes
+        } else {
+            CommandExecuted::No
+        }
+    }
+
+    fn receive_char(&mut self, _ctx: &mut EventCtx, _c: &str) {}
+}
+
 impl LapceSettingsPanelData {
     pub fn new() -> Self {
         Self {

--- a/lapce-ui/src/code_action.rs
+++ b/lapce-ui/src/code_action.rs
@@ -35,7 +35,10 @@ impl KeyPressFocus for CodeActionData {
     }
 
     fn check_condition(&self, condition: &str) -> bool {
-        matches!(condition, "list_focus" | "code_actions_focus")
+        matches!(
+            condition,
+            "list_focus" | "code_actions_focus" | "modal_focus"
+        )
     }
 
     fn run_command(
@@ -47,7 +50,7 @@ impl KeyPressFocus for CodeActionData {
         _env: &Env,
     ) -> CommandExecuted {
         match command {
-            LapceCommand::CodeActionsCancel => {
+            LapceCommand::ModalClose => {
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
                     LapceUICommand::CancelCodeActions,

--- a/lapce-ui/src/menu.rs
+++ b/lapce-ui/src/menu.rs
@@ -78,9 +78,23 @@ impl Widget<LapceWindowData> for Menu {
         ctx: &mut EventCtx,
         event: &Event,
         data: &mut LapceWindowData,
-        _env: &Env,
+        env: &Env,
     ) {
         match event {
+            Event::KeyDown(key_event) => {
+                if data.menu.shown {
+                    let keypress = data.keypress.clone();
+                    let mut_keypress = Arc::make_mut(&mut data.keypress);
+                    let performed_action = mut_keypress.key_down(
+                        ctx,
+                        key_event,
+                        Arc::make_mut(&mut data.menu),
+                        env,
+                    );
+                    data.keypress = keypress;
+                    ctx.set_handled();
+                }
+            }
             Event::MouseMove(mouse_event) => {
                 if data.menu.shown {
                     self.mouse_move(ctx, mouse_event, data);

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -147,6 +147,20 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
         }
         self.children[self.active].event(ctx, event, data, env);
         match event {
+            Event::KeyDown(key_event) => {
+                let mut keypress = data.keypress.clone();
+                let mut_keypress = Arc::make_mut(&mut keypress);
+                let performed_action = mut_keypress.key_down(
+                    ctx,
+                    key_event,
+                    Arc::make_mut(&mut data.settings),
+                    env,
+                );
+                data.keypress = keypress;
+                if performed_action {
+                    ctx.set_handled();
+                }
+            }
             Event::MouseMove(mouse_event) => {
                 ctx.set_handled();
                 if self.icon_hit_test(mouse_event) {

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -229,6 +229,15 @@ impl Widget<LapceWindowData> for LapceWindowNew {
                         ctx.set_handled();
                         let menu = Arc::make_mut(&mut data.menu);
                         menu.shown = false;
+                        let active_tab_id = data.active_id;
+                        let active_id = data
+                            .tabs
+                            .get(&active_tab_id)
+                            .and_then(|t| t.main_split.active_editor())
+                            .map(|e| e.view_id);
+                        if let Some(active_id) = active_id {
+                            ctx.set_focus(active_id)
+                        }
                     }
                     LapceUICommand::ShowMenu(point, items) => {
                         ctx.set_handled();


### PR DESCRIPTION
This adds support for hiding the completion by pressing esc, similar to vscode. I often rely on this since I navigate with the arrow keys, and use esc to quickly hide completion if I decide to move down/up. This is also useful if there is a bug in which the completion menu remains when it should not (such as #227 ).  
