### PR TITLE
Refactor towards testability, step 4: add separate `register` field

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -680,6 +680,7 @@ impl LapceTabData {
             buffer,
             editor: editor.clone(),
             config: self.config.clone(),
+            register: self.main_split.register.clone(),
         }
     }
 
@@ -749,15 +750,19 @@ impl LapceTabData {
         editor: &Arc<LapceEditorData>,
         buffer: &Arc<Buffer>,
     ) {
-        self.completion = editor_buffer_data.completion.clone();
-        self.hover = editor_buffer_data.hover.clone();
-        self.main_split = editor_buffer_data.main_split.clone();
-        self.find = editor_buffer_data.find.clone();
+        // Update possibly cloned `Arc`s.
+        self.completion = editor_buffer_data.completion;
+        self.hover = editor_buffer_data.hover;
+        self.main_split = editor_buffer_data.main_split;
+        self.main_split.register = editor_buffer_data.register;
+        self.find = editor_buffer_data.find;
+
         if !editor_buffer_data.editor.same(editor) {
             self.main_split
                 .editors
                 .insert(editor.view_id, editor_buffer_data.editor);
         }
+
         if !editor_buffer_data.buffer.same(buffer) {
             match &buffer.content {
                 BufferContent::File(path) => {

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -11,6 +11,7 @@ use crate::command::LAPCE_NEW_COMMAND;
 use crate::completion::{CompletionData, CompletionStatus, Snippet};
 use crate::config::Config;
 use crate::data::MotionMode;
+use crate::data::Register;
 use crate::data::RegisterKind;
 use crate::data::{
     EditorDiagnostic, InlineFindDirection, LapceEditorData, LapceMainSplitData,
@@ -132,6 +133,7 @@ pub struct LapceEditorBufferData {
     pub find: Arc<Find>,
     pub proxy: Arc<LapceProxy>,
     pub config: Arc<Config>,
+    pub register: Arc<Register>,
 }
 
 impl LapceEditorBufferData {
@@ -272,7 +274,7 @@ impl LapceEditorBufferData {
                 VisualMode::Normal
             },
         };
-        let register = Arc::make_mut(&mut self.main_split.register);
+        let register = Arc::make_mut(&mut self.register);
         register.add(kind, data);
     }
 
@@ -1302,7 +1304,7 @@ impl LapceEditorBufferData {
                     .editor
                     .cursor
                     .yank(&self.buffer, self.config.editor.tab_width);
-                let register = Arc::make_mut(&mut self.main_split.register);
+                let register = Arc::make_mut(&mut self.register);
                 register.add_delete(data);
             }
             CursorMode::Insert(_) => {}
@@ -2085,7 +2087,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                     .editor
                     .cursor
                     .yank(&self.buffer, self.config.editor.tab_width);
-                let register = Arc::make_mut(&mut self.main_split.register);
+                let register = Arc::make_mut(&mut self.register);
                 register.add_yank(data);
                 match &self.editor.cursor.mode {
                     #[allow(unused_variables)]
@@ -2143,7 +2145,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                         .editor
                         .cursor
                         .yank(&self.buffer, self.config.editor.tab_width);
-                    let register = Arc::make_mut(&mut self.main_split.register);
+                    let register = Arc::make_mut(&mut self.register);
                     register.add_yank(data);
                 } else {
                     Arc::make_mut(&mut self.editor).motion_mode = None;
@@ -2185,7 +2187,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                 }
             }
             LapceCommand::Paste => {
-                let data = self.main_split.register.unamed.clone();
+                let data = self.register.unamed.clone();
                 self.paste(ctx, &data);
             }
             LapceCommand::DeleteWordForward => {


### PR DESCRIPTION
This PR adds `register` so commands don't need to access the whole `main_split` field. Based on #297