### PR TITLE
Implement hover support

### DIFF
--- a/defaults/dark-theme.toml
+++ b/defaults/dark-theme.toml
@@ -57,6 +57,8 @@ magenta = "#C678DD"
 "completion.background" = "#21252B"
 "completion.current" = "#2C313A"
 
+"hover.background" = "#21252B"
+
 "panel.background" = "#21252B"
 "panel.current" = "#2C313A"
 

--- a/defaults/light-theme.toml
+++ b/defaults/light-theme.toml
@@ -56,6 +56,8 @@ magenta = "#A626A4"
 "completion.background" = "#eaeaeb"
 "completion.current" = "#dbdbdc"
 
+"hover.background" = "#eaeaeb"
+
 "panel.background" = "#eaeaeb"
 "panel.current" = "#dbdbdc"
 

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -11,3 +11,4 @@ code-lens-font-size = 2
 line-height = 25
 tab-width = 4
 show-tab = true
+hover-delay = 300 # ms

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -9,8 +9,8 @@ use lapce_rpc::{
     source_control::DiffInfo, style::Style, terminal::TermId,
 };
 use lsp_types::{
-    CodeActionResponse, CompletionItem, CompletionResponse, Location, Position,
-    ProgressParams, PublishDiagnosticsParams, TextEdit,
+    CodeActionResponse, CompletionItem, CompletionResponse, Hover, Location,
+    Position, ProgressParams, PublishDiagnosticsParams, TextEdit,
 };
 use serde_json::Value;
 use strum::{self, EnumMessage, IntoEnumIterator};
@@ -585,6 +585,7 @@ pub enum LapceUICommand {
     CancelCompletion(usize),
     ResolveCompletion(BufferId, u64, usize, Box<CompletionItem>),
     UpdateCompletion(usize, String, CompletionResponse),
+    UpdateHover(usize, Hover),
     UpdateCodeActions(PathBuf, u64, usize, CodeActionResponse),
     CancelPalette,
     ShowCodeActions,

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -72,6 +72,8 @@ impl LapceTheme {
     pub const COMPLETION_BACKGROUND: &'static str = "completion.background";
     pub const COMPLETION_CURRENT: &'static str = "completion.current";
 
+    pub const HOVER_BACKGROUND: &'static str = "hover.background";
+
     pub const PANEL_BACKGROUND: &'static str = "panel.background";
     pub const PANEL_CURRENT: &'static str = "panel.current";
 
@@ -128,6 +130,10 @@ pub struct EditorConfig {
     pub tab_width: usize,
     #[field_names(desc = "If opened editors are shown in a tab")]
     pub show_tab: bool,
+    #[field_names(
+        desc = "How long (in ms) it should take before the hover information appears"
+    )]
+    pub hover_delay: u64,
 }
 
 impl EditorConfig {

--- a/lapce-data/src/hover.rs
+++ b/lapce-data/src/hover.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+
+use druid::{ExtEventSink, Size, Target, WidgetId};
+use lapce_rpc::buffer::BufferId;
+use lsp_types::{
+    Hover, HoverContents, MarkedString, MarkupContent, MarkupKind, Position,
+};
+
+use crate::{
+    command::{LapceUICommand, LAPCE_UI_COMMAND},
+    proxy::LapceProxy,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HoverStatus {
+    Inactive,
+    Started,
+}
+
+#[derive(Clone)]
+pub struct HoverData {
+    pub id: WidgetId,
+    pub scroll_id: WidgetId,
+    /// The current request status
+    pub status: HoverStatus,
+    /// The offset that is currently being handled, if there is one
+    pub offset: usize,
+    /// The buffer that this hover is for
+    pub buffer_id: BufferId,
+    /// A counter to keep track of the active requests
+    pub request_id: usize,
+    /// Stores the size of the hover box
+    pub size: Size,
+
+    /// The current hover string that is active, because there can be multiple for a single entry
+    /// (such as if there is uncertainty over the exact version, such as in overloading or
+    /// scripting languages where the declaration is uncertain)
+    pub active_item_index: usize,
+    /// The hover items that are currently loaded
+    pub items: Arc<Vec<HoverItem>>,
+}
+impl HoverData {
+    pub fn new() -> Self {
+        Self {
+            id: WidgetId::next(),
+            scroll_id: WidgetId::next(),
+            status: HoverStatus::Inactive,
+            offset: 0,
+            buffer_id: BufferId(0),
+            request_id: 0,
+            size: Size::new(400.0, 300.0),
+
+            active_item_index: 0,
+            items: Arc::new(Vec::new()),
+        }
+    }
+
+    pub fn get_current_item(&self) -> Option<&HoverItem> {
+        self.items.get(self.active_item_index)
+    }
+
+    /// The length of the current hover items
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Move to the next hover item
+    pub fn next(&mut self) {
+        // If there is an item after the current one, then actually change
+        if self.active_item_index + 1 < self.len() {
+            self.active_item_index += 1;
+        }
+    }
+
+    /// Move to the previous hover item
+    pub fn previous(&mut self) {
+        if self.active_item_index > 0 {
+            self.active_item_index -= 1;
+        }
+    }
+
+    /// Cancel the current hover information, clearing out held data
+    pub fn cancel(&mut self) {
+        if self.status == HoverStatus::Inactive {
+            return;
+        }
+
+        self.status = HoverStatus::Inactive;
+        Arc::make_mut(&mut self.items).clear();
+        self.active_item_index = 0;
+    }
+
+    /// Send a request to update the hover at the given position anad file
+    pub fn request(
+        &self,
+        proxy: Arc<LapceProxy>,
+        request_id: usize,
+        buffer_id: BufferId,
+        position: Position,
+        hover_widget_id: WidgetId,
+        event_sink: ExtEventSink,
+    ) {
+        proxy.get_hover(
+            request_id,
+            buffer_id,
+            position,
+            Box::new(move |result| {
+                if let Ok(resp) = result {
+                    if let Ok(resp) = serde_json::from_value::<Hover>(resp) {
+                        let _ = event_sink.submit_command(
+                            LAPCE_UI_COMMAND,
+                            LapceUICommand::UpdateHover(request_id, resp),
+                            Target::Widget(hover_widget_id),
+                        );
+                    }
+                }
+            }),
+        );
+    }
+
+    /// Receive the result of a hover request
+    pub fn receive(&mut self, request_id: usize, resp: lsp_types::Hover) {
+        // If we've moved to inactive between the time the request started and now
+        // or we've moved to a different request
+        // then don't bother processing the received data
+        if self.status == HoverStatus::Inactive || self.request_id != request_id {
+            return;
+        }
+
+        let items = Arc::make_mut(&mut self.items);
+        // Extract the items in the format that we want them to be in
+        *items = match resp.contents {
+            HoverContents::Scalar(text) => vec![HoverItem::from(text)],
+            HoverContents::Array(entries) => {
+                entries.into_iter().map(HoverItem::from).collect()
+            }
+            HoverContents::Markup(content) => {
+                vec![HoverItem::from(content)]
+            }
+        };
+    }
+}
+
+/// A hover entry
+/// This is separate from the lsp-types version to make using it more direct
+#[derive(Clone)]
+pub enum HoverItem {
+    // TODO: This could hold the data needed to render the markdown output
+    Markdown(String),
+    PlainText(String),
+}
+impl HoverItem {
+    pub fn as_str(&self) -> &str {
+        match self {
+            HoverItem::Markdown(x) | HoverItem::PlainText(x) => x.as_str(),
+        }
+    }
+}
+impl From<MarkedString> for HoverItem {
+    fn from(text: MarkedString) -> Self {
+        match text {
+            MarkedString::String(text) => HoverItem::Markdown(text),
+            // This is a short version of a code block
+            MarkedString::LanguageString(code) => {
+                // Simply construct the string as if it was written directly
+                HoverItem::Markdown(format!(
+                    "```{}\n{}\n```",
+                    code.language, code.value
+                ))
+            }
+        }
+    }
+}
+impl From<MarkupContent> for HoverItem {
+    fn from(content: MarkupContent) -> Self {
+        match content.kind {
+            MarkupKind::Markdown => HoverItem::Markdown(content.value),
+            MarkupKind::PlainText => HoverItem::PlainText(content.value),
+        }
+    }
+}

--- a/lapce-data/src/lib.rs
+++ b/lapce-data/src/lib.rs
@@ -9,6 +9,7 @@ pub mod db;
 pub mod editor;
 pub mod explorer;
 pub mod find;
+pub mod hover;
 pub mod keypress;
 pub mod lsp;
 pub mod menu;

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -490,6 +490,24 @@ impl LapceProxy {
         );
     }
 
+    pub fn get_hover(
+        &self,
+        request_id: usize,
+        buffer_id: BufferId,
+        position: Position,
+        f: Box<dyn Callback>,
+    ) {
+        self.rpc.send_rpc_request_async(
+            "get_hover",
+            &json!({
+                "request_id": request_id,
+                "buffer_id": buffer_id,
+                "position": position,
+            }),
+            f,
+        );
+    }
+
     pub fn get_signature(
         &self,
         buffer_id: BufferId,

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -436,7 +436,16 @@ impl Dispatcher {
                     .lock()
                     .completion_resolve(id, buffer, &completion_item);
             }
-            GetSignature {
+            GetHover {
+                buffer_id,
+                position,
+                request_id,
+            } => {
+                let buffers = self.buffers.lock();
+                let buffer = buffers.get(&buffer_id).unwrap();
+                self.lsp.lock().get_hover(id, request_id, buffer, position);
+            }
+            GetSignature {                
                 buffer_id,
                 position,
             } => {

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -72,6 +72,11 @@ pub enum ProxyRequest {
         buffer_id: BufferId,
         completion_item: Box<CompletionItem>,
     },
+    GetHover {
+        request_id: usize,
+        buffer_id: BufferId,
+        position: Position,
+    },
     GetSignature {
         buffer_id: BufferId,
         position: Position,

--- a/lapce-ui/src/hover.rs
+++ b/lapce-ui/src/hover.rs
@@ -1,0 +1,380 @@
+use std::sync::Arc;
+
+use druid::{
+    piet::{PietText, PietTextLayout, Text, TextLayout, TextLayoutBuilder},
+    theme, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, FontFamily,
+    LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Point, RenderContext, Size,
+    Target, UpdateCtx, Widget, WidgetId, WidgetPod,
+};
+use lapce_data::{
+    command::{LapceUICommand, LAPCE_UI_COMMAND},
+    config::LapceTheme,
+    data::LapceTabData,
+    hover::{HoverData, HoverStatus},
+};
+
+use crate::scroll::{LapceIdentityWrapper, LapceScrollNew};
+
+pub struct HoverContainer {
+    id: WidgetId,
+    scroll_id: WidgetId,
+    hover: WidgetPod<
+        LapceTabData,
+        LapceIdentityWrapper<LapceScrollNew<LapceTabData, Hover>>,
+    >,
+    content_size: Size,
+}
+impl HoverContainer {
+    pub fn new(data: &HoverData) -> Self {
+        let hover = LapceIdentityWrapper::wrap(
+            LapceScrollNew::new(Hover {}).vertical(),
+            data.scroll_id,
+        );
+        Self {
+            id: data.id,
+            scroll_id: data.scroll_id,
+            hover: WidgetPod::new(hover),
+            content_size: Size::ZERO,
+        }
+    }
+
+    fn ensure_visible(
+        &mut self,
+        ctx: &mut UpdateCtx,
+        _data: &LapceTabData,
+        env: &Env,
+    ) {
+        let width = ctx.size().width;
+        let rect = Size::new(width, 0.0).to_rect();
+        if self
+            .hover
+            .widget_mut()
+            .inner_mut()
+            .scroll_to_visible(rect, env)
+        {
+            ctx.submit_command(Command::new(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::ResetFade,
+                Target::Widget(self.scroll_id),
+            ));
+        }
+    }
+}
+impl Widget<LapceTabData> for HoverContainer {
+    fn id(&self) -> Option<WidgetId> {
+        Some(self.id)
+    }
+
+    fn event(
+        &mut self,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut LapceTabData,
+        env: &Env,
+    ) {
+        match event {
+            Event::Command(cmd) if cmd.is(LAPCE_UI_COMMAND) => {
+                let command = cmd.get_unchecked(LAPCE_UI_COMMAND);
+                match command {
+                    LapceUICommand::UpdateHover(request_id, resp) => {
+                        let hover = Arc::make_mut(&mut data.hover);
+                        hover.receive(*request_id, resp.to_owned());
+                        ctx.request_paint();
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+        self.hover.event(ctx, event, data, env);
+    }
+
+    fn lifecycle(
+        &mut self,
+        ctx: &mut LifeCycleCtx,
+        event: &LifeCycle,
+        data: &LapceTabData,
+        env: &Env,
+    ) {
+        self.hover.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(
+        &mut self,
+        ctx: &mut UpdateCtx,
+        old_data: &LapceTabData,
+        data: &LapceTabData,
+        env: &Env,
+    ) {
+        let old_hover = &old_data.hover;
+        let hover = &data.hover;
+
+        if hover.status != HoverStatus::Inactive {
+            let old_editor = old_data.main_split.active_editor();
+            let old_editor = match old_editor {
+                Some(editor) => editor,
+                None => return,
+            };
+            let editor = data.main_split.active_editor();
+            let editor = match editor {
+                Some(editor) => editor,
+                None => return,
+            };
+            if old_editor.window_origin != editor.window_origin
+                || old_editor.scroll_offset != editor.scroll_offset
+            {
+                ctx.request_layout();
+            }
+        }
+
+        if old_hover.request_id != hover.request_id
+            || old_hover.status != hover.status
+            || !old_hover.items.same(&hover.items)
+        {
+            ctx.request_layout();
+        }
+
+        if old_hover.status == HoverStatus::Inactive
+            && hover.status != HoverStatus::Inactive
+        {
+            ctx.submit_command(Command::new(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::ResetFade,
+                Target::Widget(self.scroll_id),
+            ));
+        }
+
+        if old_hover.active_item_index != hover.active_item_index {
+            self.ensure_visible(ctx, data, env);
+            ctx.request_paint();
+        }
+    }
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        _bc: &BoxConstraints,
+        data: &LapceTabData,
+        env: &Env,
+    ) -> Size {
+        let size = data.hover.size;
+        let bc = BoxConstraints::new(Size::ZERO, size);
+        self.content_size = self.hover.layout(ctx, &bc, data, env);
+        self.hover.set_origin(ctx, data, env, Point::ZERO);
+        ctx.set_paint_insets((10.0, 10.0, 10.0, 10.0));
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, env: &Env) {
+        if data.hover.status != HoverStatus::Inactive && !data.hover.is_empty() {
+            let shadow_width = 5.0;
+            let rect = self.content_size.to_rect();
+            ctx.blurred_rect(
+                rect,
+                shadow_width,
+                data.config
+                    .get_color_unchecked(LapceTheme::LAPCE_DROPDOWN_SHADOW),
+            );
+            self.hover.paint(ctx, data, env);
+        }
+    }
+}
+
+enum HoverLayout {
+    Text {
+        text_layout: PietTextLayout,
+        /// The y position including this layout
+        y: f64,
+    },
+    /// Empty, should be ignored
+    Empty,
+    /// The final entry
+    Final { height: f64 },
+}
+
+#[derive(Default)]
+pub struct Hover {}
+impl Hover {
+    const STARTING_Y: f64 = 5.0;
+    const STARTING_X: f64 = 10.0;
+
+    /// Map the text to the line and the layout builder instance
+    fn iter_text<'a>(
+        mut piet_text: PietText,
+        line_height: f64,
+        editor_foreground: Color,
+        font_size: f64,
+        font: FontFamily,
+        lines: impl Iterator<Item = &'a str> + 'a,
+        max_width: f64,
+    ) -> impl Iterator<Item = HoverLayout> + 'a {
+        let mut last_was_empty = false;
+        let mut y = Hover::STARTING_Y;
+        lines
+            .map(Option::Some)
+            .chain(std::iter::once(None))
+            .map(move |line| {
+                let line = if let Some(line) = line {
+                    line
+                } else {
+                    // We've finished
+                    return HoverLayout::Final { height: y };
+                };
+                let prev_y = y;
+                if line.trim().is_empty() {
+                    if !last_was_empty {
+                        y += line_height;
+                    }
+
+                    last_was_empty = true;
+                    return HoverLayout::Empty;
+                } else {
+                    last_was_empty = false;
+                }
+
+                let text_layout = piet_text
+                    .new_text_layout(line.to_string())
+                    .font(font.clone(), font_size)
+                    .text_color(editor_foreground.clone())
+                    .max_width(max_width)
+                    .build()
+                    .unwrap();
+
+                let text_layout_size = text_layout.size();
+                // Advance past any wrapping and the line height
+                y += text_layout_size.height;
+
+                HoverLayout::Text {
+                    text_layout,
+                    y: prev_y,
+                }
+            })
+    }
+}
+impl Widget<LapceTabData> for Hover {
+    fn event(
+        &mut self,
+        _ctx: &mut EventCtx,
+        _event: &Event,
+        _data: &mut LapceTabData,
+        _env: &Env,
+    ) {
+    }
+
+    fn lifecycle(
+        &mut self,
+        _ctx: &mut LifeCycleCtx,
+        _event: &LifeCycle,
+        _data: &LapceTabData,
+        _env: &Env,
+    ) {
+    }
+
+    fn update(
+        &mut self,
+        _ctx: &mut UpdateCtx,
+        _old_data: &LapceTabData,
+        _data: &LapceTabData,
+        _env: &Env,
+    ) {
+    }
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &LapceTabData,
+        env: &Env,
+    ) -> Size {
+        let item = match data.hover.get_current_item() {
+            Some(item) => item,
+            // There is nothing to render
+            None => return Size::ZERO,
+        };
+        let text = item.as_str();
+
+        let line_height = data.config.editor.line_height as f64;
+        let editor_foreground = data
+            .config
+            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+            .clone();
+        let font_size = data.config.editor.font_size as f64;
+        let font = FontFamily::new_unchecked(data.config.editor.font_family.clone());
+
+        let width = bc.max().width;
+        let max_width = width
+            - Hover::STARTING_X
+            - env.get(theme::SCROLLBAR_WIDTH)
+            - env.get(theme::SCROLLBAR_PAD);
+
+        let mut height = 0.0;
+        for layout in Hover::iter_text(
+            ctx.text().clone(),
+            line_height,
+            editor_foreground,
+            font_size,
+            font,
+            text.lines(),
+            max_width,
+        ) {
+            match layout {
+                HoverLayout::Final {
+                    height: final_height,
+                } => height = final_height,
+                _ => {}
+            }
+        }
+
+        height += line_height;
+        Size::new(width, height)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, env: &Env) {
+        if data.hover.status == HoverStatus::Inactive {
+            return;
+        }
+        let item = match data.hover.get_current_item() {
+            Some(item) => item,
+            // There is nothing to render
+            None => return,
+        };
+        let text = item.as_str();
+
+        let line_height = data.config.editor.line_height as f64;
+        let editor_foreground = data
+            .config
+            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+            .clone();
+        let font_size = data.config.editor.font_size as f64;
+        let font = FontFamily::new_unchecked(data.config.editor.font_family.clone());
+
+        let rect = ctx.region().bounding_box();
+        let size = ctx.size();
+
+        let max_width = size.width
+            - Hover::STARTING_X
+            - env.get(theme::SCROLLBAR_WIDTH)
+            - env.get(theme::SCROLLBAR_PAD);
+
+        ctx.fill(
+            rect,
+            data.config
+                .get_color_unchecked(LapceTheme::HOVER_BACKGROUND),
+        );
+
+        for layout in Hover::iter_text(
+            ctx.text().clone(),
+            line_height,
+            editor_foreground,
+            font_size,
+            font,
+            text.lines(),
+            max_width,
+        ) {
+            if let HoverLayout::Text { y, text_layout } = layout {
+                let text_point = Point::new(Hover::STARTING_X, y);
+                ctx.draw_text(&text_layout, text_point);
+            }
+        }
+    }
+}

--- a/lapce-ui/src/lib.rs
+++ b/lapce-ui/src/lib.rs
@@ -6,6 +6,7 @@ pub mod container;
 pub mod editor;
 pub mod explorer;
 pub mod find;
+pub mod hover;
 pub mod keymap;
 pub mod menu;
 pub mod outline;


### PR DESCRIPTION
This implements hover support for language servers.  
Currently this is limited in some ways. (These could be opened as issues)  
 - No markdown support. RA doesn't produce good plaintext output as well. This would not be too challenging to add.
 - Could look better
 - Would be useful to be able to select text inside them
 - Able to show hover with a keybind
 - Hide when mouse moves from the target word in document, similar to vscode