### PR TITLE
Pass unhandled key events through the default handler

### DIFF
--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -23,7 +23,7 @@ use lapce_data::{
     },
     editor::EditorLocationNew,
     hover::HoverStatus,
-    keypress::KeyPressData,
+    keypress::{DefaultKeyPressHandler, KeyPressData},
     movement::{self, CursorMode, Selection},
     palette::PaletteStatus,
     panel::{PanelPosition, PanelResizePosition},
@@ -1007,10 +1007,25 @@ impl Widget<LapceTabData> for LapceTabNew {
         }
         self.activity.event(ctx, event, data, env);
 
-        if let Event::MouseUp(_) = event {
-            if data.drag.is_some() {
-                *Arc::make_mut(&mut data.drag) = None;
+        match event {
+            Event::MouseUp(_) => {
+                if data.drag.is_some() {
+                    *Arc::make_mut(&mut data.drag) = None;
+                }
             }
+            Event::KeyDown(key_event) if !ctx.is_handled() => {
+                let mut keypress = data.keypress.clone();
+                let mut_keypress = Arc::make_mut(&mut keypress);
+                mut_keypress.key_down(
+                    ctx,
+                    key_event,
+                    &mut DefaultKeyPressHandler {},
+                    env,
+                );
+                data.keypress = keypress;
+                ctx.set_handled();
+            }
+            _ => (),
         }
     }
 


### PR DESCRIPTION
Resolves #344

@dzhou121 ~do you have a better idea? This PR is pretty bad, in that it's not the widgets that pass focus back to the main split (I couldn't get that to work, only for FileExplorer). This means, if one of the panels will support any kind of keyboard input in the future, the implementor needs to know about this special casing.~