### PR TITLE
Adds alternative keymap to normal_mode

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -220,6 +220,12 @@ mode = "niv"
 when = "!search_focus"
 
 [[keymaps]]
+key = "ctrl+["
+command = "normal_mode"
+mode = "niv"
+when = "!search_focus"
+
+[[keymaps]]
 key = ":"
 command = "palette.command"
 mode = "n"


### PR DESCRIPTION
This adds an alternative keymap to `normal_mode` when modal editing is enabled.