### PR TITLE
Refactor buffer editing to allow testing

### DIFF
--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -14,7 +14,7 @@ use lsp_types::SemanticTokensServerCapabilities;
 use lsp_types::{CodeActionResponse, Position};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
-use std::cmp::{self, Ordering};
+use std::cmp;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::rc::Rc;
@@ -23,12 +23,12 @@ use std::sync::atomic::{self, AtomicU64};
 use std::{borrow::Cow, collections::BTreeSet, path::PathBuf, sync::Arc, thread};
 use unicode_width::UnicodeWidthChar;
 use xi_rope::{
-    multiset::Subset, rope::Rope, spans::Spans, Cursor, Delta, DeltaBuilder,
-    Interval, RopeDelta, RopeInfo,
+    multiset::Subset, rope::Rope, spans::Spans, Cursor, Delta, Interval, RopeDelta,
+    RopeInfo,
 };
 use xi_unicode::EmojiExt;
 
-use crate::buffer::data::{BufferData, BufferDataListener};
+use crate::buffer::data::{BufferData, BufferDataListener, EditableBufferData};
 use crate::buffer::decoration::BufferDecoration;
 use crate::config::{Config, LapceTheme};
 use crate::editor::EditorLocationNew;
@@ -212,15 +212,7 @@ impl BufferContent {
 
 #[derive(Clone)]
 pub struct Buffer {
-    pub id: BufferId,
-    pub rope: Rope,
-    pub content: BufferContent,
-    pub max_len: usize,
-    pub max_len_line: usize,
-    pub num_lines: usize,
-    pub rev: u64,
-    pub atomic_rev: Arc<AtomicU64>,
-    pub dirty: bool,
+    data: BufferData,
     pub indent_style: IndentStyle,
     pub start_to_load: Rc<RefCell<bool>>,
 
@@ -228,24 +220,13 @@ pub struct Buffer {
     pub history_line_styles: Rc<RefCell<HashMap<String, LineStyles>>>,
     pub history_changes: im::HashMap<String, Arc<Vec<DiffLines>>>,
 
-    revs: Vec<Revision>,
-    cur_undo: usize,
-    undos: BTreeSet<usize>,
-    undo_group_id: usize,
-    live_undos: Vec<usize>,
-    deletes_from_union: Subset,
-    undone_groups: BTreeSet<usize>,
-    tombstones: Rope,
-
-    last_edit_type: EditType,
-
     pub cursor_offset: usize,
     pub scroll_offset: Vec2,
 
     pub code_actions: im::HashMap<usize, CodeActionResponse>,
 
-    pub loaded: bool,
-    pub local: bool,
+    loaded: bool,
+    local: bool,
     pub find: Rc<RefCell<Find>>,
     pub find_progress: Rc<RefCell<FindProgress>>,
     pub syntax: Option<Syntax>,
@@ -258,7 +239,7 @@ pub struct Buffer {
 
 pub struct BufferEditListener<'a> {
     decoration: &'a mut BufferDecoration,
-    proxy: &'a Arc<LapceProxy>,
+    proxy: &'a LapceProxy,
 }
 
 impl BufferDataListener for BufferEditListener<'_> {
@@ -293,45 +274,49 @@ impl Buffer {
         };
 
         Self {
-            id: BufferId::next(),
-            rope,
+            data: BufferData {
+                id: BufferId::next(),
+                rope,
+                content,
+
+                max_len: 0,
+                max_len_line: 0,
+                num_lines: 0,
+
+                rev: 0,
+                atomic_rev: Arc::new(AtomicU64::new(0)),
+                dirty: false,
+
+                revs: vec![Revision {
+                    max_undo_so_far: 0,
+                    edit: Contents::Undo {
+                        toggled_groups: BTreeSet::new(),
+                        deletes_bitxor: Subset::new(0),
+                    },
+                }],
+                cur_undo: 1,
+                undos: BTreeSet::new(),
+                undo_group_id: 1,
+                live_undos: vec![0],
+                deletes_from_union: Subset::new(0),
+                undone_groups: BTreeSet::new(),
+                tombstones: Rope::default(),
+
+                last_edit_type: EditType::Other,
+            },
             syntax,
             line_styles: Rc::new(RefCell::new(HashMap::new())),
             indent_style: DEFAULT_INDENT,
             semantic_styles: None,
-            content,
             find: Rc::new(RefCell::new(Find::new(0))),
             find_progress: Rc::new(RefCell::new(FindProgress::Ready)),
-            max_len: 0,
-            max_len_line: 0,
-            num_lines: 0,
-            rev: 0,
-            atomic_rev: Arc::new(AtomicU64::new(0)),
             start_to_load: Rc::new(RefCell::new(false)),
             loaded: false,
-            dirty: false,
             local: false,
             histories: im::HashMap::new(),
             history_styles: im::HashMap::new(),
             history_line_styles: Rc::new(RefCell::new(HashMap::new())),
             history_changes: im::HashMap::new(),
-
-            revs: vec![Revision {
-                max_undo_so_far: 0,
-                edit: Contents::Undo {
-                    toggled_groups: BTreeSet::new(),
-                    deletes_bitxor: Subset::new(0),
-                },
-            }],
-            cur_undo: 1,
-            undos: BTreeSet::new(),
-            undo_group_id: 1,
-            live_undos: vec![0],
-            deletes_from_union: Subset::new(0),
-            undone_groups: BTreeSet::new(),
-            tombstones: Rope::default(),
-
-            last_edit_type: EditType::Other,
 
             cursor_offset: 0,
             scroll_offset: Vec2::ZERO,
@@ -342,26 +327,78 @@ impl Buffer {
         }
     }
 
+    pub fn id(&self) -> BufferId {
+        self.data.id
+    }
+
+    pub fn rope(&self) -> &Rope {
+        &self.data.rope
+    }
+
+    pub fn content(&self) -> &BufferContent {
+        &self.data.content
+    }
+
+    pub fn max_len(&self) -> usize {
+        self.data.max_len
+    }
+
+    pub fn max_len_line(&self) -> usize {
+        self.data.max_len_line
+    }
+
+    pub fn num_lines(&self) -> usize {
+        self.data.num_lines
+    }
+
+    pub fn rev(&self) -> u64 {
+        self.data.rev
+    }
+
+    pub fn set_rev(&mut self, rev: u64) {
+        self.data.rev = rev;
+    }
+
+    pub fn dirty(&self) -> bool {
+        self.data.dirty
+    }
+
+    pub fn set_dirty(&mut self, dirty: bool) {
+        self.data.dirty = dirty;
+    }
+
     pub fn set_local(mut self) -> Self {
         self.local = true;
         self
     }
 
     pub fn reset_revs(&mut self) {
-        self.rope = Rope::from("");
-        self.revs = vec![Revision {
-            max_undo_so_far: 0,
-            edit: Contents::Undo {
-                toggled_groups: BTreeSet::new(),
-                deletes_bitxor: Subset::new(0),
+        self.data.reset_revs();
+    }
+
+    pub fn update_edit_type(&mut self) {
+        self.data.last_edit_type = EditType::Other;
+    }
+
+    pub fn loaded(&self) -> bool {
+        self.loaded
+    }
+
+    pub fn local(&self) -> bool {
+        self.local
+    }
+
+    pub fn editable<'a>(
+        &'a mut self,
+        proxy: &'a LapceProxy,
+    ) -> EditableBufferData<'a, BufferEditListener> {
+        EditableBufferData {
+            listener: BufferEditListener {
+                decoration: todo!(),
+                proxy,
             },
-        }];
-        self.cur_undo = 1;
-        self.undo_group_id = 1;
-        self.live_undos = vec![0];
-        self.deletes_from_union = Subset::new(0);
-        self.undone_groups = BTreeSet::new();
-        self.tombstones = Rope::default();
+            buffer: &mut self.data,
+        }
     }
 
     pub fn load_history(&mut self, version: &str, content: Rope) {
@@ -377,26 +414,26 @@ impl Buffer {
             let delta =
                 Delta::simple_edit(Interval::new(0, 0), Rope::from(content), 0);
             let (new_rev, new_text, new_tombstones, new_deletes_from_union) =
-                self.mk_new_rev(0, delta);
-            self.revs.push(new_rev);
-            self.rope = new_text;
-            self.tombstones = new_tombstones;
-            self.deletes_from_union = new_deletes_from_union;
+                self.data.mk_new_rev(0, delta);
+            self.data.revs.push(new_rev);
+            self.data.rope = new_text;
+            self.data.tombstones = new_tombstones;
+            self.data.deletes_from_union = new_deletes_from_union;
         }
 
         self.code_actions.clear();
         let (max_len, max_len_line) = self.get_max_line_len();
-        self.max_len = max_len;
-        self.max_len_line = max_len_line;
-        self.num_lines = self.num_lines();
+        self.data.max_len = max_len;
+        self.data.max_len_line = max_len_line;
+        self.data.num_lines = self.calc_num_lines();
         self.loaded = true;
         self.detect_indent();
         self.notify_update(None);
     }
 
     pub fn detect_indent(&mut self) {
-        self.indent_style =
-            auto_detect_indent_style(&self.rope).unwrap_or_else(|| {
+        self.indent_style = auto_detect_indent_style(&self.data.rope)
+            .unwrap_or_else(|| {
                 self.syntax
                     .as_ref()
                     .map(|s| IndentStyle::from_str(s.language.indent_unit()))
@@ -409,8 +446,8 @@ impl Buffer {
     }
 
     fn retrieve_history_styles(&self, version: &str, content: Rope) {
-        if let BufferContent::File(path) = &self.content {
-            let id = self.id;
+        if let BufferContent::File(path) = &self.data.content {
+            let id = self.id();
             let path = path.clone();
             let tab_id = self.tab_id;
             let version = version.to_string();
@@ -437,14 +474,14 @@ impl Buffer {
     }
 
     fn trigger_history_change(&self) {
-        if let BufferContent::File(path) = &self.content {
+        if let BufferContent::File(path) = &self.data.content {
             if let Some(head) = self.histories.get("head") {
-                let id = self.id;
-                let rev = self.rev;
-                let atomic_rev = self.atomic_rev.clone();
+                let id = self.id();
+                let rev = self.rev();
+                let atomic_rev = self.data.atomic_rev.clone();
                 let path = path.clone();
                 let left_rope = head.clone();
-                let right_rope = self.rope.clone();
+                let right_rope = self.rope().clone();
                 let event_sink = self.event_sink.clone();
                 let tab_id = self.tab_id;
                 rayon::spawn(move || {
@@ -478,10 +515,10 @@ impl Buffer {
     }
 
     fn notify_special(&self) {
-        match &self.content {
+        match &self.data.content {
             BufferContent::File(_) => {}
             BufferContent::Local(local) => {
-                let s = self.rope.to_string();
+                let s = self.data.rope.to_string();
                 match local {
                     LocalBufferKind::Search => {
                         let _ = self.event_sink.submit_command(
@@ -519,7 +556,7 @@ impl Buffer {
             BufferContent::Value(_) => {}
         }
 
-        if let BufferContent::Local(LocalBufferKind::Search) = self.content {}
+        if let BufferContent::Local(LocalBufferKind::Search) = self.data.content {}
     }
 
     pub fn notify_update(&self, delta: Option<&RopeDelta>) {
@@ -528,13 +565,13 @@ impl Buffer {
     }
 
     fn trigger_syntax_change(&self, delta: Option<&RopeDelta>) {
-        if let BufferContent::File(path) = &self.content {
+        if let BufferContent::File(path) = &self.data.content {
             if let Some(syntax) = self.syntax.clone() {
                 let path = path.clone();
-                let rev = self.rev;
-                let text = self.rope.clone();
+                let rev = self.rev();
+                let text = self.data.rope.clone();
                 let delta = delta.cloned();
-                let atomic_rev = self.atomic_rev.clone();
+                let atomic_rev = self.data.atomic_rev.clone();
                 let event_sink = self.event_sink.clone();
                 let tab_id = self.tab_id;
                 rayon::spawn(move || {
@@ -565,8 +602,8 @@ impl Buffer {
         proxy: Arc<LapceProxy>,
         event_sink: ExtEventSink,
     ) {
-        let id = self.id;
-        if let BufferContent::File(path) = &self.content {
+        let id = self.data.id;
+        if let BufferContent::File(path) = &self.data.content {
             let path = path.clone();
             thread::spawn(move || {
                 proxy.get_buffer_head(
@@ -605,8 +642,8 @@ impl Buffer {
             return;
         }
         *self.start_to_load.borrow_mut() = true;
-        let id = self.id;
-        if let BufferContent::File(path) = &self.content {
+        let id = self.data.id;
+        if let BufferContent::File(path) = &self.data.content {
             let path = path.clone();
             let proxy = proxy.clone();
             let event_sink = event_sink.clone();
@@ -713,7 +750,7 @@ impl Buffer {
         if let Some((search_range_start, search_range_end)) = search_range {
             if !find.is_multiline_regex() {
                 find.update_find(
-                    &self.rope,
+                    &self.data.rope,
                     search_range_start,
                     search_range_end,
                     true,
@@ -722,7 +759,7 @@ impl Buffer {
                 // only execute multi-line regex queries if we are searching the entire text (last step)
                 if search_range_start == 0 && search_range_end == self.len() {
                     find.update_find(
-                        &self.rope,
+                        &self.data.rope,
                         search_range_start,
                         search_range_end,
                         true,
@@ -732,18 +769,18 @@ impl Buffer {
         }
     }
 
-    pub fn num_lines(&self) -> usize {
-        self.line_of_offset(self.rope.len()) + 1
+    fn calc_num_lines(&self) -> usize {
+        self.line_of_offset(self.data.rope.len()) + 1
     }
 
     pub fn last_line(&self) -> usize {
-        self.line_of_offset(self.rope.len())
+        self.line_of_offset(self.data.rope.len())
     }
 
     pub fn line_of_offset(&self, offset: usize) -> usize {
         let max = self.len();
         let offset = if offset > max { max } else { offset };
-        self.rope.line_of_offset(offset)
+        self.data.rope.line_of_offset(offset)
     }
 
     pub fn offset_line_content(&self, offset: usize) -> Cow<str> {
@@ -763,18 +800,18 @@ impl Buffer {
         } else {
             line
         };
-        self.rope.offset_of_line(line)
+        self.data.rope.offset_of_line(line)
     }
 
     pub fn select_word(&self, offset: usize) -> (usize, usize) {
-        WordCursor::new(&self.rope, offset).select_word()
+        WordCursor::new(&self.data.rope, offset).select_word()
     }
 
     pub fn char_at_offset(&self, offset: usize) -> Option<char> {
         if self.is_empty() {
             return None;
         }
-        WordCursor::new(&self.rope, offset)
+        WordCursor::new(&self.data.rope, offset)
             .inner
             .peek_next_codepoint()
     }
@@ -786,16 +823,16 @@ impl Buffer {
         } else {
             line
         };
-        let line_start_offset = self.rope.offset_of_line(line);
-        WordCursor::new(&self.rope, line_start_offset).next_non_blank_char()
+        let line_start_offset = self.data.rope.offset_of_line(line);
+        WordCursor::new(&self.data.rope, line_start_offset).next_non_blank_char()
     }
 
     pub fn get_max_line_len(&self) -> (usize, usize) {
         let mut pre_offset = 0;
         let mut max_len = 0;
         let mut max_len_line = 0;
-        for line in 0..self.num_lines() + 1 {
-            let offset = self.rope.offset_of_line(line);
+        for line in 0..self.calc_num_lines() + 1 {
+            let offset = self.data.rope.offset_of_line(line);
             let line_len = offset - pre_offset;
             pre_offset = offset;
             if line_len > max_len {
@@ -807,7 +844,7 @@ impl Buffer {
     }
 
     pub fn len(&self) -> usize {
-        self.rope.len()
+        self.data.rope.len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -871,7 +908,7 @@ impl Buffer {
                 .or_else(|| self.syntax.as_ref().and_then(|s| s.styles.as_ref()));
 
             let line_styles = styles
-                .map(|styles| line_styles(&self.rope, line, styles))
+                .map(|styles| line_styles(&self.data.rope, line, styles))
                 .unwrap_or_default();
             self.line_styles
                 .borrow_mut()
@@ -972,15 +1009,19 @@ impl Buffer {
     }
 
     pub fn indent_on_line(&self, line: usize) -> String {
-        let line_start_offset = self.rope.offset_of_line(line);
-        let word_boundary =
-            WordCursor::new(&self.rope, line_start_offset).next_non_blank_char();
-        let indent = self.rope.slice_to_cow(line_start_offset..word_boundary);
+        let line_start_offset = self.data.rope.offset_of_line(line);
+        let word_boundary = WordCursor::new(&self.data.rope, line_start_offset)
+            .next_non_blank_char();
+        let indent = self
+            .data
+            .rope
+            .slice_to_cow(line_start_offset..word_boundary);
         indent.to_string()
     }
 
     pub fn slice_to_cow(&self, range: Range<usize>) -> Cow<str> {
-        self.rope
+        self.data
+            .rope
             .slice_to_cow(range.start.min(self.len())..range.end.min(self.len()))
     }
 
@@ -1172,7 +1213,7 @@ impl Buffer {
         count: usize,
         limit: usize,
     ) -> usize {
-        let mut cursor = Cursor::new(&self.rope, offset);
+        let mut cursor = Cursor::new(&self.data.rope, offset);
         let mut new_offset = offset;
         for _i in 0..count {
             if let Some(prev_offset) = cursor.prev_grapheme() {
@@ -1199,7 +1240,7 @@ impl Buffer {
         } else {
             offset
         };
-        let mut cursor = Cursor::new(&self.rope, offset);
+        let mut cursor = Cursor::new(&self.data.rope, offset);
         let mut new_offset = offset;
         for _i in 0..count {
             if let Some(next_offset) = cursor.next_grapheme() {
@@ -1530,13 +1571,13 @@ impl Buffer {
             Movement::Offset(offset) => {
                 let new_offset = *offset;
                 let new_offset =
-                    self.rope.prev_grapheme_offset(new_offset + 1).unwrap();
+                    self.data.rope.prev_grapheme_offset(new_offset + 1).unwrap();
                 let (_, col) =
                     self.offset_to_line_col(new_offset, config.editor.tab_width);
                 (new_offset, ColPosition::Col(col))
             }
             Movement::WordEndForward => {
-                let mut new_offset = WordCursor::new(&self.rope, offset)
+                let mut new_offset = WordCursor::new(&self.data.rope, offset)
                     .end_boundary()
                     .unwrap_or(offset);
                 if mode != Mode::Insert {
@@ -1547,7 +1588,7 @@ impl Buffer {
                 (new_offset, ColPosition::Col(col))
             }
             Movement::WordForward => {
-                let new_offset = WordCursor::new(&self.rope, offset)
+                let new_offset = WordCursor::new(&self.data.rope, offset)
                     .next_boundary()
                     .unwrap_or(offset);
                 let (_, col) =
@@ -1555,7 +1596,7 @@ impl Buffer {
                 (new_offset, ColPosition::Col(col))
             }
             Movement::WordBackward => {
-                let new_offset = WordCursor::new(&self.rope, offset)
+                let new_offset = WordCursor::new(&self.data.rope, offset)
                     .prev_boundary()
                     .unwrap_or(offset);
                 let (_, col) =
@@ -1571,7 +1612,7 @@ impl Buffer {
                         self.offset_to_line_col(new_offset, config.editor.tab_width);
                     (new_offset, ColPosition::Col(col))
                 } else {
-                    let new_offset = WordCursor::new(&self.rope, offset)
+                    let new_offset = WordCursor::new(&self.data.rope, offset)
                         .next_unmatched(*c)
                         .map_or(offset, |new| new - 1);
                     let (_, col) =
@@ -1588,7 +1629,7 @@ impl Buffer {
                         self.offset_to_line_col(new_offset, config.editor.tab_width);
                     (new_offset, ColPosition::Col(col))
                 } else {
-                    let new_offset = WordCursor::new(&self.rope, offset)
+                    let new_offset = WordCursor::new(&self.data.rope, offset)
                         .previous_unmatched(*c)
                         .unwrap_or(offset);
                     let (_, col) =
@@ -1604,7 +1645,7 @@ impl Buffer {
                         self.offset_to_line_col(new_offset, config.editor.tab_width);
                     (new_offset, ColPosition::Col(col))
                 } else {
-                    let new_offset = WordCursor::new(&self.rope, offset)
+                    let new_offset = WordCursor::new(&self.data.rope, offset)
                         .match_pairs()
                         .unwrap_or(offset);
                     let (_, col) =
@@ -1619,16 +1660,16 @@ impl Buffer {
         if let Some(syntax) = self.syntax.as_ref() {
             syntax.find_tag(offset, true, &c.to_string())
         } else {
-            WordCursor::new(&self.rope, offset).previous_unmatched(c)
+            WordCursor::new(&self.data.rope, offset).previous_unmatched(c)
         }
     }
 
     pub fn prev_code_boundary(&self, offset: usize) -> usize {
-        WordCursor::new(&self.rope, offset).prev_code_boundary()
+        WordCursor::new(&self.data.rope, offset).prev_code_boundary()
     }
 
     pub fn next_code_boundary(&self, offset: usize) -> usize {
-        WordCursor::new(&self.rope, offset).next_code_boundary()
+        WordCursor::new(&self.data.rope, offset).next_code_boundary()
     }
 
     pub fn update_history_changes(
@@ -1637,409 +1678,10 @@ impl Buffer {
         history: &str,
         changes: Arc<Vec<DiffLines>>,
     ) {
-        if rev != self.rev {
+        if rev != self.rev() {
             return;
         }
         self.history_changes.insert(history.to_string(), changes);
-    }
-
-    fn update_size(&mut self, inval_lines: &InvalLines) {
-        if inval_lines.inval_count != inval_lines.new_count {
-            self.num_lines = self.num_lines();
-        }
-        if self.max_len_line >= inval_lines.start_line
-            && self.max_len_line < inval_lines.start_line + inval_lines.inval_count
-        {
-            let (max_len, max_len_line) = self.get_max_line_len();
-            self.max_len = max_len;
-            self.max_len_line = max_len_line;
-        } else {
-            let mut max_len = 0;
-            let mut max_len_line = 0;
-            for line in inval_lines.start_line
-                ..inval_lines.start_line + inval_lines.new_count
-            {
-                let line_len = self.line_len(line);
-                if line_len > max_len {
-                    max_len = line_len;
-                    max_len_line = line;
-                }
-            }
-            if max_len > self.max_len {
-                self.max_len = max_len;
-                self.max_len_line = max_len_line;
-            } else if self.max_len_line >= inval_lines.start_line {
-                self.max_len_line = self.max_len_line + inval_lines.new_count
-                    - inval_lines.inval_count;
-            }
-        }
-    }
-
-    fn update_styles(&mut self, delta: &RopeDelta) {
-        if let Some(styles) = self.semantic_styles.as_mut() {
-            Arc::make_mut(styles).apply_shape(delta);
-        } else if let Some(syntax) = self.syntax.as_mut() {
-            if let Some(styles) = syntax.styles.as_mut() {
-                Arc::make_mut(styles).apply_shape(delta);
-            }
-        }
-
-        if let Some(syntax) = self.syntax.as_mut() {
-            syntax.lens.apply_delta(delta);
-        }
-
-        self.line_styles.borrow_mut().clear();
-    }
-
-    fn mk_new_rev(
-        &self,
-        undo_group: usize,
-        delta: RopeDelta,
-    ) -> (Revision, Rope, Rope, Subset) {
-        let (ins_delta, deletes) = delta.factor();
-
-        let deletes_at_rev = &self.deletes_from_union;
-
-        let union_ins_delta = ins_delta.transform_expand(deletes_at_rev, true);
-        let mut new_deletes = deletes.transform_expand(deletes_at_rev);
-
-        let new_inserts = union_ins_delta.inserted_subset();
-        if !new_inserts.is_empty() {
-            new_deletes = new_deletes.transform_expand(&new_inserts);
-        }
-        let cur_deletes_from_union = &self.deletes_from_union;
-        let text_ins_delta =
-            union_ins_delta.transform_shrink(cur_deletes_from_union);
-        let text_with_inserts = text_ins_delta.apply(&self.rope);
-        let rebased_deletes_from_union =
-            cur_deletes_from_union.transform_expand(&new_inserts);
-
-        let undone = self.undone_groups.contains(&undo_group);
-        let new_deletes_from_union = {
-            let to_delete = if undone { &new_inserts } else { &new_deletes };
-            rebased_deletes_from_union.union(to_delete)
-        };
-
-        let (new_text, new_tombstones) = shuffle(
-            &text_with_inserts,
-            &self.tombstones,
-            &rebased_deletes_from_union,
-            &new_deletes_from_union,
-        );
-
-        let head_rev = &self.revs.last().unwrap();
-        (
-            Revision {
-                max_undo_so_far: std::cmp::max(undo_group, head_rev.max_undo_so_far),
-                edit: Contents::Edit {
-                    undo_group,
-                    inserts: new_inserts,
-                    deletes: new_deletes,
-                },
-            },
-            new_text,
-            new_tombstones,
-            new_deletes_from_union,
-        )
-    }
-
-    fn calculate_undo_group(&mut self, edit_type: EditType) -> usize {
-        let has_undos = !self.live_undos.is_empty();
-        let is_unbroken_group = !edit_type.breaks_undo_group(self.last_edit_type);
-
-        if has_undos && is_unbroken_group {
-            *self.live_undos.last().unwrap()
-        } else {
-            let undo_group = self.undo_group_id;
-            self.live_undos.truncate(self.cur_undo);
-            self.live_undos.push(undo_group);
-            self.cur_undo += 1;
-            self.undo_group_id += 1;
-            undo_group
-        }
-    }
-
-    fn apply_edit(
-        &mut self,
-        delta: &RopeDelta,
-        new_rev: Revision,
-        new_text: Rope,
-        new_tombstones: Rope,
-        new_deletes_from_union: Subset,
-    ) -> InvalLines {
-        self.rev += 1;
-        self.atomic_rev.store(self.rev, atomic::Ordering::Release);
-        self.dirty = true;
-
-        let (iv, newlen) = delta.summary();
-        let old_logical_end_line = self.rope.line_of_offset(iv.end) + 1;
-
-        self.revs.push(new_rev);
-        self.rope = new_text;
-        self.tombstones = new_tombstones;
-        self.deletes_from_union = new_deletes_from_union;
-        self.code_actions.clear();
-
-        let logical_start_line = self.rope.line_of_offset(iv.start);
-        let new_logical_end_line = self.rope.line_of_offset(iv.start + newlen) + 1;
-        let old_hard_count = old_logical_end_line - logical_start_line;
-        let new_hard_count = new_logical_end_line - logical_start_line;
-
-        InvalLines {
-            start_line: logical_start_line,
-            inval_count: old_hard_count,
-            new_count: new_hard_count,
-        }
-    }
-
-    pub fn update_edit_type(&mut self) {
-        self.last_edit_type = EditType::Other;
-    }
-
-    pub fn edit_multiple(
-        &mut self,
-        edits: &[(&Selection, &str)],
-        proxy: Arc<LapceProxy>,
-        edit_type: EditType,
-    ) -> RopeDelta {
-        let mut builder = DeltaBuilder::new(self.len());
-        let mut interval_rope = Vec::new();
-        for (selection, content) in edits {
-            let rope = Rope::from(content);
-            for region in selection.regions() {
-                interval_rope.push((region.min(), region.max(), rope.clone()));
-            }
-        }
-        interval_rope.sort_by(|a, b| {
-            if a.0 == b.0 && a.1 == b.1 {
-                Ordering::Equal
-            } else if a.1 == b.0 {
-                Ordering::Less
-            } else {
-                a.1.cmp(&b.0)
-            }
-        });
-        for (start, end, rope) in interval_rope.into_iter() {
-            builder.replace(start..end, rope);
-        }
-        let delta = builder.build();
-        let undo_group = self.calculate_undo_group(edit_type);
-        self.last_edit_type = edit_type;
-
-        let (new_rev, new_text, new_tombstones, new_deletes_from_union) =
-            self.mk_new_rev(undo_group, delta.clone());
-
-        if self.loaded {
-            let inval_lines = self.apply_edit(
-                &delta,
-                new_rev,
-                new_text,
-                new_tombstones,
-                new_deletes_from_union,
-            );
-
-            if !self.local {
-                proxy.update(self.id, &delta, self.rev);
-            }
-
-            self.update_size(&inval_lines);
-            self.update_styles(&delta);
-            self.find.borrow_mut().unset();
-            *self.find_progress.borrow_mut() = FindProgress::Started;
-            self.notify_update(Some(&delta));
-            self.notify_special();
-        }
-
-        delta
-    }
-
-    pub fn edit(
-        &mut self,
-        selection: &Selection,
-        content: &str,
-        proxy: Arc<LapceProxy>,
-        edit_type: EditType,
-    ) -> RopeDelta {
-        self.edit_multiple(&[(selection, content)], proxy, edit_type)
-    }
-
-    pub fn do_undo(&mut self, proxy: Arc<LapceProxy>) -> Option<RopeDelta> {
-        if self.cur_undo > 1 {
-            self.cur_undo -= 1;
-            self.undos.insert(self.live_undos[self.cur_undo]);
-            self.last_edit_type = EditType::Undo;
-            Some(self.undo(self.undos.clone(), proxy))
-        } else {
-            None
-        }
-    }
-
-    pub fn do_redo(&mut self, proxy: Arc<LapceProxy>) -> Option<RopeDelta> {
-        if self.cur_undo < self.live_undos.len() {
-            self.undos.remove(&self.live_undos[self.cur_undo]);
-            self.cur_undo += 1;
-            self.last_edit_type = EditType::Redo;
-            Some(self.undo(self.undos.clone(), proxy))
-        } else {
-            None
-        }
-    }
-
-    fn undo(
-        &mut self,
-        groups: BTreeSet<usize>,
-        proxy: Arc<LapceProxy>,
-    ) -> RopeDelta {
-        let (new_rev, new_deletes_from_union) = self.compute_undo(&groups);
-        let delta = Delta::synthesize(
-            &self.tombstones,
-            &self.deletes_from_union,
-            &new_deletes_from_union,
-        );
-        let new_text = delta.apply(&self.rope);
-        let new_tombstones = shuffle_tombstones(
-            &self.rope,
-            &self.tombstones,
-            &self.deletes_from_union,
-            &new_deletes_from_union,
-        );
-        self.undone_groups = groups;
-
-        if self.loaded {
-            let inval_lines = self.apply_edit(
-                &delta,
-                new_rev,
-                new_text,
-                new_tombstones,
-                new_deletes_from_union,
-            );
-
-            if !self.local {
-                proxy.update(self.id, &delta, self.rev);
-            }
-            self.update_size(&inval_lines);
-            self.update_styles(&delta);
-            self.find.borrow_mut().unset();
-            *self.find_progress.borrow_mut() = FindProgress::Started;
-            self.notify_update(Some(&delta));
-            self.notify_special();
-        }
-
-        delta
-    }
-
-    fn deletes_from_union_before_index(
-        &self,
-        rev_index: usize,
-        invert_undos: bool,
-    ) -> Cow<Subset> {
-        let mut deletes_from_union = Cow::Borrowed(&self.deletes_from_union);
-        let mut undone_groups = Cow::Borrowed(&self.undone_groups);
-
-        // invert the changes to deletes_from_union starting in the present and working backwards
-        for rev in self.revs[rev_index..].iter().rev() {
-            deletes_from_union = match rev.edit {
-                Contents::Edit {
-                    ref inserts,
-                    ref deletes,
-                    ref undo_group,
-                    ..
-                } => {
-                    if undone_groups.contains(undo_group) {
-                        // no need to un-delete undone inserts since we'll just shrink them out
-                        Cow::Owned(deletes_from_union.transform_shrink(inserts))
-                    } else {
-                        let un_deleted = deletes_from_union.subtract(deletes);
-                        Cow::Owned(un_deleted.transform_shrink(inserts))
-                    }
-                }
-                Contents::Undo {
-                    ref toggled_groups,
-                    ref deletes_bitxor,
-                } => {
-                    if invert_undos {
-                        let new_undone = undone_groups
-                            .symmetric_difference(toggled_groups)
-                            .cloned()
-                            .collect();
-                        undone_groups = Cow::Owned(new_undone);
-                        Cow::Owned(deletes_from_union.bitxor(deletes_bitxor))
-                    } else {
-                        deletes_from_union
-                    }
-                }
-            }
-        }
-        deletes_from_union
-    }
-
-    fn find_first_undo_candidate_index(
-        &self,
-        toggled_groups: &BTreeSet<usize>,
-    ) -> usize {
-        // find the lowest toggled undo group number
-        if let Some(lowest_group) = toggled_groups.iter().cloned().next() {
-            for (i, rev) in self.revs.iter().enumerate().rev() {
-                if rev.max_undo_so_far < lowest_group {
-                    return i + 1; // +1 since we know the one we just found doesn't have it
-                }
-            }
-            0
-        } else {
-            // no toggled groups, return past end
-            self.revs.len()
-        }
-    }
-
-    fn compute_undo(&self, groups: &BTreeSet<usize>) -> (Revision, Subset) {
-        let toggled_groups = self
-            .undone_groups
-            .symmetric_difference(groups)
-            .cloned()
-            .collect();
-        let first_candidate = self.find_first_undo_candidate_index(&toggled_groups);
-        // the `false` below: don't invert undos since our first_candidate is based on the current undo set, not past
-        let mut deletes_from_union = self
-            .deletes_from_union_before_index(first_candidate, false)
-            .into_owned();
-
-        for rev in &self.revs[first_candidate..] {
-            if let Contents::Edit {
-                ref undo_group,
-                ref inserts,
-                ref deletes,
-                ..
-            } = rev.edit
-            {
-                if groups.contains(undo_group) {
-                    if !inserts.is_empty() {
-                        deletes_from_union =
-                            deletes_from_union.transform_union(inserts);
-                    }
-                } else {
-                    if !inserts.is_empty() {
-                        deletes_from_union =
-                            deletes_from_union.transform_expand(inserts);
-                    }
-                    if !deletes.is_empty() {
-                        deletes_from_union = deletes_from_union.union(deletes);
-                    }
-                }
-            }
-        }
-
-        let deletes_bitxor = self.deletes_from_union.bitxor(&deletes_from_union);
-        let max_undo_so_far = self.revs.last().unwrap().max_undo_so_far;
-        (
-            Revision {
-                max_undo_so_far,
-                edit: Contents::Undo {
-                    toggled_groups,
-                    deletes_bitxor,
-                },
-            },
-            deletes_from_union,
-        )
     }
 }
 

--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -289,15 +289,15 @@ impl Buffer {
     }
 
     pub fn id(&self) -> BufferId {
-        self.data.id
+        self.data.id()
     }
 
     pub fn rope(&self) -> &Rope {
-        &self.data.rope
+        self.data.rope()
     }
 
     pub fn content(&self) -> &BufferContent {
-        &self.data.content
+        self.data.content()
     }
 
     pub fn max_len(&self) -> usize {

--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -215,26 +215,18 @@ pub struct Buffer {
     pub id: BufferId,
     pub rope: Rope,
     pub content: BufferContent,
-    pub syntax: Option<Syntax>,
-    pub indent_style: IndentStyle,
-    pub line_styles: Rc<RefCell<LineStyles>>,
-    pub semantic_styles: Option<Arc<Spans<Style>>>,
     pub max_len: usize,
     pub max_len_line: usize,
     pub num_lines: usize,
     pub rev: u64,
     pub atomic_rev: Arc<AtomicU64>,
     pub dirty: bool,
-    pub loaded: bool,
+    pub indent_style: IndentStyle,
     pub start_to_load: Rc<RefCell<bool>>,
-    pub local: bool,
-    pub histories: im::HashMap<String, Rope>,
+
     pub history_styles: im::HashMap<String, Arc<Spans<Style>>>,
     pub history_line_styles: Rc<RefCell<HashMap<String, LineStyles>>>,
     pub history_changes: im::HashMap<String, Arc<Vec<DiffLines>>>,
-
-    pub find: Rc<RefCell<Find>>,
-    pub find_progress: Rc<RefCell<FindProgress>>,
 
     revs: Vec<Revision>,
     cur_undo: usize,
@@ -252,6 +244,14 @@ pub struct Buffer {
 
     pub code_actions: im::HashMap<usize, CodeActionResponse>,
 
+    pub loaded: bool,
+    pub local: bool,
+    pub find: Rc<RefCell<Find>>,
+    pub find_progress: Rc<RefCell<FindProgress>>,
+    pub syntax: Option<Syntax>,
+    pub line_styles: Rc<RefCell<LineStyles>>,
+    pub semantic_styles: Option<Arc<Spans<Style>>>,
+    pub histories: im::HashMap<String, Rope>,
     tab_id: WidgetId,
     event_sink: ExtEventSink,
 }

--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -40,6 +40,8 @@ use crate::{
     state::Mode,
 };
 
+pub mod data;
+
 #[allow(dead_code)]
 const FIND_BATCH_SIZE: usize = 500000;
 

--- a/lapce-data/src/buffer/data.rs
+++ b/lapce-data/src/buffer/data.rs
@@ -1,0 +1,188 @@
+use lapce_rpc::buffer::BufferId;
+use std::cmp::Ordering;
+use std::sync::atomic::{self, AtomicU64};
+use std::{collections::BTreeSet, sync::Arc};
+use xi_rope::{multiset::Subset, rope::Rope, DeltaBuilder, RopeDelta};
+
+use crate::buffer::{
+    shuffle, BufferContent, Contents, EditType, InvalLines, Revision,
+};
+use crate::movement::Selection;
+
+#[derive(Clone)]
+pub struct BufferData {
+    pub id: BufferId,
+    pub rope: Rope,
+    pub content: BufferContent,
+
+    pub max_len: usize,
+    pub max_len_line: usize,
+    pub num_lines: usize,
+
+    pub rev: u64,
+    pub atomic_rev: Arc<AtomicU64>,
+    pub dirty: bool,
+
+    revs: Vec<Revision>,
+    cur_undo: usize,
+    undo_group_id: usize,
+    live_undos: Vec<usize>,
+    deletes_from_union: Subset,
+    undone_groups: BTreeSet<usize>,
+    tombstones: Rope,
+
+    last_edit_type: EditType,
+}
+
+impl BufferData {
+    pub fn len(&self) -> usize {
+        self.rope.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn mk_new_rev(
+        &self,
+        undo_group: usize,
+        delta: RopeDelta,
+    ) -> (Revision, Rope, Rope, Subset) {
+        let (ins_delta, deletes) = delta.factor();
+
+        let deletes_at_rev = &self.deletes_from_union;
+
+        let union_ins_delta = ins_delta.transform_expand(deletes_at_rev, true);
+        let mut new_deletes = deletes.transform_expand(deletes_at_rev);
+
+        let new_inserts = union_ins_delta.inserted_subset();
+        if !new_inserts.is_empty() {
+            new_deletes = new_deletes.transform_expand(&new_inserts);
+        }
+        let cur_deletes_from_union = &self.deletes_from_union;
+        let text_ins_delta =
+            union_ins_delta.transform_shrink(cur_deletes_from_union);
+        let text_with_inserts = text_ins_delta.apply(&self.rope);
+        let rebased_deletes_from_union =
+            cur_deletes_from_union.transform_expand(&new_inserts);
+
+        let undone = self.undone_groups.contains(&undo_group);
+        let new_deletes_from_union = {
+            let to_delete = if undone { &new_inserts } else { &new_deletes };
+            rebased_deletes_from_union.union(to_delete)
+        };
+
+        let (new_text, new_tombstones) = shuffle(
+            &text_with_inserts,
+            &self.tombstones,
+            &rebased_deletes_from_union,
+            &new_deletes_from_union,
+        );
+
+        let head_rev = &self.revs.last().unwrap();
+        (
+            Revision {
+                max_undo_so_far: std::cmp::max(undo_group, head_rev.max_undo_so_far),
+                edit: Contents::Edit {
+                    undo_group,
+                    inserts: new_inserts,
+                    deletes: new_deletes,
+                },
+            },
+            new_text,
+            new_tombstones,
+            new_deletes_from_union,
+        )
+    }
+
+    fn calculate_undo_group(&mut self, edit_type: EditType) -> usize {
+        let has_undos = !self.live_undos.is_empty();
+        let is_unbroken_group = !edit_type.breaks_undo_group(self.last_edit_type);
+
+        if has_undos && is_unbroken_group {
+            *self.live_undos.last().unwrap()
+        } else {
+            let undo_group = self.undo_group_id;
+            self.live_undos.truncate(self.cur_undo);
+            self.live_undos.push(undo_group);
+            self.cur_undo += 1;
+            self.undo_group_id += 1;
+            undo_group
+        }
+    }
+
+    pub fn edit_multiple(
+        &mut self,
+        edits: &[(&Selection, &str)],
+        edit_type: EditType,
+    ) -> (RopeDelta, InvalLines) {
+        let mut builder = DeltaBuilder::new(self.len());
+        let mut interval_rope = Vec::new();
+        for (selection, content) in edits {
+            let rope = Rope::from(content);
+            for region in selection.regions() {
+                interval_rope.push((region.min(), region.max(), rope.clone()));
+            }
+        }
+        interval_rope.sort_by(|a, b| {
+            if a.0 == b.0 && a.1 == b.1 {
+                Ordering::Equal
+            } else if a.1 == b.0 {
+                Ordering::Less
+            } else {
+                a.1.cmp(&b.0)
+            }
+        });
+        for (start, end, rope) in interval_rope.into_iter() {
+            builder.replace(start..end, rope);
+        }
+        let delta = builder.build();
+        let undo_group = self.calculate_undo_group(edit_type);
+        self.last_edit_type = edit_type;
+
+        let (new_rev, new_text, new_tombstones, new_deletes_from_union) =
+            self.mk_new_rev(undo_group, delta.clone());
+
+        let invalidated = self.apply_edit(
+            &delta,
+            new_rev,
+            new_text,
+            new_tombstones,
+            new_deletes_from_union,
+        );
+
+        (delta, invalidated)
+    }
+
+    fn apply_edit(
+        &mut self,
+        delta: &RopeDelta,
+        new_rev: Revision,
+        new_text: Rope,
+        new_tombstones: Rope,
+        new_deletes_from_union: Subset,
+    ) -> InvalLines {
+        self.rev += 1;
+        self.atomic_rev.store(self.rev, atomic::Ordering::Release);
+        self.dirty = true;
+
+        let (iv, newlen) = delta.summary();
+        let old_logical_end_line = self.rope.line_of_offset(iv.end) + 1;
+
+        self.revs.push(new_rev);
+        self.rope = new_text;
+        self.tombstones = new_tombstones;
+        self.deletes_from_union = new_deletes_from_union;
+
+        let logical_start_line = self.rope.line_of_offset(iv.start);
+        let new_logical_end_line = self.rope.line_of_offset(iv.start + newlen) + 1;
+        let old_hard_count = old_logical_end_line - logical_start_line;
+        let new_hard_count = new_logical_end_line - logical_start_line;
+
+        InvalLines {
+            start_line: logical_start_line,
+            inval_count: old_hard_count,
+            new_count: new_hard_count,
+        }
+    }
+}

--- a/lapce-data/src/buffer/data.rs
+++ b/lapce-data/src/buffer/data.rs
@@ -1,11 +1,14 @@
 use lapce_rpc::buffer::BufferId;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::sync::atomic::{self, AtomicU64};
 use std::{collections::BTreeSet, sync::Arc};
+use xi_rope::Delta;
 use xi_rope::{multiset::Subset, rope::Rope, DeltaBuilder, RopeDelta};
 
 use crate::buffer::{
-    shuffle, BufferContent, Contents, EditType, InvalLines, Revision,
+    shuffle, shuffle_tombstones, BufferContent, Contents, EditType, InvalLines,
+    Revision,
 };
 use crate::movement::Selection;
 
@@ -31,6 +34,7 @@ pub struct BufferData<L> {
 
     revs: Vec<Revision>,
     cur_undo: usize,
+    undos: BTreeSet<usize>,
     undo_group_id: usize,
     live_undos: Vec<usize>,
     deletes_from_union: Subset,
@@ -193,5 +197,170 @@ impl<L: BufferDataListener> BufferData<L> {
             inval_count: old_hard_count,
             new_count: new_hard_count,
         });
+    }
+
+    pub fn do_undo(&mut self) -> Option<RopeDelta> {
+        if self.cur_undo > 1 {
+            self.cur_undo -= 1;
+            self.undos.insert(self.live_undos[self.cur_undo]);
+            self.last_edit_type = EditType::Undo;
+            Some(self.undo(self.undos.clone()))
+        } else {
+            None
+        }
+    }
+
+    pub fn do_redo(&mut self) -> Option<RopeDelta> {
+        if self.cur_undo < self.live_undos.len() {
+            self.undos.remove(&self.live_undos[self.cur_undo]);
+            self.cur_undo += 1;
+            self.last_edit_type = EditType::Redo;
+            Some(self.undo(self.undos.clone()))
+        } else {
+            None
+        }
+    }
+
+    fn undo(&mut self, groups: BTreeSet<usize>) -> RopeDelta {
+        let (new_rev, new_deletes_from_union) = self.compute_undo(&groups);
+        let delta = Delta::synthesize(
+            &self.tombstones,
+            &self.deletes_from_union,
+            &new_deletes_from_union,
+        );
+        let new_text = delta.apply(&self.rope);
+        let new_tombstones = shuffle_tombstones(
+            &self.rope,
+            &self.tombstones,
+            &self.deletes_from_union,
+            &new_deletes_from_union,
+        );
+        self.undone_groups = groups;
+
+        if self.listener.should_apply_edit() {
+            self.apply_edit(
+                &delta,
+                new_rev,
+                new_text,
+                new_tombstones,
+                new_deletes_from_union,
+            );
+        }
+
+        delta
+    }
+
+    fn deletes_from_union_before_index(
+        &self,
+        rev_index: usize,
+        invert_undos: bool,
+    ) -> Cow<Subset> {
+        let mut deletes_from_union = Cow::Borrowed(&self.deletes_from_union);
+        let mut undone_groups = Cow::Borrowed(&self.undone_groups);
+
+        // invert the changes to deletes_from_union starting in the present and working backwards
+        for rev in self.revs[rev_index..].iter().rev() {
+            deletes_from_union = match rev.edit {
+                Contents::Edit {
+                    ref inserts,
+                    ref deletes,
+                    ref undo_group,
+                    ..
+                } => {
+                    if undone_groups.contains(undo_group) {
+                        // no need to un-delete undone inserts since we'll just shrink them out
+                        Cow::Owned(deletes_from_union.transform_shrink(inserts))
+                    } else {
+                        let un_deleted = deletes_from_union.subtract(deletes);
+                        Cow::Owned(un_deleted.transform_shrink(inserts))
+                    }
+                }
+                Contents::Undo {
+                    ref toggled_groups,
+                    ref deletes_bitxor,
+                } => {
+                    if invert_undos {
+                        let new_undone = undone_groups
+                            .symmetric_difference(toggled_groups)
+                            .cloned()
+                            .collect();
+                        undone_groups = Cow::Owned(new_undone);
+                        Cow::Owned(deletes_from_union.bitxor(deletes_bitxor))
+                    } else {
+                        deletes_from_union
+                    }
+                }
+            }
+        }
+        deletes_from_union
+    }
+
+    fn find_first_undo_candidate_index(
+        &self,
+        toggled_groups: &BTreeSet<usize>,
+    ) -> usize {
+        // find the lowest toggled undo group number
+        if let Some(lowest_group) = toggled_groups.iter().cloned().next() {
+            for (i, rev) in self.revs.iter().enumerate().rev() {
+                if rev.max_undo_so_far < lowest_group {
+                    return i + 1; // +1 since we know the one we just found doesn't have it
+                }
+            }
+            0
+        } else {
+            // no toggled groups, return past end
+            self.revs.len()
+        }
+    }
+
+    fn compute_undo(&self, groups: &BTreeSet<usize>) -> (Revision, Subset) {
+        let toggled_groups = self
+            .undone_groups
+            .symmetric_difference(groups)
+            .cloned()
+            .collect();
+        let first_candidate = self.find_first_undo_candidate_index(&toggled_groups);
+        // the `false` below: don't invert undos since our first_candidate is based on the current undo set, not past
+        let mut deletes_from_union = self
+            .deletes_from_union_before_index(first_candidate, false)
+            .into_owned();
+
+        for rev in &self.revs[first_candidate..] {
+            if let Contents::Edit {
+                ref undo_group,
+                ref inserts,
+                ref deletes,
+                ..
+            } = rev.edit
+            {
+                if groups.contains(undo_group) {
+                    if !inserts.is_empty() {
+                        deletes_from_union =
+                            deletes_from_union.transform_union(inserts);
+                    }
+                } else {
+                    if !inserts.is_empty() {
+                        deletes_from_union =
+                            deletes_from_union.transform_expand(inserts);
+                    }
+                    if !deletes.is_empty() {
+                        deletes_from_union = deletes_from_union.union(deletes);
+                    }
+                }
+            }
+        }
+
+        let deletes_bitxor = self.deletes_from_union.bitxor(&deletes_from_union);
+        let max_undo_so_far = self.revs.last().unwrap().max_undo_so_far;
+        (
+            Revision {
+                max_undo_so_far,
+                edit: Contents::Undo {
+                    toggled_groups,
+                    deletes_bitxor,
+                },
+            },
+            deletes_from_union,
+        )
     }
 }

--- a/lapce-data/src/buffer/data.rs
+++ b/lapce-data/src/buffer/data.rs
@@ -15,12 +15,7 @@ use crate::movement::Selection;
 pub trait BufferDataListener {
     fn should_apply_edit(&self) -> bool;
 
-    fn on_edit_applied(
-        &mut self,
-        buffer: &BufferData,
-        delta: &RopeDelta,
-        inval_lines: InvalLines,
-    );
+    fn on_edit_applied(&mut self, buffer: &BufferData, delta: &RopeDelta);
 }
 
 #[derive(Clone)]
@@ -452,8 +447,7 @@ impl<L: BufferDataListener> EditableBufferData<'_, L> {
         );
 
         self.buffer.update_size(&inval_lines);
-        self.listener
-            .on_edit_applied(&self.buffer, delta, inval_lines);
+        self.listener.on_edit_applied(&self.buffer, delta);
     }
 
     fn undo(&mut self, groups: BTreeSet<usize>) -> RopeDelta {

--- a/lapce-data/src/buffer/data.rs
+++ b/lapce-data/src/buffer/data.rs
@@ -91,6 +91,18 @@ impl BufferData {
         self.len() == 0
     }
 
+    pub fn id(&self) -> BufferId {
+        self.id
+    }
+
+    pub fn rope(&self) -> &Rope {
+        &self.rope
+    }
+
+    pub fn content(&self) -> &BufferContent {
+        &self.content
+    }
+
     pub fn indent_unit(&self) -> &'static str {
         self.indent_style.as_str()
     }

--- a/lapce-data/src/buffer/data.rs
+++ b/lapce-data/src/buffer/data.rs
@@ -20,28 +20,28 @@ pub trait BufferDataListener {
 
 #[derive(Clone)]
 pub struct BufferData {
-    pub id: BufferId,
-    pub rope: Rope,
-    pub content: BufferContent,
+    pub(super) id: BufferId,
+    pub(super) rope: Rope,
+    pub(super) content: BufferContent,
 
-    pub max_len: usize,
-    pub max_len_line: usize,
-    pub num_lines: usize,
+    pub(super) max_len: usize,
+    pub(super) max_len_line: usize,
+    pub(super) num_lines: usize,
 
-    pub rev: u64,
-    pub atomic_rev: Arc<AtomicU64>,
-    pub dirty: bool,
+    pub(super) rev: u64,
+    pub(super) atomic_rev: Arc<AtomicU64>,
+    pub(super) dirty: bool,
 
-    revs: Vec<Revision>,
-    cur_undo: usize,
-    undos: BTreeSet<usize>,
-    undo_group_id: usize,
-    live_undos: Vec<usize>,
-    deletes_from_union: Subset,
-    undone_groups: BTreeSet<usize>,
-    tombstones: Rope,
+    pub(super) revs: Vec<Revision>,
+    pub(super) cur_undo: usize,
+    pub(super) undos: BTreeSet<usize>,
+    pub(super) undo_group_id: usize,
+    pub(super) live_undos: Vec<usize>,
+    pub(super) deletes_from_union: Subset,
+    pub(super) undone_groups: BTreeSet<usize>,
+    pub(super) tombstones: Rope,
 
-    last_edit_type: EditType,
+    pub(super) last_edit_type: EditType,
 }
 
 impl BufferData {
@@ -53,7 +53,7 @@ impl BufferData {
         self.len() == 0
     }
 
-    fn mk_new_rev(
+    pub(super) fn mk_new_rev(
         &self,
         undo_group: usize,
         delta: RopeDelta,
@@ -342,12 +342,29 @@ impl BufferData {
         }
         (max_len, max_len_line)
     }
+
+    pub(super) fn reset_revs(&mut self) {
+        self.rope = Rope::from("");
+        self.revs = vec![Revision {
+            max_undo_so_far: 0,
+            edit: Contents::Undo {
+                toggled_groups: BTreeSet::new(),
+                deletes_bitxor: Subset::new(0),
+            },
+        }];
+        self.cur_undo = 1;
+        self.undo_group_id = 1;
+        self.live_undos = vec![0];
+        self.deletes_from_union = Subset::new(0);
+        self.undone_groups = BTreeSet::new();
+        self.tombstones = Rope::default();
+    }
 }
 
 /// Make BufferData temporarily editable by attaching a listener object to it.
 pub struct EditableBufferData<'a, L> {
-    listener: L,
-    buffer: &'a mut BufferData,
+    pub(super) listener: L,
+    pub(super) buffer: &'a mut BufferData,
 }
 
 impl<L: BufferDataListener> EditableBufferData<'_, L> {

--- a/lapce-data/src/buffer/decoration.rs
+++ b/lapce-data/src/buffer/decoration.rs
@@ -20,20 +20,20 @@ use crate::{
 
 #[derive(Clone)]
 pub struct BufferDecoration {
-    pub loaded: bool,
-    pub local: bool,
+    pub(super) loaded: bool,
+    pub(super) local: bool,
 
-    pub find: Rc<RefCell<Find>>,
-    pub find_progress: Rc<RefCell<FindProgress>>,
+    pub(super) find: Rc<RefCell<Find>>,
+    pub(super) find_progress: Rc<RefCell<FindProgress>>,
 
-    pub syntax: Option<Syntax>,
-    pub line_styles: Rc<RefCell<LineStyles>>,
-    pub semantic_styles: Option<Arc<Spans<Style>>>,
+    pub(super) syntax: Option<Syntax>,
+    pub(super) line_styles: Rc<RefCell<LineStyles>>,
+    pub(super) semantic_styles: Option<Arc<Spans<Style>>>,
 
-    pub histories: im::HashMap<String, Rope>,
+    pub(super) histories: im::HashMap<String, Rope>,
 
-    tab_id: WidgetId,
-    event_sink: ExtEventSink,
+    pub(super) tab_id: WidgetId,
+    pub(super) event_sink: ExtEventSink,
 }
 
 impl BufferDecoration {

--- a/lapce-data/src/buffer/decoration.rs
+++ b/lapce-data/src/buffer/decoration.rs
@@ -1,0 +1,176 @@
+use druid::{ExtEventSink, Target, WidgetId};
+use lapce_core::syntax::Syntax;
+use lapce_rpc::style::{LineStyles, Style};
+use std::{
+    cell::RefCell,
+    path::PathBuf,
+    rc::Rc,
+    sync::{
+        atomic::{self},
+        Arc,
+    },
+};
+use xi_rope::{rope::Rope, spans::Spans, RopeDelta};
+
+use crate::{
+    buffer::{data::BufferData, rope_diff, BufferContent, LocalBufferKind},
+    command::{LapceUICommand, LAPCE_UI_COMMAND},
+    find::{Find, FindProgress},
+};
+
+#[derive(Clone)]
+pub struct BufferDecoration {
+    pub loaded: bool,
+    pub local: bool,
+
+    pub find: Rc<RefCell<Find>>,
+    pub find_progress: Rc<RefCell<FindProgress>>,
+
+    pub syntax: Option<Syntax>,
+    pub line_styles: Rc<RefCell<LineStyles>>,
+    pub semantic_styles: Option<Arc<Spans<Style>>>,
+
+    pub histories: im::HashMap<String, Rope>,
+
+    tab_id: WidgetId,
+    event_sink: ExtEventSink,
+}
+
+impl BufferDecoration {
+    pub fn update_styles(&mut self, delta: &RopeDelta) {
+        if let Some(styles) = self.semantic_styles.as_mut() {
+            Arc::make_mut(styles).apply_shape(delta);
+        } else if let Some(syntax) = self.syntax.as_mut() {
+            if let Some(styles) = syntax.styles.as_mut() {
+                Arc::make_mut(styles).apply_shape(delta);
+            }
+        }
+
+        if let Some(syntax) = self.syntax.as_mut() {
+            syntax.lens.apply_delta(delta);
+        }
+
+        self.line_styles.borrow_mut().clear();
+    }
+
+    pub fn notify_special(&self, buffer: &BufferData) {
+        match &buffer.content {
+            BufferContent::File(_) => {}
+            BufferContent::Local(local) => {
+                let s = buffer.rope.to_string();
+                match local {
+                    LocalBufferKind::Search => {
+                        let _ = self.event_sink.submit_command(
+                            LAPCE_UI_COMMAND,
+                            LapceUICommand::UpdateSearch(s),
+                            Target::Widget(self.tab_id),
+                        );
+                    }
+                    LocalBufferKind::SourceControl => {}
+                    LocalBufferKind::Empty => {}
+                    LocalBufferKind::FilePicker => {
+                        let pwd = PathBuf::from(s);
+                        let _ = self.event_sink.submit_command(
+                            LAPCE_UI_COMMAND,
+                            LapceUICommand::UpdatePickerPwd(pwd),
+                            Target::Widget(self.tab_id),
+                        );
+                    }
+                    LocalBufferKind::Keymap => {
+                        let _ = self.event_sink.submit_command(
+                            LAPCE_UI_COMMAND,
+                            LapceUICommand::UpdateKeymapsFilter(s),
+                            Target::Widget(self.tab_id),
+                        );
+                    }
+                    LocalBufferKind::Settings => {
+                        let _ = self.event_sink.submit_command(
+                            LAPCE_UI_COMMAND,
+                            LapceUICommand::UpdateSettingsFilter(s),
+                            Target::Widget(self.tab_id),
+                        );
+                    }
+                }
+            }
+            BufferContent::Value(_) => {}
+        }
+    }
+
+    pub fn notify_update(&self, buffer: &BufferData, delta: Option<&RopeDelta>) {
+        self.trigger_syntax_change(buffer, delta);
+        self.trigger_history_change(buffer);
+    }
+
+    fn trigger_syntax_change(&self, buffer: &BufferData, delta: Option<&RopeDelta>) {
+        if let BufferContent::File(path) = &buffer.content {
+            if let Some(syntax) = self.syntax.clone() {
+                let path = path.clone();
+                let rev = buffer.rev;
+                let text = buffer.rope.clone();
+                let delta = delta.cloned();
+                let atomic_rev = buffer.atomic_rev.clone();
+                let event_sink = self.event_sink.clone();
+                let tab_id = self.tab_id;
+                rayon::spawn(move || {
+                    if atomic_rev.load(atomic::Ordering::Acquire) != rev {
+                        return;
+                    }
+                    let new_syntax = syntax.parse(rev, text, delta);
+                    if atomic_rev.load(atomic::Ordering::Acquire) != rev {
+                        return;
+                    }
+                    let _ = event_sink.submit_command(
+                        LAPCE_UI_COMMAND,
+                        LapceUICommand::UpdateSyntax {
+                            path,
+                            rev,
+                            syntax: new_syntax,
+                        },
+                        Target::Widget(tab_id),
+                    );
+                });
+            }
+        }
+    }
+
+    fn trigger_history_change(&self, buffer: &BufferData) {
+        if let BufferContent::File(path) = &buffer.content {
+            if let Some(head) = self.histories.get("head") {
+                let id = buffer.id;
+                let rev = buffer.rev;
+                let atomic_rev = buffer.atomic_rev.clone();
+                let path = path.clone();
+                let left_rope = head.clone();
+                let right_rope = buffer.rope.clone();
+                let event_sink = self.event_sink.clone();
+                let tab_id = self.tab_id;
+                rayon::spawn(move || {
+                    if atomic_rev.load(atomic::Ordering::Acquire) != rev {
+                        return;
+                    }
+                    let changes =
+                        rope_diff(left_rope, right_rope, rev, atomic_rev.clone());
+                    if changes.is_none() {
+                        return;
+                    }
+                    let changes = changes.unwrap();
+                    if atomic_rev.load(atomic::Ordering::Acquire) != rev {
+                        return;
+                    }
+
+                    let _ = event_sink.submit_command(
+                        LAPCE_UI_COMMAND,
+                        LapceUICommand::UpdateHistoryChanges {
+                            id,
+                            path,
+                            rev,
+                            history: "head".to_string(),
+                            changes: Arc::new(changes),
+                        },
+                        Target::Widget(tab_id),
+                    );
+                });
+            }
+        }
+    }
+}

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2389,7 +2389,7 @@ impl LapceMainSplitData {
             };
 
             if let Some(compare) = location.history.as_ref() {
-                if !buffer.histories.contains_key(compare) {
+                if !buffer.histories().contains_key(compare) {
                     buffer.retrieve_file_head(
                         *self.tab_id,
                         self.proxy.clone(),

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -30,8 +30,8 @@ use xi_rope::{RopeDelta, Transformer};
 
 use crate::{
     buffer::{
-        matching_char, matching_pair_direction, Buffer, BufferContent, EditType,
-        LocalBufferKind,
+        data::BufferData, matching_char, matching_pair_direction, Buffer,
+        BufferContent, EditType, LocalBufferKind,
     },
     command::{
         CommandTarget, EnsureVisiblePosition, LapceCommandNew, LapceUICommand,
@@ -2314,7 +2314,7 @@ impl LapceMainSplitData {
             Some(location.path.clone()),
             config,
         );
-        editor.save_jump_location(&buffer, config.editor.tab_width);
+        editor.save_jump_location(buffer.data(), config.editor.tab_width);
         self.go_to_location(ctx, Some(editor_view_id), location, config);
         editor_view_id
     }
@@ -3071,7 +3071,7 @@ impl LapceEditorData {
         placeholders.extend_from_slice(&v[1..]);
     }
 
-    pub fn save_jump_location(&mut self, buffer: &Buffer, tab_width: usize) {
+    pub fn save_jump_location(&mut self, buffer: &BufferData, tab_width: usize) {
         if let BufferContent::File(path) = buffer.content() {
             let location = EditorLocationNew {
                 path: path.clone(),

--- a/lapce-data/src/db.rs
+++ b/lapce-data/src/db.rs
@@ -486,7 +486,7 @@ impl LapceDb {
     }
 
     pub fn save_buffer_position(&self, workspace: &LapceWorkspace, buffer: &Buffer) {
-        if let BufferContent::File(path) = &buffer.content {
+        if let BufferContent::File(path) = buffer.content() {
             let info = BufferInfo {
                 workspace: workspace.clone(),
                 path: path.clone(),

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1654,8 +1654,7 @@ impl LapceEditorBufferData {
         config: &Config,
     ) -> usize {
         let (line, char_width) = if self.editor.code_lens {
-            let (line, font_size) = if let Some(syntax) = self.buffer.syntax.as_ref()
-            {
+            let (line, font_size) = if let Some(syntax) = self.buffer.syntax() {
                 let line = syntax.lens.line_of_height(pos.y.floor() as usize);
                 let line_height = syntax.lens.height_of_line(line + 1)
                     - syntax.lens.height_of_line(line);
@@ -2937,8 +2936,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                     .edit_selection(&self.buffer, self.config.editor.tab_width);
                 let comment_token = self
                     .buffer
-                    .syntax
-                    .as_ref()
+                    .syntax()
                     .map(|s| s.language.comment_token())
                     .unwrap_or("//")
                     .to_string();

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -308,7 +308,10 @@ impl LapceEditorBufferData {
     fn do_move(&mut self, movement: &Movement, count: usize, mods: Modifiers) {
         if movement.is_jump() && movement != &self.editor.last_movement {
             let editor = Arc::make_mut(&mut self.editor);
-            editor.save_jump_location(&self.buffer, self.config.editor.tab_width);
+            editor.save_jump_location(
+                self.buffer.data(),
+                self.config.editor.tab_width,
+            );
         }
         let editor = Arc::make_mut(&mut self.editor);
         editor.last_movement = movement.clone();
@@ -1506,7 +1509,10 @@ impl LapceEditorBufferData {
         }
         if self.editor.current_location >= self.editor.locations.len() {
             let editor = Arc::make_mut(&mut self.editor);
-            editor.save_jump_location(&self.buffer, self.config.editor.tab_width);
+            editor.save_jump_location(
+                self.buffer.data(),
+                self.config.editor.tab_width,
+            );
             editor.current_location -= 1;
         }
         let editor = Arc::make_mut(&mut self.editor);

--- a/lapce-data/src/movement.rs
+++ b/lapce-data/src/movement.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use xi_rope::{RopeDelta, Transformer};
 
 use crate::{
-    buffer::Buffer,
+    buffer::data::BufferData,
     config::Config,
     data::RegisterData,
     state::{Mode, VisualMode},
@@ -70,7 +70,7 @@ impl Cursor {
         }
     }
 
-    pub fn current_line(&self, buffer: &Buffer) -> usize {
+    pub fn current_line(&self, buffer: &BufferData) -> usize {
         buffer.line_of_offset(self.offset())
     }
 
@@ -209,7 +209,7 @@ impl Cursor {
 
     pub fn current_char(
         &self,
-        buffer: &Buffer,
+        buffer: &BufferData,
         char_width: f64,
         config: &Config,
     ) -> (f64, f64) {
@@ -228,7 +228,7 @@ impl Cursor {
         (x0, x1)
     }
 
-    pub fn lines(&self, buffer: &Buffer) -> (usize, usize) {
+    pub fn lines(&self, buffer: &BufferData) -> (usize, usize) {
         match &self.mode {
             CursorMode::Normal(offset) => {
                 let line = buffer.line_of_offset(*offset);
@@ -247,7 +247,7 @@ impl Cursor {
         }
     }
 
-    pub fn yank(&self, buffer: &Buffer, tab_width: usize) -> RegisterData {
+    pub fn yank(&self, buffer: &BufferData, tab_width: usize) -> RegisterData {
         let (content, mode) = match &self.mode {
             CursorMode::Insert(selection) => {
                 let mut mode = VisualMode::Normal;
@@ -340,7 +340,11 @@ impl Cursor {
         RegisterData { content, mode }
     }
 
-    pub fn edit_selection(&self, buffer: &Buffer, tab_width: usize) -> Selection {
+    pub fn edit_selection(
+        &self,
+        buffer: &BufferData,
+        tab_width: usize,
+    ) -> Selection {
         match &self.mode {
             CursorMode::Insert(selection) => selection.clone(),
             CursorMode::Normal(offset) => Selection::region(

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -835,7 +835,7 @@ impl PaletteViewData {
         let last_line_number_len = last_line_number.to_string().len();
         let palette = Arc::make_mut(&mut self.palette);
         palette.items = buffer
-            .rope
+            .rope()
             .lines(0..buffer.len())
             .enumerate()
             .map(|(i, l)| {
@@ -871,7 +871,7 @@ impl PaletteViewData {
 
         if let BufferContent::File(path) = &editor.content {
             let path = path.clone();
-            let buffer_id = self.main_split.open_files.get(&path).unwrap().id;
+            let buffer_id = self.main_split.open_files.get(&path).unwrap().id();
             let run_id = self.palette.run_id.clone();
             let event_sink = ctx.get_external_handle();
 

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -238,16 +238,16 @@ impl LapceEditor {
                         let height =
                             syntax.lens.height_of_line(syntax.lens.len() + 1);
                         Size::new(
-                            (width * data.buffer.max_len as f64)
+                            (width * data.buffer.max_len() as f64)
                                 .max(editor_size.width),
                             (height as f64 - line_height).max(0.0)
                                 + editor_size.height,
                         )
                     } else {
-                        let height = data.buffer.num_lines
+                        let height = data.buffer.num_lines()
                             * data.config.editor.code_lens_font_size;
                         Size::new(
-                            (width * data.buffer.max_len as f64)
+                            (width * data.buffer.max_len() as f64)
                                 .max(editor_size.width),
                             (height as f64 - line_height).max(0.0)
                                 + editor_size.height,
@@ -266,14 +266,16 @@ impl LapceEditor {
                         }
                     }
                     Size::new(
-                        (width * data.buffer.max_len as f64).max(editor_size.width),
+                        (width * data.buffer.max_len() as f64)
+                            .max(editor_size.width),
                         (line_height * lines as f64 - line_height).max(0.0)
                             + editor_size.height,
                     )
                 } else {
                     Size::new(
-                        (width * data.buffer.max_len as f64).max(editor_size.width),
-                        (line_height * data.buffer.num_lines as f64 - line_height)
+                        (width * data.buffer.max_len() as f64)
+                            .max(editor_size.width),
+                        (line_height * data.buffer.num_lines() as f64 - line_height)
                             .max(0.0)
                             + editor_size.height,
                     )
@@ -284,7 +286,7 @@ impl LapceEditor {
                 | LocalBufferKind::Search
                 | LocalBufferKind::Settings
                 | LocalBufferKind::Keymap => Size::new(
-                    editor_size.width.max(width * data.buffer.rope.len() as f64),
+                    editor_size.width.max(width * data.buffer.len() as f64),
                     env.get(LapceTheme::INPUT_LINE_HEIGHT)
                         + env.get(LapceTheme::INPUT_LINE_PADDING) * 2.0,
                 ),
@@ -305,7 +307,7 @@ impl LapceEditor {
                                                 * data.buffer.num_lines() as f64,
                                         );
                                         Size::new(
-                                            (width * data.buffer.max_len as f64)
+                                            (width * data.buffer.max_len() as f64)
                                                 .max(editor_size.width),
                                             height,
                                         )
@@ -319,7 +321,7 @@ impl LapceEditor {
                 LocalBufferKind::Empty => editor_size,
             },
             BufferContent::Value(_) => Size::new(
-                editor_size.width.max(width * data.buffer.rope.len() as f64),
+                editor_size.width.max(width * data.buffer.len() as f64),
                 env.get(LapceTheme::INPUT_LINE_HEIGHT)
                     + env.get(LapceTheme::INPUT_LINE_PADDING) * 2.0,
             ),
@@ -372,7 +374,7 @@ impl LapceEditor {
             .min(last_line);
         let start_offset = data.buffer.offset_of_line(start_line);
         let end_offset = data.buffer.offset_of_line(end_line + 1);
-        let mut lines_iter = data.buffer.rope.lines(start_offset..end_offset);
+        let mut lines_iter = data.buffer.rope().lines(start_offset..end_offset);
 
         let mut y = lens.height_of_line(start_line) as f64;
         for (line, line_height) in lens.iter_chunks(start_line..end_line + 1) {

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -234,7 +234,7 @@ impl LapceEditor {
         match &data.editor.content {
             BufferContent::File(_) => {
                 if data.editor.code_lens {
-                    if let Some(syntax) = data.buffer.syntax.as_ref() {
+                    if let Some(syntax) = data.buffer.syntax() {
                         let height =
                             syntax.lens.height_of_line(syntax.lens.len() + 1);
                         Size::new(
@@ -357,7 +357,7 @@ impl LapceEditor {
             data.config.editor.code_lens_font_size,
             &[],
         );
-        let lens = if let Some(syntax) = data.buffer.syntax.as_ref() {
+        let lens = if let Some(syntax) = data.buffer.syntax() {
             &syntax.lens
         } else {
             &empty_lens
@@ -1265,7 +1265,7 @@ impl LapceEditor {
         if data.find.search_string.is_some() {
             for region in data
                 .buffer
-                .find
+                .find()
                 .borrow()
                 .occurrences()
                 .regions_in_range(start_offset, end_offset)

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -944,7 +944,7 @@ impl LapceEditor {
                 CursorMode::Normal(_) | CursorMode::Visual { .. } => {
                     if is_focused {
                         let (x0, x1) = data.editor.cursor.current_char(
-                            &data.buffer,
+                            data.buffer.data(),
                             char_width,
                             &data.config,
                         );
@@ -987,7 +987,7 @@ impl LapceEditor {
 
                 if is_focused {
                     let (x0, x1) = data.editor.cursor.current_char(
-                        &data.buffer,
+                        data.buffer.data(),
                         width,
                         &data.config,
                     );
@@ -1094,7 +1094,7 @@ impl LapceEditor {
                         let line = data.buffer.line_of_offset(*end);
 
                         let (x0, x1) = data.editor.cursor.current_char(
-                            &data.buffer,
+                            data.buffer.data(),
                             width,
                             &data.config,
                         );

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -359,7 +359,7 @@ impl LapceEditorGutter {
             data.config.editor.code_lens_font_size,
             &[],
         );
-        let lens = if let Some(syntax) = data.buffer.syntax.as_ref() {
+        let lens = if let Some(syntax) = data.buffer.syntax() {
             &syntax.lens
         } else {
             &empty_lens

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -1,3 +1,4 @@
+use crate::svg::get_svg;
 use druid::{
     piet::{Text, TextLayout, TextLayoutBuilder},
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
@@ -9,7 +10,6 @@ use lapce_data::{
     data::LapceTabData,
     editor::{LapceEditorBufferData, Syntax},
 };
-use crate::svg::get_svg;
 
 pub struct LapceEditorGutter {
     view_id: WidgetId,
@@ -121,7 +121,7 @@ impl LapceEditorGutter {
         let start_line = (scroll_offset.y / line_height).floor() as usize;
         let end_line =
             (scroll_offset.y + rect.height() / line_height).ceil() as usize;
-        let current_line = data.editor.cursor.current_line(&data.buffer);
+        let current_line = data.editor.cursor.current_line(data.buffer.data());
         let last_line = data.buffer.last_line();
         let width = data.config.editor_char_width(ctx.text());
 
@@ -378,9 +378,7 @@ impl LapceEditorGutter {
                     + data.config.editor.line_height,
             )
             .min(last_line);
-        let char_width = data
-            .config
-            .editor_char_width(ctx.text());
+        let char_width = data.config.editor_char_width(ctx.text());
         let max_line_width = (last_line + 1).to_string().len() as f64 * char_width;
 
         let mut y = lens.height_of_line(start_line) as f64;
@@ -484,7 +482,7 @@ impl LapceEditorGutter {
             let start_line = (scroll_offset.y / line_height).floor() as usize;
             let num_lines = (ctx.size().height / line_height).floor() as usize;
             let last_line = data.buffer.last_line();
-            let current_line = data.editor.cursor.current_line(&data.buffer);
+            let current_line = data.editor.cursor.current_line(data.buffer.data());
             let char_width = data.config.editor_char_width(ctx.text());
 
             let line_label_length =

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -139,7 +139,7 @@ impl LapceEditorHeader {
                 clip_rect.x1 = icon.rect.x0;
             }
         }
-        if let BufferContent::File(path) = &data.buffer.content {
+        if let BufferContent::File(path) = data.buffer.content() {
             ctx.with_save(|ctx| {
                 ctx.clip(clip_rect);
                 let mut path = path.clone();
@@ -157,7 +157,7 @@ impl LapceEditorHeader {
                     .and_then(|s| s.to_str())
                     .unwrap_or("")
                     .to_string();
-                if data.buffer.dirty {
+                if data.buffer.dirty() {
                     file_name = "*".to_string() + &file_name;
                 }
                 if let Some(_compare) = data.editor.compare.as_ref() {

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -560,7 +560,7 @@ impl TabRectRenderer for TabRect {
             let is_dirty = match &editor_tab.children[i] {
                 EditorTabChild::Editor(editor_id, _) => {
                     let buffer = data.main_split.editor_buffer(*editor_id);
-                    buffer.dirty
+                    buffer.dirty()
                 }
             };
 

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -162,10 +162,10 @@ impl LapceEditorView {
                 self.ensure_rect_visible(ctx, data, *rect, env);
             }
             LapceUICommand::ResolveCompletion(buffer_id, rev, offset, item) => {
-                if data.buffer.id != *buffer_id {
+                if data.buffer.id() != *buffer_id {
                     return;
                 }
-                if data.buffer.rev != *rev {
+                if data.buffer.rev() != *rev {
                     return;
                 }
                 if data.editor.cursor.offset() != *offset {
@@ -585,13 +585,13 @@ impl Widget<LapceTabData> for LapceEditorView {
             if syntax.line_height != data.config.editor.line_height
                 || syntax.lens_height != data.config.editor.code_lens_font_size
             {
-                if let BufferContent::File(path) = &editor_data.buffer.content {
+                if let BufferContent::File(path) = editor_data.buffer.content() {
                     let tab_id = data.id;
                     let event_sink = ctx.get_external_handle();
                     let mut syntax = syntax.clone();
                     let line_height = data.config.editor.line_height;
                     let lens_height = data.config.editor.code_lens_font_size;
-                    let rev = editor_data.buffer.rev;
+                    let rev = editor_data.buffer.rev();
                     let path = path.clone();
                     rayon::spawn(move || {
                         syntax.update_lens_height(line_height, lens_height);
@@ -630,7 +630,7 @@ impl Widget<LapceTabData> for LapceEditorView {
                 ctx.request_layout();
             }
         }
-        if editor_data.buffer.dirty != old_editor_data.buffer.dirty {
+        if editor_data.buffer.dirty() != old_editor_data.buffer.dirty() {
             ctx.request_paint();
         }
         if editor_data.editor.cursor != old_editor_data.editor.cursor {
@@ -639,8 +639,8 @@ impl Widget<LapceTabData> for LapceEditorView {
 
         let buffer = &editor_data.buffer;
         let old_buffer = &old_editor_data.buffer;
-        if buffer.max_len != old_buffer.max_len
-            || buffer.num_lines != old_buffer.num_lines
+        if buffer.max_len() != old_buffer.max_len()
+            || buffer.num_lines() != old_buffer.num_lines()
         {
             ctx.request_layout();
         }
@@ -657,7 +657,7 @@ impl Widget<LapceTabData> for LapceEditorView {
             }
         }
 
-        if buffer.rev != old_buffer.rev {
+        if buffer.rev() != old_buffer.rev() {
             ctx.request_paint();
         }
 

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -334,8 +334,7 @@ impl LapceEditorView {
             let empty_vec = Vec::new();
             let normal_lines = data
                 .buffer
-                .syntax
-                .as_ref()
+                .syntax()
                 .map(|s| &s.normal_lines)
                 .unwrap_or(&empty_vec);
 
@@ -581,7 +580,7 @@ impl Widget<LapceTabData> for LapceEditorView {
         let old_editor_data = old_data.editor_view_content(self.view_id);
         let editor_data = data.editor_view_content(self.view_id);
 
-        if let Some(syntax) = editor_data.buffer.syntax.as_ref() {
+        if let Some(syntax) = editor_data.buffer.syntax() {
             if syntax.line_height != data.config.editor.line_height
                 || syntax.lens_height != data.config.editor.code_lens_font_size
             {
@@ -617,8 +616,8 @@ impl Widget<LapceTabData> for LapceEditorView {
         if editor_data.editor.compare.is_some() {
             if !editor_data
                 .buffer
-                .histories
-                .ptr_eq(&old_editor_data.buffer.histories)
+                .histories()
+                .ptr_eq(old_editor_data.buffer.histories())
             {
                 ctx.request_layout();
             }

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -957,14 +957,14 @@ impl Widget<LapceTabData> for LapceSettingsItem {
                 let buffer = data.main_split.value_buffers.get(name).unwrap();
                 let old_buffer =
                     old_data.main_split.value_buffers.get(name).unwrap();
-                if buffer.rope.len() != old_buffer.rope.len()
-                    || buffer.rope.slice_to_cow(..)
-                        != old_buffer.rope.slice_to_cow(..)
+                if buffer.len() != old_buffer.len()
+                    || buffer.rope().slice_to_cow(..)
+                        != old_buffer.rope().slice_to_cow(..)
                 {
                     let new_value = match &self.value {
                         serde_json::Value::Number(_n) => {
                             if let Ok(new_n) =
-                                buffer.rope.slice_to_cow(..).parse::<i64>()
+                                buffer.rope().slice_to_cow(..).parse::<i64>()
                             {
                                 serde_json::json!(new_n)
                             } else {
@@ -972,7 +972,7 @@ impl Widget<LapceTabData> for LapceSettingsItem {
                             }
                         }
                         serde_json::Value::String(_s) => {
-                            serde_json::json!(&buffer.rope.slice_to_cow(..))
+                            serde_json::json!(&buffer.rope().slice_to_cow(..))
                         }
                         _ => return,
                     };

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -340,7 +340,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                             .local_buffers
                             .get_mut(&LocalBufferKind::Search)
                             .unwrap();
-                        if &buffer.rope.to_string() != pattern {
+                        if &buffer.rope().to_string() != pattern {
                             Arc::make_mut(buffer).load_content(pattern);
                         }
                         if pattern.is_empty() {
@@ -408,7 +408,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                             .local_buffers
                             .get(&LocalBufferKind::Search)
                             .unwrap();
-                        if &buffer.rope.to_string() == pattern {
+                        if &buffer.rope().to_string() == pattern {
                             Arc::make_mut(&mut data.search).matches =
                                 matches.clone();
                         }
@@ -579,8 +579,8 @@ impl Widget<LapceTabData> for LapceTabNew {
                     LapceUICommand::BufferSave(path, rev) => {
                         let buffer =
                             data.main_split.open_files.get_mut(path).unwrap();
-                        if buffer.rev == *rev {
-                            Arc::make_mut(buffer).dirty = false;
+                        if buffer.rev() == *rev {
+                            Arc::make_mut(buffer).set_dirty(false);
                         }
                         ctx.set_handled();
                     }
@@ -761,7 +761,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                         if let Some(buffer) =
                             data.main_split.open_files.get_mut(path)
                         {
-                            if buffer.rev == *rev {
+                            if buffer.rev() == *rev {
                                 Arc::make_mut(buffer)
                                     .code_actions
                                     .insert(*offset, resp.clone());
@@ -791,16 +791,16 @@ impl Widget<LapceTabData> for LapceTabNew {
                     }
                     LapceUICommand::ReloadBuffer(id, rev, new_content) => {
                         for (_, buffer) in data.main_split.open_files.iter_mut() {
-                            if &buffer.id == id {
-                                if buffer.rev + 1 == *rev {
+                            if buffer.id() == *id {
+                                if buffer.rev() + 1 == *rev {
                                     let buffer = Arc::make_mut(buffer);
                                     buffer.load_content(new_content);
-                                    buffer.rev = *rev;
+                                    buffer.set_rev(*rev);
 
                                     for (_, editor) in
                                         data.main_split.editors.iter_mut()
                                     {
-                                        if editor.content == buffer.content
+                                        if &editor.content == buffer.content()
                                             && editor.cursor.offset() >= buffer.len()
                                         {
                                             let editor = Arc::make_mut(editor);
@@ -841,7 +841,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                     LapceUICommand::UpdateSemanticStyles(_id, path, rev, styles) => {
                         let buffer =
                             data.main_split.open_files.get_mut(path).unwrap();
-                        if buffer.rev == *rev {
+                        if buffer.rev() == *rev {
                             let buffer = Arc::make_mut(buffer);
                             buffer.semantic_styles = Some(styles.clone());
                             buffer.line_styles.borrow_mut().clear();
@@ -914,7 +914,7 @@ impl Widget<LapceTabData> for LapceTabNew {
                         let buffer =
                             data.main_split.open_files.get_mut(path).unwrap();
                         let buffer = Arc::make_mut(buffer);
-                        if buffer.rev == *rev {
+                        if buffer.rev() == *rev {
                             buffer.syntax = Some(syntax.clone());
                             if buffer.semantic_styles.is_none() {
                                 buffer.line_styles.borrow_mut().clear();

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -843,8 +843,8 @@ impl Widget<LapceTabData> for LapceTabNew {
                             data.main_split.open_files.get_mut(path).unwrap();
                         if buffer.rev() == *rev {
                             let buffer = Arc::make_mut(buffer);
-                            buffer.semantic_styles = Some(styles.clone());
-                            buffer.line_styles.borrow_mut().clear();
+                            buffer.set_semantic_styles(Some(styles.clone()));
+                            buffer.line_styles().borrow_mut().clear();
                         }
                         ctx.set_handled();
                     }
@@ -915,9 +915,9 @@ impl Widget<LapceTabData> for LapceTabNew {
                             data.main_split.open_files.get_mut(path).unwrap();
                         let buffer = Arc::make_mut(buffer);
                         if buffer.rev() == *rev {
-                            buffer.syntax = Some(syntax.clone());
-                            if buffer.semantic_styles.is_none() {
-                                buffer.line_styles.borrow_mut().clear();
+                            buffer.set_syntax(Some(syntax.clone()));
+                            if buffer.semantic_styles().is_none() {
+                                buffer.line_styles().borrow_mut().clear();
                             }
                         }
                     }


### PR DESCRIPTION
This PR splits up Buffer into three parts:
 - `BufferData`, which contains everything strictly necessary for edits and undo/redo.
 - `BufferDecoration` which holds the special sauce provided by Buffer, e.g. syntax highlighting. This is split off so it can be wrapped into a decorator type for the fancy edit operations that e.g. trigger commands.
 - the rest - some of the `Buffer` data the other two groups didn't need (yet).

This PR introduces the `BufferDataListener` trait to observe and control the edit apply process, `EditableBufferData` that exposes the actual low-level edit operations, combined with a listener object, and `BufferEditListener` that is used by `Buffer` to glue things together.

Names are bad and are subject to change.