### PR TITLE
Fix explorer hover effect not resetting on mouse leave

### DIFF
--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -367,6 +367,9 @@ impl Widget<LapceTabData> for FileExplorerFileList {
         data: &mut LapceTabData,
         _env: &Env,
     ) {
+        if !ctx.is_hot() {
+            return;
+        }
         match event {
             Event::MouseMove(mouse_event) => {
                 if let Some(workspace) = data.file_explorer.workspace.as_ref() {


### PR DESCRIPTION
Druid seems to generate a mouse move event **after** updating the lifecycle to no longer hot. This unexpected event set the `hovered` field back to some value, instead of leaving it `None`, so the hover styling did not get cleared on mouse leave. This PR only handles mouse events if the file list widget is hot, to ignore this additional event.