### PR TITLE
Close tabs on mouse up, don't start dragging until tab is actually dragged

### DIFF
--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -62,12 +62,6 @@ impl LapceEditorTabHeaderContent {
             if mouse_event.button.is_left()
                 && tab_rect.rect.contains(mouse_event.pos)
             {
-                let editor_tab = data
-                    .main_split
-                    .editor_tabs
-                    .get_mut(&self.widget_id)
-                    .unwrap();
-                let editor_tab = Arc::make_mut(editor_tab);
                 if tab_rect.close_rect.contains(mouse_event.pos) {
                     self.cancel_pending_drag(data);
                     ctx.submit_command(Command::new(
@@ -77,6 +71,14 @@ impl LapceEditorTabHeaderContent {
                     ));
                     return;
                 }
+
+                let editor_tab = data
+                    .main_split
+                    .editor_tabs
+                    .get_mut(&self.widget_id)
+                    .unwrap();
+                let editor_tab = Arc::make_mut(editor_tab);
+
                 if editor_tab.active != i {
                     editor_tab.active = i;
                     ctx.submit_command(Command::new(

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -92,6 +92,17 @@ impl LapceEditorTabHeaderContent {
 
                 return;
             }
+
+            if mouse_event.button.is_middle()
+                && tab_rect.rect.contains(mouse_event.pos)
+            {
+                ctx.submit_command(Command::new(
+                    LAPCE_UI_COMMAND,
+                    LapceUICommand::EditorTabRemove(i, true, true),
+                    Target::Widget(self.widget_id),
+                ));
+                return;
+            }
         }
     }
 
@@ -120,28 +131,18 @@ impl LapceEditorTabHeaderContent {
                 let editor_tab =
                     data.main_split.editor_tabs.get(&self.widget_id).unwrap();
                 let tab_rect = &self.rects[target];
+
                 let offset =
                     mouse_event.pos.to_vec2() - tab_rect.rect.origin().to_vec2();
                 *Arc::make_mut(&mut data.drag) = Some((
                     offset,
                     DragContent::EditorTab(
                         editor_tab.widget_id,
-                        editor_tab.active,
-                        editor_tab.children[editor_tab.active].clone(),
+                        target,
+                        editor_tab.children[target].clone(),
                         tab_rect.clone(),
                     ),
                 ));
-            }
-
-            if mouse_event.button.is_middle()
-                && tab_rect.rect.contains(mouse_event.pos)
-            {
-                ctx.submit_command(Command::new(
-                    LAPCE_UI_COMMAND,
-                    LapceUICommand::EditorTabRemove(i, true, true),
-                    Target::Widget(self.widget_id),
-                ));
-                return;
             }
         }
     }

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -47,7 +47,6 @@ impl LapceEditorTabHeaderContent {
     }
 
     fn cancel_pending_drag(&mut self, data: &mut LapceTabData) {
-        self.mouse_down_target = None;
         *Arc::make_mut(&mut data.drag) = None;
     }
 
@@ -129,7 +128,7 @@ impl LapceEditorTabHeaderContent {
         }
 
         if data.drag.is_none() {
-            if let Some(target) = self.mouse_down_target {
+            if let Some(target) = self.mouse_down_target.take() {
                 let editor_tab =
                     data.main_split.editor_tabs.get(&self.widget_id).unwrap();
                 let tab_rect = &self.rects[target];
@@ -185,12 +184,12 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
                 self.mouse_down(ctx, data, mouse_event);
             }
             Event::MouseUp(mouse_event) if mouse_event.button.is_left() => {
+                self.mouse_down_target = None;
                 if let Some((
                     _,
                     DragContent::EditorTab(from_id, from_index, child, _),
                 )) = Arc::make_mut(&mut data.drag).take()
                 {
-                    self.mouse_down_target = None;
                     let mut mouse_index = self.drag_target_idx(mouse_event.pos);
 
                     let editor_tab = data
@@ -256,14 +255,10 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
     fn lifecycle(
         &mut self,
         _ctx: &mut LifeCycleCtx,
-        event: &LifeCycle,
+        _event: &LifeCycle,
         _data: &LapceTabData,
         _env: &Env,
     ) {
-        if let LifeCycle::HotChanged(_) = event {
-            // Prevent re-entering with MouseDown to pick up a random tab.
-            self.mouse_down_target = None;
-        }
     }
 
     fn update(

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -44,9 +44,9 @@ impl LapceEditorTabHeaderContent {
         }
     }
 
-    fn icon_hit_test(&self, mouse_event: &MouseEvent) -> bool {
+    fn tab_hit_test(&self, mouse_event: &MouseEvent) -> bool {
         for tab_idx in 0..self.rects.len() {
-            if self.is_close_icon_hit(tab_idx, mouse_event.pos) {
+            if self.is_tab_hit(tab_idx, mouse_event.pos) {
                 return true;
             }
         }
@@ -121,7 +121,7 @@ impl LapceEditorTabHeaderContent {
         mouse_event: &MouseEvent,
     ) {
         self.mouse_pos = mouse_event.pos;
-        if self.icon_hit_test(mouse_event) {
+        if self.tab_hit_test(mouse_event) {
             ctx.set_cursor(&druid::Cursor::Pointer);
         } else {
             ctx.clear_cursor();

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -376,23 +376,11 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, _env: &Env) {
-        let editor_tab = data.main_split.editor_tabs.get(&self.widget_id).unwrap();
         let size = ctx.size();
 
         for (i, tab_rect) in self.rects.iter().enumerate() {
-            if i != editor_tab.active {
-                tab_rect.paint(ctx, data, self.widget_id, i, size, self.mouse_pos);
-            }
+            tab_rect.paint(ctx, data, self.widget_id, i, size, self.mouse_pos);
         }
-
-        self.rects.get(editor_tab.active).unwrap().paint(
-            ctx,
-            data,
-            self.widget_id,
-            editor_tab.active,
-            size,
-            self.mouse_pos,
-        );
 
         if ctx.is_hot() && data.drag.is_some() {
             let mouse_index = self.drag_target_idx(self.mouse_pos);

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -169,7 +169,7 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
             Event::MouseDown(mouse_event) => {
                 self.mouse_down(ctx, data, mouse_event);
             }
-            Event::MouseUp(mouse_event) => {
+            Event::MouseUp(mouse_event) if mouse_event.button.is_left() => {
                 self.mouse_down_target = None;
 
                 if let Some((


### PR DESCRIPTION
 - Only start actually dragging on mouse move
 - Fix an edge case: when the user drags a tab to the top menubar and releases left mouse button, then moves the cursor back to the editor, the tab is no longer dragged.
 - Only close tabs on `MouseUp` to allow cancelling
 - Changes cursor to Pointer when it is inside a tab, not just in the close icon. (VSCode behavior)

For whatever reason, clicking the right mouse button during a drag cancels the drag. This behaviour does not come from the tab header component and was there previously.