### PR TITLE
Fix window title crash on opening volume root (e.g. `C:\`)

### DIFF
--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -861,8 +861,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                                 let dir = p
                                     .file_name()
                                     .unwrap_or_else(|| p.as_os_str())
-                                    .to_str()
-                                    .unwrap();
+                                    .to_string_lossy();
                                 let dir = match &data.workspace.kind {
                                     LapceWorkspaceType::Local => dir.to_string(),
                                     LapceWorkspaceType::RemoteSSH(user, host) => {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -858,7 +858,11 @@ impl Widget<LapceTabData> for LapceTabNew {
                             .path
                             .as_ref()
                             .map(|p| {
-                                let dir = p.file_name().unwrap().to_str().unwrap();
+                                let dir = p
+                                    .file_name()
+                                    .unwrap_or_else(|| p.as_os_str())
+                                    .to_str()
+                                    .unwrap();
                                 let dir = match &data.workspace.kind {
                                     LapceWorkspaceType::Local => dir.to_string(),
                                     LapceWorkspaceType::RemoteSSH(user, host) => {

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -298,8 +298,7 @@ impl Widget<LapceWindowData> for Title {
             workspace_path
                 .file_name()
                 .unwrap_or_else(|| workspace_path.as_os_str())
-                .to_str()
-                .unwrap()
+                .to_string_lossy()
                 .to_string()
         } else {
             "Open Folder".to_string()

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -297,7 +297,7 @@ impl Widget<LapceWindowData> for Title {
         let text = if let Some(workspace_path) = tab.workspace.path.as_ref() {
             workspace_path
                 .file_name()
-                .unwrap()
+                .unwrap_or_else(|| workspace_path.as_os_str())
                 .to_str()
                 .unwrap()
                 .to_string()


### PR DESCRIPTION
Fixes #337

Includes a bonus fix when the path is not a valid `str`