### PR TITLE
Fix crash when offset does not exist in undo/redo

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -3809,9 +3809,9 @@ impl KeyPressFocus for LapceEditorBufferData {
                 let proxy = self.proxy.clone();
                 let buffer = self.buffer_mut();
                 if let Some(delta) = buffer.do_undo(proxy) {
-                    self.update_completion(ctx);
                     self.jump_to_nearest_delta(&delta);
                     self.update_diagnositcs_offset(&delta);
+                    self.update_completion(ctx);
                 }
             }
             LapceCommand::Redo => {
@@ -3819,9 +3819,9 @@ impl KeyPressFocus for LapceEditorBufferData {
                 let proxy = self.proxy.clone();
                 let buffer = self.buffer_mut();
                 if let Some(delta) = buffer.do_redo(proxy) {
-                    self.update_completion(ctx);
                     self.jump_to_nearest_delta(&delta);
                     self.update_diagnositcs_offset(&delta);
+                    self.update_completion(ctx);
                 }
             }
             LapceCommand::Append => {


### PR DESCRIPTION
This fixes a crash that I introduced when making undo/redo update completion. This would update the completion _before_ the mouse cursor was updated, which would let the offset be in an invalid location. This merely fixes that by updating the completion after the update of the cursor.  
