### PR TITLE
Don't allocate strings for syntax highlight lookups

### DIFF
--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -885,9 +885,7 @@ impl Buffer {
         if let Some(styles) = self.get_hisotry_line_styles(history, line) {
             for line_style in styles.iter() {
                 if let Some(fg_color) = line_style.style.fg_color.as_ref() {
-                    if let Some(fg_color) =
-                        config.get_color(&("style.".to_string() + fg_color))
-                    {
+                    if let Some(fg_color) = config.get_style_color(fg_color) {
                         layout_builder = layout_builder.range_attribute(
                             line_style.start..line_style.end,
                             TextAttribute::TextColor(fg_color.clone()),
@@ -938,9 +936,7 @@ impl Buffer {
 
         for line_style in styles.iter() {
             if let Some(fg_color) = line_style.style.fg_color.as_ref() {
-                if let Some(fg_color) =
-                    config.get_color(&("style.".to_string() + fg_color))
-                {
+                if let Some(fg_color) = config.get_style_color(fg_color) {
                     layout_builder = layout_builder.range_attribute(
                         line_style.start..line_style.end,
                         TextAttribute::TextColor(fg_color.clone()),

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -522,7 +522,7 @@ impl Config {
     /// Otherwise, get the color from the base them
     /// # Panics
     /// If the color was not able to be found in either theme, which may be indicative that
-    /// it is mispelled or needs to be added to the base-theme.
+    /// it is misspelled or needs to be added to the base-theme.
     pub fn get_color_unchecked(&self, name: &str) -> &Color {
         self.themes
             .color(name)

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -152,7 +152,7 @@ impl Theme {
                 style.insert(stripped.to_string(), value.clone());
             }
 
-            // Keep styles in the other map, so it's easier to transition
+            // Keep styles in the other map, so they can still be looked up by their full paths.
             other.insert(key, value);
         }
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -379,14 +379,7 @@ impl Config {
 
         config.themes = Themes::default();
 
-        if config
-            .themes
-            .apply_theme(&config.lapce.color_theme)
-            .is_err()
-        {
-            // Set as preview so we won't overwrite the user's theme setting.
-            config.set_theme("Lapce Light", true);
-        }
+        let _ = config.themes.apply_theme(&config.lapce.color_theme);
 
         Ok(config)
     }

--- a/lapce-ui/src/svg.rs
+++ b/lapce-ui/src/svg.rs
@@ -122,8 +122,6 @@ pub fn completion_svg(
 
     Some((
         get_svg(&format!("symbol-{}.svg", kind_str))?,
-        config
-            .get_color(&("style.".to_string() + theme_str))
-            .cloned(),
+        config.get_style_color(theme_str).cloned(),
     ))
 }


### PR DESCRIPTION
This PR tries to clean up syntax highlighting by not creating temporary strings just to look up in a hashmap. Besides that, this PR extracts some Theme related operations from Config.