### PR TITLE
Make terminal paint in proper background color

### DIFF
--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -344,6 +344,8 @@ impl Widget<LapceTabData> for PanelSectionHeader {
     }
 }
 
+/// This struct is used as the outer container for a panel,
+/// it contains the heading such as "Terminal" or "File Explorer".
 pub struct PanelMainHeader {
     text: String,
     icons: Vec<LapceIcon>,
@@ -516,10 +518,15 @@ impl Widget<LapceTabData> for PanelMainHeader {
                 data.config
                     .get_color_unchecked(LapceTheme::LAPCE_DROPDOWN_SHADOW),
             );
+
+            let bg_color_name = match self.kind {
+                PanelKind::Terminal => LapceTheme::TERMINAL_BACKGROUND,
+                _ => LapceTheme::EDITOR_BACKGROUND
+            };
+
             ctx.fill(
                 rect,
-                data.config
-                    .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
+                data.config.get_color_unchecked(bg_color_name),
             );
 
             let text_layout = ctx

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -519,14 +519,10 @@ impl Widget<LapceTabData> for PanelMainHeader {
                     .get_color_unchecked(LapceTheme::LAPCE_DROPDOWN_SHADOW),
             );
 
-            let bg_color_name = match self.kind {
-                PanelKind::Terminal => LapceTheme::TERMINAL_BACKGROUND,
-                _ => LapceTheme::EDITOR_BACKGROUND
-            };
-
             ctx.fill(
                 rect,
-                data.config.get_color_unchecked(bg_color_name),
+                data.config
+                    .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
             );
 
             let text_layout = ctx

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -84,6 +84,8 @@ impl RawTerminal {
     }
 }
 
+/// This struct represents the main body of the terminal, i.e. the part
+/// where the shell is presented.
 pub struct TerminalPanel {
     widget_id: WidgetId,
     split: WidgetPod<LapceTabData, LapceSplitNew>,
@@ -189,6 +191,11 @@ impl Widget<LapceTabData> for TerminalPanel {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, env: &Env) {
+        let rect = ctx.size().to_rect();
+        ctx.fill(
+            rect,
+            data.config.get_color_unchecked(LapceTheme::TERMINAL_BACKGROUND),
+        );
         self.split.paint(ctx, data, env);
     }
 }
@@ -289,7 +296,7 @@ impl Widget<LapceTabData> for LapceTerminalView {
             ctx.fill(
                 rect,
                 data.config
-                    .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
+                    .get_color_unchecked(LapceTheme::TERMINAL_BACKGROUND),
             );
         });
 


### PR DESCRIPTION
Fixes https://github.com/lapce/lapce/issues/348

Screen now looks like this

![image](https://user-images.githubusercontent.com/1809220/161433584-1792dd0b-d509-4c98-844d-381ac149ad13.png)

Code is not super-elegant, this is my best shot without refactoring a lot more. From the user's perspective the terminal is everything below and including the header that contains the word "Terminal", as that is where the separator bar is, that can be moved with the mouse. In the code base, the background for these areas is split between the terminal-proper and the PanelMainHeader struct BUT the same code in PanelMainHeader is also used to paint the "File Explorer", "Source Control" headings etc. Luckily there was a `kind` member which allowed me to just pick out the terminal and preserve current behaviour for the other UI elements.

It does beg the question of how the theme files should correspond to the UI areas. For example, I initially took the "editor..." colors  to refer to the textual editing area, but they are being used to paint other areas of the screen as well, as can be seen in the screenshot.

