### PR TITLE
Refactor towards testability, step 3: Remove `workspace` field from `LapceEditorBufferData`

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -680,7 +680,6 @@ impl LapceTabData {
             buffer,
             editor: editor.clone(),
             config: self.config.clone(),
-            workspace: self.workspace.clone(),
         }
     }
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -16,11 +16,10 @@ use crate::data::{
     EditorDiagnostic, InlineFindDirection, LapceEditorData, LapceMainSplitData,
     RegisterData, SplitContent,
 };
-use crate::movement::InsertDrift;
 use crate::hover::HoverData;
 use crate::hover::HoverStatus;
+use crate::movement::InsertDrift;
 use crate::proxy::path_from_url;
-use crate::state::LapceWorkspace;
 use crate::{buffer::WordProperty, movement::CursorMode};
 use crate::{
     command::{LapceCommand, LapceUICommand, LAPCE_UI_COMMAND},
@@ -128,7 +127,6 @@ pub struct LapceEditorBufferData {
     pub buffer: Arc<Buffer>,
     pub completion: Arc<CompletionData>,
     pub hover: Arc<HoverData>,
-    pub workspace: Arc<LapceWorkspace>,
     pub main_split: LapceMainSplitData,
     pub source_control: Arc<SourceControlData>,
     pub find: Arc<Find>,

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -12,6 +12,7 @@ use lapce_data::{
     config::LapceTheme,
     data::LapceTabData,
     editor::LapceEditorBufferData,
+    state::LapceWorkspace,
 };
 
 use crate::{
@@ -111,7 +112,12 @@ impl LapceEditorHeader {
         false
     }
 
-    pub fn paint_buffer(&self, ctx: &mut PaintCtx, data: &LapceEditorBufferData) {
+    pub fn paint_buffer(
+        &self,
+        ctx: &mut PaintCtx,
+        data: &LapceEditorBufferData,
+        workspace: &LapceWorkspace,
+    ) {
         let shadow_width = 5.0;
         let rect = ctx.size().to_rect();
         ctx.blurred_rect(
@@ -169,7 +175,7 @@ impl LapceEditorHeader {
                     .unwrap();
                 ctx.draw_text(&text_layout, Point::new(30.0, 7.0));
 
-                if let Some(workspace_path) = data.workspace.path.as_ref() {
+                if let Some(workspace_path) = workspace.path.as_ref() {
                     path = path
                         .strip_prefix(workspace_path)
                         .unwrap_or(&path)
@@ -297,6 +303,10 @@ impl Widget<LapceTabData> for LapceEditorHeader {
         if !self.display {
             return;
         }
-        self.paint_buffer(ctx, &data.editor_view_content(self.view_id));
+        self.paint_buffer(
+            ctx,
+            &data.editor_view_content(self.view_id),
+            &data.workspace,
+        );
     }
 }


### PR DESCRIPTION
Part 3 or the refactor started in #295, containing the commits from #296

This is a smaller step, and one not strictly necessary.