### PR TITLE
Ignore reformat commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# CRLF to LF
+a321c88e493efae2259d1baf2e258f8345843ac4


### PR DESCRIPTION
This tells github to hide the line ending change commit in its blame view: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

For this to work locally, set the following git config: `git config blame.ignorerevsfile .git-blame-ignore-revs`

Reformatting commits should be added to this file to prevent hiding relevant changes.

Thanks to https://github.com/rust-lang/rust/pull/95342