### PR TITLE
Only react to left clicks on editor tabs headers

### DIFF
--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -50,7 +50,10 @@ impl LapceEditorTabHeaderContent {
         mouse_event: &MouseEvent,
     ) {
         for (i, tab_rect) in self.rects.iter().enumerate() {
-            if tab_rect.rect.contains(mouse_event.pos) {
+            // Only react to left button clicks
+            if mouse_event.button.is_left()
+                && tab_rect.rect.contains(mouse_event.pos)
+            {
                 let editor_tab = data
                     .main_split
                     .editor_tabs


### PR DESCRIPTION
Clicking/dragging with right or middle mouse button is confusing, and https://github.com/lapce/lapce/pull/100 would use the middle button to close a tab, so let's limit the "normal" interactions to the left mouse button.