### PR TITLE
Fix and simplify `Movement::update_index`

### DIFF
--- a/lapce-data/src/movement.rs
+++ b/lapce-data/src/movement.rs
@@ -897,9 +897,13 @@ impl Movement {
 
 pub fn remove_n_at<T>(v: &mut Vec<T>, index: usize, n: usize) {
     match n.cmp(&1) {
-        Ordering::Equal => {v.remove(index);},
-        Ordering::Greater => {v.splice(index..index + n, std::iter::empty());},
-        _ => ()
+        Ordering::Equal => {
+            v.remove(index);
+        }
+        Ordering::Greater => {
+            v.drain(index..index + n);
+        }
+        _ => (),
     };
 }
 

--- a/lapce-data/src/movement.rs
+++ b/lapce-data/src/movement.rs
@@ -873,22 +873,26 @@ impl Movement {
         index: usize,
         len: usize,
         count: usize,
-        recursive: bool,
+        wrapping: bool,
     ) -> usize {
         if len == 0 {
             return 0;
         }
+        let last = len - 1;
         match self {
-            Movement::Up => {
-                format_index(index as i64 - count as i64, len, recursive)
-            }
-            Movement::Down => {
-                format_index(index as i64 + count as i64, len, recursive)
-            }
+            // Select the next entry/line
+            Movement::Down if wrapping => (index + count) % len,
+            Movement::Down => (index + count).min(last),
+
+            // Selects the previous entry/line
+            Movement::Up if wrapping => (index + (len.saturating_sub(count))) % len,
+            Movement::Up => (index.saturating_sub(count)),
+
             Movement::Line(position) => match position {
-                LinePosition::Line(n) => format_index(*n as i64, len, recursive),
+                // Selects the nth line
+                LinePosition::Line(n) => (*n).min(last),
                 LinePosition::First => 0,
-                LinePosition::Last => len - 1,
+                LinePosition::Last => last,
             },
             _ => index,
         }
@@ -907,20 +911,49 @@ pub fn remove_n_at<T>(v: &mut Vec<T>, index: usize, n: usize) {
     };
 }
 
-fn format_index(index: i64, len: usize, recursive: bool) -> usize {
-    if recursive {
-        if index >= len as i64 {
-            (index % len as i64) as usize
-        } else if index < 0 {
-            len - (-index % len as i64) as usize
-        } else {
-            index as usize
-        }
-    } else if index >= len as i64 {
-        len - 1
-    } else if index < 0 {
-        0
-    } else {
-        index as usize
+#[cfg(test)]
+mod test {
+    use crate::movement::Movement;
+
+    #[test]
+    fn test_wrapping() {
+        // Move by 1 position
+        // List length of 1
+        assert_eq!(0, Movement::Up.update_index(0, 1, 1, true));
+        assert_eq!(0, Movement::Down.update_index(0, 1, 1, true));
+
+        // List length of 5
+        assert_eq!(4, Movement::Up.update_index(0, 5, 1, true));
+        assert_eq!(1, Movement::Down.update_index(0, 5, 1, true));
+
+        // Move by 2 positions
+        // List length of 1
+        assert_eq!(0, Movement::Up.update_index(0, 1, 2, true));
+        assert_eq!(0, Movement::Down.update_index(0, 1, 2, true));
+
+        // List length of 5
+        assert_eq!(3, Movement::Up.update_index(0, 5, 2, true));
+        assert_eq!(2, Movement::Down.update_index(0, 5, 2, true));
+    }
+
+    #[test]
+    fn test_non_wrapping() {
+        // Move by 1 position
+        // List length of 1
+        assert_eq!(0, Movement::Up.update_index(0, 1, 1, false));
+        assert_eq!(0, Movement::Down.update_index(0, 1, 1, false));
+
+        // List length of 5
+        assert_eq!(0, Movement::Up.update_index(0, 5, 1, false));
+        assert_eq!(1, Movement::Down.update_index(0, 5, 1, false));
+
+        // Move by 2 positions
+        // List length of 1
+        assert_eq!(0, Movement::Up.update_index(0, 1, 2, false));
+        assert_eq!(0, Movement::Down.update_index(0, 1, 2, false));
+
+        // List length of 5
+        assert_eq!(0, Movement::Up.update_index(0, 5, 2, false));
+        assert_eq!(2, Movement::Down.update_index(0, 5, 2, false));
     }
 }


### PR DESCRIPTION
Some of the new test cases failed with the old code. Namely, `Movement::Up.update_index(0, 1, 1, true);` previously gave `1` which resulted in the crash worked around in https://github.com/lapce/lapce/pull/269

This issue is visible when the language server offers a single code assist. In this case, when the assist list is visible, the up key allows switching selection between the actual code assist, and an invalid item that causes a visual glitch. Selecting this invalid item previously (before #269) crashed Lapce.

A demonstration of the issue:

https://user-images.githubusercontent.com/977627/160213054-e6315242-e04e-47e2-8d71-d7bc1a018db1.mp4

With this PR applied, this behaviour does not occur, and pressing the up/down arrows has no visual effect (because of this, I did not record a video, that would look like a single unchanging frame).
