### PR TITLE
Add tree-sitter C support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tree-sitter",
+ "tree-sitter-c",
  "tree-sitter-go",
  "tree-sitter-highlight",
  "tree-sitter-javascript",
@@ -4057,6 +4058,16 @@ checksum = "09b3b781640108d29892e8b9684642d2cda5ea05951fd58f0fea1db9edeb9b71"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bdc5574c6cbc39c409246caeb1dd4d3c4bd6d30d4e9b399776086c20365fd24"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -18,5 +18,7 @@ tree-sitter-typescript = "0.20.0"
 tree-sitter-python = "0.19.1"
 tree-sitter-toml = "0.20.0"
 tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", version = "0.19.1" }
+tree-sitter-c = "0.20.1"
+
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
 lapce-proxy = { path = "../lapce-proxy" }

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -44,6 +44,7 @@ pub enum LapceLanguage {
     Python,
     Toml,
     Php,
+    C,
 }
 
 impl LapceLanguage {
@@ -59,6 +60,7 @@ impl LapceLanguage {
             "py" => LapceLanguage::Python,
             "toml" => LapceLanguage::Toml,
             "php" => LapceLanguage::Php,
+            "c" | "h" => LapceLanguage::C,
             _ => return None,
         })
     }
@@ -74,6 +76,7 @@ impl LapceLanguage {
             LapceLanguage::Python => "#",
             LapceLanguage::Toml => "#",
             LapceLanguage::Php => "//",
+            LapceLanguage::C => "//",
         }
     }
 
@@ -88,6 +91,7 @@ impl LapceLanguage {
             LapceLanguage::Python => "    ",
             LapceLanguage::Toml => "  ",
             LapceLanguage::Php => "  ",
+            LapceLanguage::C => "  ",
         }
     }
 
@@ -104,6 +108,7 @@ impl LapceLanguage {
             LapceLanguage::Python => tree_sitter_python::language(),
             LapceLanguage::Toml => tree_sitter_toml::language(),
             LapceLanguage::Php => tree_sitter_php::language(),
+            LapceLanguage::C => tree_sitter_c::language(),
         }
     }
 
@@ -126,6 +131,7 @@ impl LapceLanguage {
             LapceLanguage::Python => tree_sitter_python::HIGHLIGHT_QUERY,
             LapceLanguage::Toml => tree_sitter_toml::HIGHLIGHT_QUERY,
             LapceLanguage::Php => tree_sitter_php::HIGHLIGHT_QUERY,
+            LapceLanguage::C => tree_sitter_c::HIGHLIGHT_QUERY,
         };
 
         HighlightConfiguration::new(language, query, "", "").unwrap()


### PR DESCRIPTION
- Supports "c" and "h" filename extensions

Linked in encompassing issue: https://github.com/lapce/lapce/issues/272