### PR TITLE
Add support for WSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1885,6 +1885,7 @@ dependencies = [
  "base64",
  "bit-vec 0.5.1",
  "bitflags",
+ "bytemuck",
  "cc",
  "chrono",
  "config",

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -56,6 +56,7 @@ structdesc = { git = "https://github.com/lapce/structdesc" }
 lapce-core = { path = "../lapce-core" }
 lapce-rpc = { path = "../lapce-rpc" }
 lapce-proxy = { path = "../lapce-proxy" }
+bytemuck = "1.8.0"
 
 [build-dependencies]
 cc = "1"

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -166,6 +166,10 @@ pub enum LapceWorkbenchCommand {
     #[strum(message = "Connect to WSL")]
     ConnectWsl,
 
+    #[strum(serialize = "disconnect_remote")]
+    #[strum(message = "Disconnect From Remote")]
+    DisconnectRemote,
+
     #[strum(serialize = "palette.line")]
     PaletteLine,
 

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -162,6 +162,10 @@ pub enum LapceWorkbenchCommand {
     #[strum(message = "Connect to SSH Host")]
     ConnectSshHost,
 
+    #[strum(serialize = "connect_wsl")]
+    #[strum(message = "Connect to WSL")]
+    ConnectWsl,
+
     #[strum(serialize = "palette.line")]
     PaletteLine,
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -250,14 +250,15 @@ impl Config {
         }
 
         match workspace.kind {
-            crate::state::LapceWorkspaceType::Local => {
+            LapceWorkspaceType::Local => {
                 if let Some(path) = workspace.path.as_ref() {
                     let path = path.join("./.lapce/settings.toml");
                     let _ = settings
                         .merge(config::File::from(path.as_path()).required(false));
                 }
             }
-            crate::state::LapceWorkspaceType::RemoteSSH(_, _) => {}
+            LapceWorkspaceType::RemoteSSH(_, _) => {}
+            LapceWorkspaceType::RemoteWSL => {}
         }
 
         let mut config: Config = settings.try_into()?;
@@ -463,6 +464,7 @@ impl Config {
                         LapceWorkspaceType::RemoteSSH(user, host) => {
                             format!("ssh://{}@{}", user, host)
                         }
+                        LapceWorkspaceType::RemoteWSL => "wsl".to_string(),
                     }),
                 );
                 table.insert(
@@ -508,6 +510,7 @@ impl Config {
                             let host = parts.next()?.to_string();
                             LapceWorkspaceType::RemoteSSH(user, host)
                         }
+                        "wsl" => LapceWorkspaceType::RemoteWSL,
                         _ => LapceWorkspaceType::Local,
                     };
                     let last_open = value

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1358,6 +1358,17 @@ impl LapceTabData {
                 }),
                 Target::Auto,
             )),
+            LapceWorkbenchCommand::DisconnectRemote => {
+                ctx.submit_command(Command::new(
+                    LAPCE_UI_COMMAND,
+                    LapceUICommand::SetWorkspace(LapceWorkspace {
+                        kind: LapceWorkspaceType::Local,
+                        path: None,
+                        last_open: 0,
+                    }),
+                    Target::Auto,
+                ))
+            }
         }
     }
 

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1349,6 +1349,15 @@ impl LapceTabData {
                     Target::Widget(self.palette.widget_id),
                 ));
             }
+            LapceWorkbenchCommand::ConnectWsl => ctx.submit_command(Command::new(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::SetWorkspace(LapceWorkspace {
+                    kind: LapceWorkspaceType::RemoteWSL,
+                    path: None,
+                    last_open: 0,
+                }),
+                Target::Auto,
+            )),
         }
     }
 

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -279,7 +279,10 @@ impl PaletteItemContent {
                 let text = match &w.kind {
                     LapceWorkspaceType::Local => text.to_string(),
                     LapceWorkspaceType::RemoteSSH(user, host) => {
-                        format!("[{}@{}] {}", user, host, text)
+                        format!("[{user}@{host}] {text}")
+                    }
+                    LapceWorkspaceType::RemoteWSL => {
+                        format!("[wsl] {text}")
                     }
                 };
                 (None, text, indices.to_vec(), "".to_string(), vec![])
@@ -859,11 +862,8 @@ impl PaletteViewData {
         let workspaces = Config::recent_workspaces().unwrap_or_default();
         let mut hosts = HashSet::new();
         for workspace in workspaces.iter() {
-            match &workspace.kind {
-                LapceWorkspaceType::Local => (),
-                LapceWorkspaceType::RemoteSSH(user, host) => {
-                    hosts.insert((user.to_string(), host.to_string()));
-                }
+            if let LapceWorkspaceType::RemoteSSH(user, host) = &workspace.kind {
+                hosts.insert((user.to_string(), host.to_string()));
             }
         }
 
@@ -900,6 +900,9 @@ impl PaletteViewData {
                     LapceWorkspaceType::Local => text,
                     LapceWorkspaceType::RemoteSSH(user, host) => {
                         format!("[{}@{}] {}", user, host, text)
+                    }
+                    LapceWorkspaceType::RemoteWSL => {
+                        format!("[wsl] {text}")
                     }
                 };
                 NewPaletteItem {

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -680,24 +680,6 @@ impl Remote for WslRemote {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum CursorShape {
-    /// Cursor is a block like `▒`.
-    Block,
-
-    /// Cursor is an underscore like `_`.
-    Underline,
-
-    /// Cursor is a vertical bar `⎸`.
-    Beam,
-
-    /// Cursor is a box like `☐`.
-    HollowBlock,
-
-    /// Invisible cursor.
-    Hidden,
-}
-
 // Rust-analyzer returns paths in the form of "file:///<drive>:/...", which gets parsed into URL
 // as "/<drive>://" which is then interpreted by PathBuf::new() as a UNIX-like path from root.
 // This function strips the additional / from the beginning, if the first segment is a drive letter.

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -596,6 +596,7 @@ impl LapceProxy {
 }
 
 fn new_command(program: &str) -> Command {
+    #[allow(unused_mut)]
     let mut cmd = Command::new(program);
     #[cfg(target_os = "windows")]
     cmd.creation_flags(0x08000000);

--- a/lapce-data/src/state.rs
+++ b/lapce-data/src/state.rs
@@ -118,14 +118,15 @@ pub struct KeyMap {
 pub enum LapceWorkspaceType {
     Local,
     RemoteSSH(String, String),
+    RemoteWSL,
 }
 
 impl LapceWorkspaceType {
     pub fn is_remote(&self) -> bool {
-        if let LapceWorkspaceType::RemoteSSH(_, _) = &self {
-            return true;
-        }
-        false
+        matches!(
+            self,
+            LapceWorkspaceType::RemoteSSH(_, _) | LapceWorkspaceType::RemoteWSL
+        )
     }
 }
 
@@ -136,6 +137,7 @@ impl Display for LapceWorkspaceType {
             LapceWorkspaceType::RemoteSSH(user, host) => {
                 write!(f, "ssh://{}@{}", user, host)
             }
+            LapceWorkspaceType::RemoteWSL => f.write_str("WSL"),
         }
     }
 }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -859,6 +859,9 @@ impl Widget<LapceTabData> for LapceTabNew {
                                     LapceWorkspaceType::RemoteSSH(user, host) => {
                                         format!("{} [{}@{}]", dir, user, host)
                                     }
+                                    LapceWorkspaceType::RemoteWSL => {
+                                        format!("{dir} [wsl]")
+                                    }
                                 };
                                 dir
                             })
@@ -1569,6 +1572,9 @@ impl Widget<LapceTabData> for LapceTabHeader {
                     LapceWorkspaceType::Local => dir.to_string(),
                     LapceWorkspaceType::RemoteSSH(user, host) => {
                         format!("{} [{}@{}]", dir, user, host)
+                    }
+                    LapceWorkspaceType::RemoteWSL => {
+                        format!("{dir} [wsl]")
                     }
                 };
                 dir

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -159,6 +159,25 @@ impl Widget<LapceWindowData> for Title {
                     .unwrap();
                 Some(text_layout)
             }
+            LapceWorkspaceType::RemoteWSL => {
+                let text = match *tab.proxy_status {
+                    ProxyStatus::Connecting => "Connecting to WSL ...".to_string(),
+                    ProxyStatus::Connected => "WSL".to_string(),
+                    ProxyStatus::Disconnected => "Disconnected WSL".to_string(),
+                };
+                let text_layout = ctx
+                    .text()
+                    .new_text_layout(text)
+                    .font(FontFamily::SYSTEM_UI, 13.0)
+                    .text_color(
+                        data.config
+                            .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND)
+                            .clone(),
+                    )
+                    .build()
+                    .unwrap();
+                Some(text_layout)
+            }
         };
 
         let remote_rect = Size::new(
@@ -174,11 +193,13 @@ impl Widget<LapceWindowData> for Title {
         .with_origin(Point::new(x, 0.0));
         let color = match &tab.workspace.kind {
             LapceWorkspaceType::Local => Color::rgb8(64, 120, 242),
-            LapceWorkspaceType::RemoteSSH(_, _) => match *tab.proxy_status {
-                ProxyStatus::Connecting => Color::rgb8(193, 132, 1),
-                ProxyStatus::Connected => Color::rgb8(80, 161, 79),
-                ProxyStatus::Disconnected => Color::rgb8(228, 86, 73),
-            },
+            LapceWorkspaceType::RemoteSSH(_, _) | LapceWorkspaceType::RemoteWSL => {
+                match *tab.proxy_status {
+                    ProxyStatus::Connecting => Color::rgb8(193, 132, 1),
+                    ProxyStatus::Connected => Color::rgb8(80, 161, 79),
+                    ProxyStatus::Disconnected => Color::rgb8(228, 86, 73),
+                }
+            }
         };
         ctx.fill(remote_rect, &color);
         let remote_svg = get_svg("remote.svg").unwrap();
@@ -204,8 +225,42 @@ impl Widget<LapceWindowData> for Title {
         x += remote_rect.width();
         let command_rect =
             command_rect.with_size(Size::new(x - command_rect.x0, size.height));
-        self.commands.push((
-            command_rect,
+        let command = if cfg!(target_os = "windows") {
+            Command::new(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::ShowMenu(
+                    Point::new(command_rect.x0, command_rect.y1),
+                    Arc::new(vec![
+                        MenuItem {
+                            text: LapceWorkbenchCommand::ConnectSshHost
+                                .get_message()
+                                .unwrap()
+                                .to_string(),
+                            command: LapceCommandNew {
+                                cmd: LapceWorkbenchCommand::ConnectSshHost
+                                    .to_string(),
+                                palette_desc: None,
+                                data: None,
+                                target: CommandTarget::Workbench,
+                            },
+                        },
+                        MenuItem {
+                            text: LapceWorkbenchCommand::ConnectWsl
+                                .get_message()
+                                .unwrap()
+                                .to_string(),
+                            command: LapceCommandNew {
+                                cmd: LapceWorkbenchCommand::ConnectWsl.to_string(),
+                                palette_desc: None,
+                                data: None,
+                                target: CommandTarget::Workbench,
+                            },
+                        },
+                    ]),
+                ),
+                Target::Auto,
+            )
+        } else {
             Command::new(
                 LAPCE_NEW_COMMAND,
                 LapceCommandNew {
@@ -215,8 +270,9 @@ impl Widget<LapceWindowData> for Title {
                     target: CommandTarget::Workbench,
                 },
                 Target::Widget(data.active_id),
-            ),
-        ));
+            )
+        };
+        self.commands.push((command_rect, command));
 
         let command_rect = Size::ZERO.to_rect().with_origin(Point::new(x, 0.0));
 


### PR DESCRIPTION
This PR adds support for remote workspaces using WSL on Windows. This works similarly to the ssh functionality but uses the `wsl` command to interact with the remote instead of ssh.

Closes #198