### PR TITLE
Refactor towards testability, step 6: make buffer edit operations more generic

### DIFF
--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -1779,7 +1779,7 @@ impl Buffer {
 
     fn apply_edit(
         &mut self,
-        proxy: Arc<LapceProxy>,
+        proxy: &LapceProxy,
         delta: &RopeDelta,
         new_rev: Revision,
         new_text: Rope,
@@ -1831,7 +1831,7 @@ impl Buffer {
     pub fn edit_multiple(
         &mut self,
         edits: &[(&Selection, &str)],
-        proxy: Arc<LapceProxy>,
+        proxy: &LapceProxy,
         edit_type: EditType,
     ) -> RopeDelta {
         let mut builder = DeltaBuilder::new(self.len());
@@ -1878,13 +1878,13 @@ impl Buffer {
         &mut self,
         selection: &Selection,
         content: &str,
-        proxy: Arc<LapceProxy>,
+        proxy: &LapceProxy,
         edit_type: EditType,
     ) -> RopeDelta {
         self.edit_multiple(&[(selection, content)], proxy, edit_type)
     }
 
-    pub fn do_undo(&mut self, proxy: Arc<LapceProxy>) -> Option<RopeDelta> {
+    pub fn do_undo(&mut self, proxy: &LapceProxy) -> Option<RopeDelta> {
         if self.cur_undo > 1 {
             self.cur_undo -= 1;
             self.undos.insert(self.live_undos[self.cur_undo]);
@@ -1895,7 +1895,7 @@ impl Buffer {
         }
     }
 
-    pub fn do_redo(&mut self, proxy: Arc<LapceProxy>) -> Option<RopeDelta> {
+    pub fn do_redo(&mut self, proxy: &LapceProxy) -> Option<RopeDelta> {
         if self.cur_undo < self.live_undos.len() {
             self.undos.remove(&self.live_undos[self.cur_undo]);
             self.cur_undo += 1;
@@ -1906,11 +1906,7 @@ impl Buffer {
         }
     }
 
-    fn undo(
-        &mut self,
-        groups: BTreeSet<usize>,
-        proxy: Arc<LapceProxy>,
-    ) -> RopeDelta {
+    fn undo(&mut self, groups: BTreeSet<usize>, proxy: &LapceProxy) -> RopeDelta {
         let (new_rev, new_deletes_from_union) = self.compute_undo(&groups);
         let delta = Delta::synthesize(
             &self.tombstones,
@@ -1926,7 +1922,7 @@ impl Buffer {
         );
         self.undone_groups = groups;
         self.apply_edit(
-            proxy,
+            &proxy,
             &delta,
             new_rev,
             new_text,

--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -33,21 +33,19 @@ impl Snippet {
         loop {
             if s.len() == pos {
                 break;
-            } else if let Some((ele, end)) = Self::extract_tabstop(s, pos) {
-                elements.push(ele);
-                pos = end;
-            } else if let Some((ele, end)) = Self::extract_placeholder(s, pos) {
-                elements.push(ele);
-                pos = end;
-            } else if let Some((ele, end)) =
-                Self::extract_text(s, pos, escs, loose_escs)
+            }
+
+            if let Some((ele, end)) = Self::extract_tabstop(s, pos)
+                .or_else(|| Self::extract_placeholder(s, pos))
+                .or_else(|| Self::extract_text(s, pos, escs, loose_escs))
             {
                 elements.push(ele);
                 pos = end;
             } else {
                 break;
-            }
+            };
         }
+
         (elements, pos)
     }
 

--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, fmt::Display, sync::Arc};
+use std::{fmt::Display, sync::Arc};
 
 use anyhow::Error;
 use druid::{ExtEventSink, Size, Target, WidgetId};

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2036,7 +2036,6 @@ impl LapceMainSplitData {
         config: &Config,
     ) -> Option<RopeDelta> {
         self.initiate_diagnositcs_offset(path, config);
-        let proxy = self.proxy.clone();
         let buffer = self.open_files.get_mut(path)?;
 
         let buffer_len = buffer.len();
@@ -2050,7 +2049,8 @@ impl LapceMainSplitData {
             }
         }
 
-        let delta = Arc::make_mut(buffer).edit_multiple(edits, proxy, edit_type);
+        let delta =
+            Arc::make_mut(buffer).edit_multiple(edits, &self.proxy, edit_type);
         if move_cursor {
             self.cursor_apply_delta(path, &delta);
         }

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -31,7 +31,7 @@ use xi_rope::{RopeDelta, Transformer};
 use crate::{
     buffer::{
         matching_char, matching_pair_direction, Buffer, BufferContent, EditType,
-        LocalBufferKind,
+        LocalBufferKind, ProxyUpdateListener,
     },
     command::{
         CommandTarget, EnsureVisiblePosition, LapceCommandNew, LapceUICommand,
@@ -2049,8 +2049,11 @@ impl LapceMainSplitData {
             }
         }
 
-        let delta =
-            Arc::make_mut(buffer).edit_multiple(edits, &self.proxy, edit_type);
+        let delta = Arc::make_mut(buffer).edit_multiple(
+            edits,
+            &mut ProxyUpdateListener(&self.proxy),
+            edit_type,
+        );
         if move_cursor {
             self.cursor_apply_delta(path, &delta);
         }

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -680,6 +680,7 @@ impl LapceTabData {
             buffer,
             editor: editor.clone(),
             config: self.config.clone(),
+            register: self.main_split.register.clone(),
         }
     }
 
@@ -749,15 +750,19 @@ impl LapceTabData {
         editor: &Arc<LapceEditorData>,
         buffer: &Arc<Buffer>,
     ) {
-        self.completion = editor_buffer_data.completion.clone();
-        self.hover = editor_buffer_data.hover.clone();
-        self.main_split = editor_buffer_data.main_split.clone();
-        self.find = editor_buffer_data.find.clone();
+        // Update possibly cloned `Arc`s.
+        self.completion = editor_buffer_data.completion;
+        self.hover = editor_buffer_data.hover;
+        self.main_split = editor_buffer_data.main_split;
+        self.main_split.register = editor_buffer_data.register;
+        self.find = editor_buffer_data.find;
+
         if !editor_buffer_data.editor.same(editor) {
             self.main_split
                 .editors
                 .insert(editor.view_id, editor_buffer_data.editor);
         }
+
         if !editor_buffer_data.buffer.same(buffer) {
             match &buffer.content {
                 BufferContent::File(path) => {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -680,7 +680,6 @@ impl LapceTabData {
             buffer,
             editor: editor.clone(),
             config: self.config.clone(),
-            workspace: self.workspace.clone(),
         }
     }
 

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2094,7 +2094,7 @@ impl LapceMainSplitData {
 
         Arc::make_mut(
             self.editor_tabs
-                .get_mut(&(*self.active_tab.clone()).unwrap())
+                .get_mut(&self.active_tab.as_ref().unwrap())
                 .unwrap(),
         )
     }
@@ -2117,6 +2117,7 @@ impl LapceMainSplitData {
                             if config.editor.show_tab {
                                 if let Some(path) = path {
                                     let mut editor_size = Size::ZERO;
+                                    let file_path = BufferContent::File(path);
                                     for (i, child) in
                                         editor_tab.children.iter().enumerate()
                                     {
@@ -2129,11 +2130,7 @@ impl LapceMainSplitData {
                                                 if current_size.height > 0.0 {
                                                     editor_size = current_size;
                                                 }
-                                                if editor.content
-                                                    == BufferContent::File(
-                                                        path.clone(),
-                                                    )
-                                                {
+                                                if editor.content == file_path {
                                                     editor_tab.active = i;
                                                     ctx.submit_command(
                                                         Command::new(

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -11,6 +11,7 @@ use crate::command::LAPCE_NEW_COMMAND;
 use crate::completion::{CompletionData, CompletionStatus, Snippet};
 use crate::config::Config;
 use crate::data::MotionMode;
+use crate::data::Register;
 use crate::data::RegisterKind;
 use crate::data::{
     EditorDiagnostic, InlineFindDirection, LapceEditorData, LapceMainSplitData,
@@ -132,6 +133,7 @@ pub struct LapceEditorBufferData {
     pub find: Arc<Find>,
     pub proxy: Arc<LapceProxy>,
     pub config: Arc<Config>,
+    pub register: Arc<Register>,
 }
 
 impl LapceEditorBufferData {
@@ -272,7 +274,7 @@ impl LapceEditorBufferData {
                 VisualMode::Normal
             },
         };
-        let register = Arc::make_mut(&mut self.main_split.register);
+        let register = Arc::make_mut(&mut self.register);
         register.add(kind, data);
     }
 
@@ -1302,7 +1304,7 @@ impl LapceEditorBufferData {
                     .editor
                     .cursor
                     .yank(&self.buffer, self.config.editor.tab_width);
-                let register = Arc::make_mut(&mut self.main_split.register);
+                let register = Arc::make_mut(&mut self.register);
                 register.add_delete(data);
             }
             CursorMode::Insert(_) => {}
@@ -2085,7 +2087,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                     .editor
                     .cursor
                     .yank(&self.buffer, self.config.editor.tab_width);
-                let register = Arc::make_mut(&mut self.main_split.register);
+                let register = Arc::make_mut(&mut self.register);
                 register.add_yank(data);
                 match &self.editor.cursor.mode {
                     #[allow(unused_variables)]
@@ -2143,7 +2145,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                         .editor
                         .cursor
                         .yank(&self.buffer, self.config.editor.tab_width);
-                    let register = Arc::make_mut(&mut self.main_split.register);
+                    let register = Arc::make_mut(&mut self.register);
                     register.add_yank(data);
                 } else {
                     Arc::make_mut(&mut self.editor).motion_mode = None;
@@ -2185,7 +2187,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                 }
             }
             LapceCommand::Paste => {
-                let data = self.main_split.register.unamed.clone();
+                let data = self.register.unamed.clone();
                 self.paste(ctx, &data);
             }
             LapceCommand::DeleteWordForward => {

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -16,11 +16,10 @@ use crate::data::{
     EditorDiagnostic, InlineFindDirection, LapceEditorData, LapceMainSplitData,
     RegisterData, SplitContent,
 };
-use crate::movement::InsertDrift;
 use crate::hover::HoverData;
 use crate::hover::HoverStatus;
+use crate::movement::InsertDrift;
 use crate::proxy::path_from_url;
-use crate::state::LapceWorkspace;
 use crate::{buffer::WordProperty, movement::CursorMode};
 use crate::{
     command::{LapceCommand, LapceUICommand, LAPCE_UI_COMMAND},
@@ -128,7 +127,6 @@ pub struct LapceEditorBufferData {
     pub buffer: Arc<Buffer>,
     pub completion: Arc<CompletionData>,
     pub hover: Arc<HoverData>,
-    pub workspace: Arc<LapceWorkspace>,
     pub main_split: LapceMainSplitData,
     pub source_control: Arc<SourceControlData>,
     pub find: Arc<Find>,

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -532,20 +532,17 @@ impl LapceEditorBufferData {
     }
 
     pub fn apply_completion_item(&mut self, item: &CompletionItem) -> Result<()> {
+        let tab_width = self.config.editor.tab_width;
         let additional_edit: Option<Vec<_>> =
             item.additional_text_edits.as_ref().map(|edits| {
                 edits
                     .iter()
                     .map(|edit| {
                         let selection = Selection::region(
-                            self.buffer.offset_of_position(
-                                &edit.range.start,
-                                self.config.editor.tab_width,
-                            ),
-                            self.buffer.offset_of_position(
-                                &edit.range.end,
-                                self.config.editor.tab_width,
-                            ),
+                            self.buffer
+                                .offset_of_position(&edit.range.start, tab_width),
+                            self.buffer
+                                .offset_of_position(&edit.range.end, tab_width),
                         );
                         (selection, edit.new_text.clone())
                     })
@@ -567,14 +564,10 @@ impl LapceEditorBufferData {
                     let offset = self.editor.cursor.offset();
                     let start_offset = self.buffer.prev_code_boundary(offset);
                     let end_offset = self.buffer.next_code_boundary(offset);
-                    let edit_start = self.buffer.offset_of_position(
-                        &edit.range.start,
-                        self.config.editor.tab_width,
-                    );
-                    let edit_end = self.buffer.offset_of_position(
-                        &edit.range.end,
-                        self.config.editor.tab_width,
-                    );
+                    let edit_start =
+                        self.buffer.offset_of_position(&edit.range.start, tab_width);
+                    let edit_end =
+                        self.buffer.offset_of_position(&edit.range.end, tab_width);
                     let selection = Selection::region(
                         start_offset.min(edit_start),
                         end_offset.max(edit_end),

--- a/lapce-ui/src/code_action.rs
+++ b/lapce-ui/src/code_action.rs
@@ -346,29 +346,6 @@ impl Widget<LapceTabData> for CodeAction {
             let buffer = data.main_split.open_files.get(path).unwrap();
             let code_actions = CodeActionData::code_actions(buffer, editor);
 
-            let action_text_layouts: Vec<TextLayout<String>> = code_actions
-                .iter()
-                .map(|code_action| {
-                    let title = match code_action {
-                        CodeActionOrCommand::Command(cmd) => cmd.title.to_string(),
-                        CodeActionOrCommand::CodeAction(action) => {
-                            action.title.to_string()
-                        }
-                    };
-                    let mut text_layout = TextLayout::<String>::from_text(title);
-                    text_layout.set_font(
-                        FontDescriptor::new(FontFamily::SYSTEM_UI).with_size(14.0),
-                    );
-                    text_layout.set_text_color(
-                        data.config
-                            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
-                            .clone(),
-                    );
-                    text_layout.rebuild_if_needed(ctx.text(), env);
-                    text_layout
-                })
-                .collect();
-
             let line_height = data.config.editor.line_height as f64;
 
             let line_rect = Rect::ZERO
@@ -383,7 +360,27 @@ impl Widget<LapceTabData> for CodeAction {
                     .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
             );
 
-            for (i, text_layout) in action_text_layouts.iter().enumerate() {
+            let action_text_layouts = code_actions.iter().map(|code_action| {
+                let title = match code_action {
+                    CodeActionOrCommand::Command(cmd) => cmd.title.to_string(),
+                    CodeActionOrCommand::CodeAction(action) => {
+                        action.title.to_string()
+                    }
+                };
+                let mut text_layout = TextLayout::<String>::from_text(title);
+                text_layout.set_font(
+                    FontDescriptor::new(FontFamily::SYSTEM_UI).with_size(14.0),
+                );
+                text_layout.set_text_color(
+                    data.config
+                        .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+                        .clone(),
+                );
+                text_layout
+            });
+
+            for (i, mut text_layout) in action_text_layouts.enumerate() {
+                text_layout.rebuild_if_needed(ctx.text(), env);
                 text_layout.draw(ctx, Point::new(5.0, i as f64 * line_height + 5.0));
             }
         }

--- a/lapce-ui/src/completion.rs
+++ b/lapce-ui/src/completion.rs
@@ -14,6 +14,7 @@ use lapce_data::{
     config::LapceTheme,
     data::LapceTabData,
 };
+use lazy_static::lazy_static;
 use lsp_types::CompletionItem;
 use regex::Regex;
 use std::str::FromStr;
@@ -59,10 +60,13 @@ impl Snippet {
     }
 
     fn extract_tabstop(s: &str, pos: usize) -> Option<(SnippetElement, usize)> {
-        for re in &[
-            Regex::new(r#"^\$(\d+)"#).unwrap(),
-            Regex::new(r#"^\$\{(\d+)\}"#).unwrap(),
-        ] {
+        lazy_static! {
+            static ref PATTERNS: [Regex; 2] = [
+                Regex::new(r#"^\$(\d+)"#).unwrap(),
+                Regex::new(r#"^\$\{(\d+)\}"#).unwrap(),
+            ];
+        }
+        for re in PATTERNS.iter() {
             if let Some(caps) = re.captures(&s[pos..]) {
                 let end = pos + re.find(&s[pos..])?.end();
                 let m = caps.get(1)?;
@@ -75,10 +79,12 @@ impl Snippet {
     }
 
     fn extract_placeholder(s: &str, pos: usize) -> Option<(SnippetElement, usize)> {
-        let re = Regex::new(r#"^\$\{(\d+):(.*?)\}"#).unwrap();
-        let end = pos + re.find(&s[pos..])?.end();
+        lazy_static! {
+            static ref PATTERN: Regex = Regex::new(r#"^\$\{(\d+):(.*?)\}"#).unwrap();
+        }
+        let end = pos + PATTERN.find(&s[pos..])?.end();
 
-        let caps = re.captures(&s[pos..])?;
+        let caps = PATTERN.captures(&s[pos..])?;
 
         let tab = caps.get(1)?.as_str().parse::<usize>().ok()?;
 

--- a/lapce-ui/src/completion.rs
+++ b/lapce-ui/src/completion.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, fmt::Display, sync::Arc};
+use std::{cmp::Ordering, sync::Arc};
 
 use druid::{
     piet::{Text, TextAttribute, TextLayoutBuilder},
@@ -6,7 +6,6 @@ use druid::{
     LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Point, Rect, RenderContext, Size,
     Target, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
-use itertools::Itertools;
 use lapce_data::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     completion::{CompletionData, CompletionStatus, ScoredCompletionItem},
@@ -19,52 +18,6 @@ use crate::{
     scroll::{LapceIdentityWrapper, LapceScrollNew},
     svg::completion_svg,
 };
-
-#[derive(Debug)]
-pub enum SnippetElement {
-    Text(String),
-    PlaceHolder(usize, Vec<SnippetElement>),
-    Tabstop(usize),
-}
-
-impl SnippetElement {
-    pub fn len(&self) -> usize {
-        match &self {
-            SnippetElement::Text(text) => text.len(),
-            SnippetElement::PlaceHolder(_, elements) => {
-                elements.iter().map(|e| e.len()).sum()
-            }
-            SnippetElement::Tabstop(_) => 0,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn text(&self) -> String {
-        match &self {
-            SnippetElement::Text(t) => t.to_string(),
-            SnippetElement::PlaceHolder(_, elements) => {
-                elements.iter().map(|e| e.text()).join("")
-            }
-            SnippetElement::Tabstop(_) => "".to_string(),
-        }
-    }
-}
-
-impl Display for SnippetElement {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self {
-            SnippetElement::Text(text) => f.write_str(text),
-            SnippetElement::PlaceHolder(tab, elements) => {
-                let elements = elements.iter().map(|e| e.to_string()).join("");
-                write!(f, "${{{}:{}}}", tab, elements)
-            }
-            SnippetElement::Tabstop(tab) => write!(f, "${}", tab),
-        }
-    }
-}
 
 pub struct CompletionContainer {
     id: WidgetId,

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -12,6 +12,7 @@ use lapce_data::{
     config::LapceTheme,
     data::LapceTabData,
     editor::LapceEditorBufferData,
+    state::LapceWorkspace,
 };
 
 use crate::{
@@ -111,7 +112,12 @@ impl LapceEditorHeader {
         false
     }
 
-    pub fn paint_buffer(&self, ctx: &mut PaintCtx, data: &LapceEditorBufferData) {
+    pub fn paint_buffer(
+        &self,
+        ctx: &mut PaintCtx,
+        data: &LapceEditorBufferData,
+        workspace: &LapceWorkspace,
+    ) {
         let shadow_width = 5.0;
         let rect = ctx.size().to_rect();
         ctx.blurred_rect(
@@ -169,7 +175,7 @@ impl LapceEditorHeader {
                     .unwrap();
                 ctx.draw_text(&text_layout, Point::new(30.0, 7.0));
 
-                if let Some(workspace_path) = data.workspace.path.as_ref() {
+                if let Some(workspace_path) = workspace.path.as_ref() {
                     path = path
                         .strip_prefix(workspace_path)
                         .unwrap_or(&path)
@@ -297,6 +303,10 @@ impl Widget<LapceTabData> for LapceEditorHeader {
         if !self.display {
             return;
         }
-        self.paint_buffer(ctx, &data.editor_view_content(self.view_id));
+        self.paint_buffer(
+            ctx,
+            &data.editor_view_content(self.view_id),
+            &data.workspace,
+        );
     }
 }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -878,9 +878,9 @@ impl Widget<LapceTabData> for LapceTabNew {
                     }
                     LapceUICommand::FocusSourceControl => {
                         for (_, panel) in data.panels.iter_mut() {
-                            for kind in panel.widgets.clone() {
+                            let panel = Arc::make_mut(panel);
+                            for kind in panel.widgets.iter().copied() {
                                 if kind == PanelKind::SourceControl {
-                                    let panel = Arc::make_mut(panel);
                                     panel.active = PanelKind::SourceControl;
                                     panel.shown = true;
                                     ctx.submit_command(Command::new(


### PR DESCRIPTION
Simple edit tests won't ever touch non-local buffers, so let's allow them to pass in no-op operations. Based on #208