### PR TITLE
Add Cpp tree-sitter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "thiserror",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-highlight",
  "tree-sitter-javascript",
@@ -4065,6 +4066,16 @@ name = "tree-sitter-c"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bdc5574c6cbc39c409246caeb1dd4d3c4bd6d30d4e9b399776086c20365fd24"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a869e3c5cef4e5db4e9ab16a8dc84d73010e60ada14cdc60d2f6d8aed17779d"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -19,6 +19,6 @@ tree-sitter-python = "0.19.1"
 tree-sitter-toml = "0.20.0"
 tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", version = "0.19.1" }
 tree-sitter-c = "0.20.1"
-
+tree-sitter-cpp = "0.20.0"
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
 lapce-proxy = { path = "../lapce-proxy" }

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -45,6 +45,7 @@ pub enum LapceLanguage {
     Toml,
     Php,
     C,
+    Cpp,
 }
 
 impl LapceLanguage {
@@ -61,6 +62,7 @@ impl LapceLanguage {
             "toml" => LapceLanguage::Toml,
             "php" => LapceLanguage::Php,
             "c" | "h" => LapceLanguage::C,
+            "cpp" | "cxx" | "cc" | "hpp" | "hxx" => LapceLanguage::Cpp,
             _ => return None,
         })
     }
@@ -77,6 +79,7 @@ impl LapceLanguage {
             LapceLanguage::Toml => "#",
             LapceLanguage::Php => "//",
             LapceLanguage::C => "//",
+            LapceLanguage::Cpp => "//",
         }
     }
 
@@ -92,6 +95,7 @@ impl LapceLanguage {
             LapceLanguage::Toml => "  ",
             LapceLanguage::Php => "  ",
             LapceLanguage::C => "  ",
+            LapceLanguage::Cpp => "    ",
         }
     }
 
@@ -109,6 +113,7 @@ impl LapceLanguage {
             LapceLanguage::Toml => tree_sitter_toml::language(),
             LapceLanguage::Php => tree_sitter_php::language(),
             LapceLanguage::C => tree_sitter_c::language(),
+            LapceLanguage::Cpp => tree_sitter_cpp::language(),
         }
     }
 
@@ -132,6 +137,7 @@ impl LapceLanguage {
             LapceLanguage::Toml => tree_sitter_toml::HIGHLIGHT_QUERY,
             LapceLanguage::Php => tree_sitter_php::HIGHLIGHT_QUERY,
             LapceLanguage::C => tree_sitter_c::HIGHLIGHT_QUERY,
+            LapceLanguage::Cpp => tree_sitter_cpp::HIGHLIGHT_QUERY,
         };
 
         HighlightConfiguration::new(language, query, "", "").unwrap()


### PR DESCRIPTION
Add tree-sitter Cpp support to cpp, cxx, cc, hpp, hxx file name extensions.

Tree Sitter Support Issue: https://github.com/lapce/lapce/issues/272
