### PR TITLE
Add CSS tree-sitter language

### DIFF
--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -20,5 +20,6 @@ tree-sitter-toml = "0.20.0"
 tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", version = "0.19.1" }
 tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
+tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css.git", version = "0.20.0" }
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
 lapce-rpc = { path = "../lapce-rpc" }

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -46,6 +46,7 @@ pub enum LapceLanguage {
     Php,
     C,
     Cpp,
+    Css,
 }
 
 impl LapceLanguage {
@@ -63,6 +64,7 @@ impl LapceLanguage {
             "php" => LapceLanguage::Php,
             "c" | "h" => LapceLanguage::C,
             "cpp" | "cxx" | "cc" | "hpp" | "hxx" => LapceLanguage::Cpp,
+            "css" => LapceLanguage::Css,
             _ => return None,
         })
     }
@@ -80,6 +82,7 @@ impl LapceLanguage {
             LapceLanguage::Php => "//",
             LapceLanguage::C => "//",
             LapceLanguage::Cpp => "//",
+            LapceLanguage::Css => "",
         }
     }
 
@@ -96,6 +99,7 @@ impl LapceLanguage {
             LapceLanguage::Php => "  ",
             LapceLanguage::C => "  ",
             LapceLanguage::Cpp => "    ",
+            LapceLanguage::Css => "    ",
         }
     }
 
@@ -114,6 +118,7 @@ impl LapceLanguage {
             LapceLanguage::Php => tree_sitter_php::language(),
             LapceLanguage::C => tree_sitter_c::language(),
             LapceLanguage::Cpp => tree_sitter_cpp::language(),
+            LapceLanguage::Css => tree_sitter_css::language(),
         }
     }
 
@@ -138,6 +143,7 @@ impl LapceLanguage {
             LapceLanguage::Php => tree_sitter_php::HIGHLIGHT_QUERY,
             LapceLanguage::C => tree_sitter_c::HIGHLIGHT_QUERY,
             LapceLanguage::Cpp => tree_sitter_cpp::HIGHLIGHT_QUERY,
+            LapceLanguage::Css => tree_sitter_css::HIGHLIGHTS_QUERY,
         };
 
         HighlightConfiguration::new(language, query, "", "").unwrap()


### PR DESCRIPTION
Requires upstream changes to bump to tree-sitter 0.20.

Upstream PR: https://github.com/tree-sitter/tree-sitter-css/pull/22
Tree sitter issue: https://github.com/lapce/lapce/issues/272