### PR TITLE
Delete unused Counters

### DIFF
--- a/lapce-data/src/state.rs
+++ b/lapce-data/src/state.rs
@@ -4,8 +4,6 @@ use druid::Modifiers;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Write};
 use std::path::PathBuf;
-use std::sync::atomic;
-use std::sync::atomic::AtomicU64;
 
 #[derive(PartialEq)]
 enum KeymapMatch {
@@ -172,23 +170,4 @@ impl Display for LapceWorkspace {
                 .unwrap_or_else(|| "".to_string())
         )
     }
-}
-
-pub struct Counter(AtomicU64);
-
-impl Counter {
-    pub const fn new() -> Counter {
-        Counter(AtomicU64::new(1))
-    }
-
-    pub fn next(&self) -> u64 {
-        self.0.fetch_add(1, atomic::Ordering::Relaxed)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_check_condition() {}
 }

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -3,7 +3,6 @@ use std::{
     collections::VecDeque,
     io::{self, ErrorKind, Read, Write},
     path::PathBuf,
-    sync::atomic::{self, AtomicU64},
 };
 
 use alacritty_terminal::{
@@ -28,18 +27,6 @@ use serde_json::json;
 use crate::dispatch::Dispatcher;
 
 const READ_BUFFER_SIZE: usize = 0x10_0000;
-
-pub struct Counter(AtomicU64);
-
-impl Counter {
-    pub const fn new() -> Counter {
-        Counter(AtomicU64::new(1))
-    }
-
-    pub fn next(&self) -> u64 {
-        self.0.fetch_add(1, atomic::Ordering::Relaxed)
-    }
-}
 
 pub type TermConfig = alacritty_terminal::config::Config;
 


### PR DESCRIPTION
This leaves just one Counter struct definition, in the RPC crate.