### PR TITLE
Fix crash caused by overflow

### DIFF
--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -803,7 +803,10 @@ impl Widget<LapceTabData> for LapceTabNew {
                                                 editor.cursor =
                                                     movement::Cursor::new(
                                                         CursorMode::Normal(
-                                                            buffer.len() - 1,
+                                                            buffer.offset_line_end(
+                                                                buffer.len(),
+                                                                false,
+                                                            ),
                                                         ),
                                                         None,
                                                     );
@@ -812,7 +815,11 @@ impl Widget<LapceTabData> for LapceTabNew {
                                                     movement::Cursor::new(
                                                         CursorMode::Insert(
                                                             Selection::caret(
-                                                                buffer.len() - 1,
+                                                                buffer
+                                                                    .offset_line_end(
+                                                                        buffer.len(),
+                                                                        true,
+                                                                    ),
                                                             ),
                                                         ),
                                                         None,


### PR DESCRIPTION
This PR fixes the following crash:
![image](https://user-images.githubusercontent.com/977627/159751145-cf871c02-8072-45cf-88a2-d82cf17448ac.png)

I don't know why this happened, though, so this might not be the root cause of the issue.