### PR TITLE
Don't crash when code action does not exist

### DIFF
--- a/lapce-ui/src/code_action.rs
+++ b/lapce-ui/src/code_action.rs
@@ -117,7 +117,12 @@ impl CodeActionData {
             let code_actions =
                 buffer.code_actions.get(&prev_offset).unwrap_or(&empty_vec);
 
-            let action = &code_actions[self.main_split.current_code_actions];
+            let action = match code_actions.get(self.main_split.current_code_actions)
+            {
+                Some(action) => action,
+                None => return,
+            };
+
             match action {
                 CodeActionOrCommand::Command(_cmd) => {}
                 CodeActionOrCommand::CodeAction(action) => {


### PR DESCRIPTION
I got a crash when trying to apply a refactoring assist (replace if-let with match, in my case). This PR ignores the edit, instead of crashing on it.