### PR TITLE
Fix incorrect file path parsing on windows

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -17,6 +17,7 @@ use crate::data::{
     EditorDiagnostic, InlineFindDirection, LapceEditorData, LapceMainSplitData,
     LapceTabData, PanelData, PanelKind, RegisterData, SplitContent,
 };
+use crate::proxy::path_from_url;
 use crate::state::LapceWorkspace;
 use crate::svg::get_svg;
 use crate::{
@@ -5018,8 +5019,8 @@ impl KeyPressFocus for LapceEditorBufferData {
                                                 editor_view_id,
                                                 offset,
                                                 EditorLocationNew {
-                                                    path: PathBuf::from(
-                                                        location.uri.path(),
+                                                    path: path_from_url(
+                                                        &location.uri,
                                                     ),
                                                     position: Some(
                                                         location.range.start,
@@ -5609,7 +5610,7 @@ fn process_get_references(
                 editor_view_id,
                 offset,
                 EditorLocationNew {
-                    path: PathBuf::from(location.uri.path()),
+                    path: path_from_url(&location.uri),
                     position: Some(location.range.start),
                     scroll_offset: None,
                     hisotry: None,

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -777,3 +777,33 @@ pub struct ProxyHandlerNew {
 //         Err(xi_rpc::RemoteError::InvalidRequest(None))
 //     }
 // }
+
+use lsp_types::Url;
+
+// Rust-analyzer returns paths in the form of "file:///<drive>:/...", which gets parsed into URL
+// as "/<drive>://" which is then interpreted by PathBuf::new() as a UNIX-like path from root.
+// This function strips the additional / from the beginning, if the first segment is a drive letter.
+#[cfg(windows)]
+pub fn path_from_url(url: &Url) -> PathBuf {
+    let path = url.path();
+    if let Some(path) = path.strip_prefix('/') {
+        if let Some((maybe_drive_letter, _)) = path.split_once(&['/', '\\']) {
+            let b = maybe_drive_letter.as_bytes();
+            if b.len() == 2
+                && matches!(
+                    b[0],
+                    b'a'..=b'z' | b'A'..=b'Z'
+                )
+                && b[1] == b':'
+            {
+                return PathBuf::from(path);
+            }
+        }
+    }
+    PathBuf::from(path)
+}
+
+#[cfg(not(windows))]
+pub fn path_from_url(url: &Url) -> PathBuf {
+    PathBuf::from(url.path())
+}

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -430,7 +430,10 @@ impl LspClient {
             state.opened_documents.contains_key(&buffer.id)
         };
         if !exits {
-            let document_uri = Url::from_file_path(&buffer.path).unwrap();
+            let document_uri =
+                Url::from_file_path(&buffer.path).unwrap_or_else(|_| {
+                    panic!("Failed to create URL from path {:?}", buffer.path)
+                });
             self.send_did_open(
                 &buffer.id,
                 document_uri,

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -425,11 +425,11 @@ impl LspClient {
     }
 
     pub fn get_uri(&self, buffer: &Buffer) -> Url {
-        let exits = {
+        let exists = {
             let state = self.state.lock();
             state.opened_documents.contains_key(&buffer.id)
         };
-        if !exits {
+        if !exists {
             let document_uri =
                 Url::from_file_path(&buffer.path).unwrap_or_else(|_| {
                     panic!("Failed to create URL from path {:?}", buffer.path)

--- a/lapce-ui/src/problem.rs
+++ b/lapce-ui/src/problem.rs
@@ -13,6 +13,7 @@ use lapce_data::{
     data::{EditorDiagnostic, LapceTabData, PanelKind},
     editor::EditorLocationNew,
     problem::ProblemData,
+    proxy::path_from_url,
     split::SplitDirection,
 };
 use lsp_types::DiagnosticSeverity;
@@ -436,7 +437,7 @@ impl Widget<LapceTabData> for ProblemContent {
 
                         let text = format!(
                             "{}[{}, {}]: {}",
-                            PathBuf::from(related.location.uri.path())
+                            path_from_url(&related.location.uri)
                                 .file_name()
                                 .and_then(|f| f.to_str())
                                 .unwrap_or(""),

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -26,6 +26,7 @@ use lapce_data::{
     movement::{self, CursorMode, Selection},
     palette::PaletteStatus,
     panel::{PanelPosition, PanelResizePosition},
+    proxy::path_from_url,
     state::LapceWorkspaceType,
 };
 use lsp_types::DiagnosticSeverity;
@@ -518,7 +519,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                         }
                     }
                     LapceUICommand::PublishDiagnostics(diagnostics) => {
-                        let path = PathBuf::from(diagnostics.uri.path());
+                        let path = path_from_url(&diagnostics.uri);
                         let diagnostics = diagnostics
                             .diagnostics
                             .iter()
@@ -769,7 +770,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                                 let locations = locations
                                     .iter()
                                     .map(|l| EditorLocationNew {
-                                        path: PathBuf::from(l.uri.path()),
+                                        path: path_from_url(&l.uri),
                                         position: Some(l.range.start),
                                         scroll_offset: None,
                                         hisotry: None,


### PR DESCRIPTION
Fixes #187

This PR fixes code navigation features where the LSP returns a file path in the form of `file:///<drive letter>:/...`.