### PR TITLE
Add PHP syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,7 @@ dependencies = [
  "tree-sitter-go",
  "tree-sitter-highlight",
  "tree-sitter-javascript",
+ "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-toml",
@@ -4084,6 +4085,15 @@ name = "tree-sitter-javascript"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2490fab08630b2c8943c320f7b63473cbf65511c8d83aec551beb9b4375906ed"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.19.1"
+source = "git+https://github.com/tree-sitter/tree-sitter-php.git#ead3e4cc5f54602a6b54826c5d6881c9a9da15af"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -17,4 +17,5 @@ tree-sitter-javascript = "0.20.0"
 tree-sitter-typescript = "0.20.0"
 tree-sitter-python = "0.19.1"
 tree-sitter-toml = "0.20.0"
+tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", version = "0.19.1" }
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -43,6 +43,7 @@ pub enum LapceLanguage {
     Tsx,
     Python,
     Toml,
+    Php,
 }
 
 impl LapceLanguage {
@@ -57,6 +58,7 @@ impl LapceLanguage {
             "go" => LapceLanguage::Go,
             "py" => LapceLanguage::Python,
             "toml" => LapceLanguage::Toml,
+            "php" => LapceLanguage::Php,
             _ => return None,
         })
     }
@@ -71,6 +73,7 @@ impl LapceLanguage {
             LapceLanguage::Tsx => "//",
             LapceLanguage::Python => "#",
             LapceLanguage::Toml => "#",
+            LapceLanguage::Php => "//",
         }
     }
 
@@ -84,6 +87,7 @@ impl LapceLanguage {
             LapceLanguage::Tsx => "  ",
             LapceLanguage::Python => "    ",
             LapceLanguage::Toml => "  ",
+            LapceLanguage::Php => "  ",
         }
     }
 
@@ -99,6 +103,7 @@ impl LapceLanguage {
             LapceLanguage::Tsx => tree_sitter_typescript::language_tsx(),
             LapceLanguage::Python => tree_sitter_python::language(),
             LapceLanguage::Toml => tree_sitter_toml::language(),
+            LapceLanguage::Php => tree_sitter_php::language(),
         }
     }
 
@@ -120,6 +125,7 @@ impl LapceLanguage {
             LapceLanguage::Tsx => tree_sitter_typescript::HIGHLIGHT_QUERY,
             LapceLanguage::Python => tree_sitter_python::HIGHLIGHT_QUERY,
             LapceLanguage::Toml => tree_sitter_toml::HIGHLIGHT_QUERY,
+            LapceLanguage::Php => tree_sitter_php::HIGHLIGHT_QUERY,
         };
 
         HighlightConfiguration::new(language, query, "", "").unwrap()


### PR DESCRIPTION
Seems to work fine :)
![image](https://user-images.githubusercontent.com/759887/159880643-908234d1-8cdd-42ad-929d-969a2bbda795.png)

The code lens I don't understand enough to implement proper support for, it replaces the entire file like this atm:
![image](https://user-images.githubusercontent.com/759887/159881021-e8a9b82c-ab56-4612-86bd-5f4c67118349.png)
