### PR TITLE
Avoid cloning compare strings

### DIFF
--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -1098,20 +1098,13 @@ impl Buffer {
         mode: Mode,
         modify: bool,
         code_lens: bool,
-        compare: Option<String>,
+        compare: Option<&str>,
         config: &Config,
     ) -> Selection {
         let mut new_selection = Selection::new();
         for region in selection.regions() {
             let region = self.update_region(
-                region,
-                count,
-                movement,
-                mode,
-                modify,
-                code_lens,
-                compare.clone(),
-                config,
+                region, count, movement, mode, modify, code_lens, compare, config,
             );
             new_selection.add_region(region);
         }
@@ -1127,7 +1120,7 @@ impl Buffer {
         mode: Mode,
         modify: bool,
         code_lens: bool,
-        compare: Option<String>,
+        compare: Option<&str>,
         config: &Config,
     ) -> SelRegion {
         let (end, horiz) = self.move_offset(
@@ -1343,7 +1336,7 @@ impl Buffer {
         movement: &Movement,
         mode: Mode,
         code_lens: bool,
-        compare: Option<String>,
+        compare: Option<&str>,
         config: &Config,
     ) -> (usize, ColPosition) {
         let horiz = if let Some(horiz) = horiz {
@@ -1389,7 +1382,7 @@ impl Buffer {
                 let line = self.line_of_offset(offset);
                 let line = if line == 0 {
                     0
-                } else if let Some(compare) = compare.as_ref() {
+                } else if let Some(compare) = compare {
                     let cursor_line = self.diff_cursor_line(compare, line);
                     let cursor_line = if cursor_line > count {
                         cursor_line - count
@@ -1443,7 +1436,7 @@ impl Buffer {
                 let last_line = self.last_line();
                 let line = self.line_of_offset(offset);
 
-                let line = if let Some(compare) = compare.as_ref() {
+                let line = if let Some(compare) = compare {
                     let cursor_line = self.diff_cursor_line(compare, line);
                     let cursor_line = cursor_line + count;
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -322,7 +322,7 @@ impl LapceEditorBufferData {
                     movement,
                     Mode::Normal,
                     self.editor.code_lens,
-                    compare,
+                    compare.as_deref(),
                     &self.config,
                 );
 
@@ -385,7 +385,7 @@ impl LapceEditorBufferData {
                     movement,
                     Mode::Visual,
                     self.editor.code_lens,
-                    compare,
+                    compare.as_deref(),
                     &self.config,
                 );
                 let start = *start;
@@ -406,7 +406,7 @@ impl LapceEditorBufferData {
                     Mode::Insert,
                     mods.shift(),
                     self.editor.code_lens,
-                    compare,
+                    compare.as_deref(),
                     &self.config,
                 );
                 self.set_cursor(Cursor::new(CursorMode::Insert(selection), None));
@@ -1948,7 +1948,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                         &Movement::Right,
                         Mode::Insert,
                         self.editor.code_lens,
-                        self.editor.compare.clone(),
+                        self.editor.compare.as_deref(),
                         &self.config,
                     )
                     .0;
@@ -1966,7 +1966,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                     &Movement::EndOfLine,
                     Mode::Insert,
                     self.editor.code_lens,
-                    self.editor.compare.clone(),
+                    self.editor.compare.as_deref(),
                     &self.config,
                 );
                 self.buffer_mut().update_edit_type();
@@ -1991,7 +1991,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                             &Movement::FirstNonBlank,
                             Mode::Normal,
                             self.editor.code_lens,
-                            self.editor.compare.clone(),
+                            self.editor.compare.as_deref(),
                             &self.config,
                         );
                         self.buffer_mut().update_edit_type();
@@ -2056,7 +2056,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                             Mode::Insert,
                             true,
                             self.editor.code_lens,
-                            self.editor.compare.clone(),
+                            self.editor.compare.as_deref(),
                             &self.config,
                         )
                     }
@@ -2209,7 +2209,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                             Mode::Insert,
                             true,
                             self.editor.code_lens,
-                            self.editor.compare.clone(),
+                            self.editor.compare.as_deref(),
                             &self.config,
                         )
                     }
@@ -2239,7 +2239,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                             Mode::Insert,
                             true,
                             self.editor.code_lens,
-                            self.editor.compare.clone(),
+                            self.editor.compare.as_deref(),
                             &self.config,
                         )
                     }
@@ -2273,7 +2273,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                                         Mode::Insert,
                                         true,
                                         self.editor.code_lens,
-                                        self.editor.compare.clone(),
+                                        self.editor.compare.as_deref(),
                                         &self.config,
                                     )
                                 } else {
@@ -2304,7 +2304,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                                         Mode::Insert,
                                         true,
                                         self.editor.code_lens,
-                                        self.editor.compare.clone(),
+                                        self.editor.compare.as_deref(),
                                         &self.config,
                                     )
                                 }
@@ -2376,7 +2376,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                                     Mode::Insert,
                                     true,
                                     self.editor.code_lens,
-                                    self.editor.compare.clone(),
+                                    self.editor.compare.as_deref(),
                                     &self.config,
                                 )
                             } else {
@@ -2548,7 +2548,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                         &Movement::Up,
                         Mode::Insert,
                         self.editor.code_lens,
-                        self.editor.compare.clone(),
+                        self.editor.compare.as_deref(),
                         &self.config,
                     );
                     if new_offset != offset {
@@ -2574,7 +2574,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                         &Movement::Down,
                         Mode::Insert,
                         self.editor.code_lens,
-                        self.editor.compare.clone(),
+                        self.editor.compare.as_deref(),
                         &self.config,
                     );
                     if new_offset != offset {
@@ -2872,7 +2872,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                         Mode::Insert,
                         true,
                         self.editor.code_lens,
-                        self.editor.compare.clone(),
+                        self.editor.compare.as_deref(),
                         &self.config,
                     )
                 } else {
@@ -3051,7 +3051,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                                 &Movement::Left,
                                 Mode::Normal,
                                 self.editor.code_lens,
-                                self.editor.compare.clone(),
+                                self.editor.compare.as_deref(),
                                 &self.config,
                             )
                             .0


### PR DESCRIPTION
This PR uses `Option::as_deref()` to turn `Option<String>` into `Option<&str>`, allowing to remove unnecessary cloning.