### PR TITLE
Improve text measurement

### DIFF
--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -541,28 +541,64 @@ impl Config {
     /// Calculate the width of the character "W" (being the widest character)
     /// in the editor's current font family at the specified font size.
     pub fn char_width(&self, text: &mut PietText, font_size: f64) -> f64 {
-        Self::editor_text_size_internal(self.editor.font_family(), font_size, text, "W").width
+        Self::editor_text_size_internal(
+            self.editor.font_family(),
+            font_size,
+            text,
+            "W",
+        )
+        .width
     }
 
     /// Calculate the width of the character "W" (being the widest character)
     /// in the editor's current font family and current font size.
     pub fn editor_char_width(&self, text: &mut PietText) -> f64 {
-        Self::editor_text_size_internal(self.editor.font_family(), self.editor.font_size as f64, text, "W").width
+        Self::editor_text_size_internal(
+            self.editor.font_family(),
+            self.editor.font_size as f64,
+            text,
+            "W",
+        )
+        .width
     }
 
     /// Calculate the width of `text_to_measure` in the editor's current font family and font size.
-    pub fn editor_text_width(&self, text: &mut PietText, text_to_measure: &str) -> f64 {
-        Self::editor_text_size_internal(self.editor.font_family(), self.editor.font_size as f64, text, text_to_measure).width
+    pub fn editor_text_width(
+        &self,
+        text: &mut PietText,
+        text_to_measure: &str,
+    ) -> f64 {
+        Self::editor_text_size_internal(
+            self.editor.font_family(),
+            self.editor.font_size as f64,
+            text,
+            text_to_measure,
+        )
+        .width
     }
 
     /// Calculate the size of `text_to_measure` in the editor's current font family and font size.
-    pub fn editor_text_size(&self, text: &mut PietText, text_to_measure: &str) -> Size {
-        Self::editor_text_size_internal(self.editor.font_family(), self.editor.font_size as f64, text, text_to_measure)
+    pub fn editor_text_size(
+        &self,
+        text: &mut PietText,
+        text_to_measure: &str,
+    ) -> Size {
+        Self::editor_text_size_internal(
+            self.editor.font_family(),
+            self.editor.font_size as f64,
+            text,
+            text_to_measure,
+        )
     }
 
     /// Efficiently calculate the size of a piece of text, without allocating.
     /// This function should not be made public, use one of the public wrapper functions instead.
-    fn editor_text_size_internal(font_family: FontFamily, font_size: f64, text: &mut PietText, text_to_measure: &str) -> Size {
+    fn editor_text_size_internal(
+        font_family: FontFamily,
+        font_size: f64,
+        text: &mut PietText,
+        text_to_measure: &str,
+    ) -> Size {
         // Lie about the lifetime of `text_to_measure`.
         //
         // The method `new_text_layout` will take ownership of its parameter
@@ -578,19 +614,18 @@ impl Config {
         // always dropped inside this function, and hence its lifetime is always stricly less
         // than the lifetime of `text_to_measure`, irrespective of whether `text_to_measure`
         // is actually static or not.
-        let static_str: &'static str = unsafe { 
-            std::mem::transmute(text_to_measure)
-        };
+        let static_str: &'static str =
+            unsafe { std::mem::transmute(text_to_measure) };
 
         let text_layout = text
             .new_text_layout(static_str)
             .font(font_family, font_size)
             .build()
             .unwrap();
-            
+
         text_layout.size()
     }
-    
+
     pub fn update_recent_workspaces(workspaces: Vec<LapceWorkspace>) -> Option<()> {
         let path = Self::recent_workspaces_file()?;
         let mut array = toml::value::Array::new();

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -801,7 +801,7 @@ impl LapceTabData {
                 let offset = editor.cursor.offset();
                 let (line, col) =
                     buffer.offset_to_line_col(offset, self.config.editor.tab_width);
-                let width = config.editor_text_width(text, "W");
+                let width = config.editor_char_width(text);
                 let x = col as f64 * width;
                 let y = (line + 1) as f64 * line_height;
 
@@ -836,7 +836,7 @@ impl LapceTabData {
                 let offset = self.completion.offset;
                 let (line, col) =
                     buffer.offset_to_line_col(offset, self.config.editor.tab_width);
-                let width = config.editor_text_width(text, "W");
+                let width = config.editor_char_width(text);
                 let x = col as f64 * width - line_height - 5.0;
                 let y = (line + 1) as f64 * line_height;
                 let mut origin = editor.window_origin - self.window_origin.to_vec2()
@@ -889,7 +889,7 @@ impl LapceTabData {
                 let offset = self.hover.offset;
                 let (line, col) =
                     buffer.offset_to_line_col(offset, self.config.editor.tab_width);
-                let width = config.editor_text_width(text, "W");
+                let width = config.editor_char_width(text);
                 let x = col as f64 * width - line_height - 5.0;
                 let y = (line + 1) as f64 * line_height;
                 let mut origin = editor.window_origin - self.window_origin.to_vec2()

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1681,13 +1681,13 @@ impl LapceEditorBufferData {
             let line = self.buffer.diff_actual_line_from_visual(compare, line);
             (
                 line,
-                config.char_width(text, config.editor.font_size as f64),
+                config.editor_char_width(text),
             )
         } else {
             let line = (pos.y / config.editor.line_height as f64).floor() as usize;
             (
                 line,
-                config.char_width(text, config.editor.font_size as f64),
+                config.editor_char_width(text),
             )
         };
 

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -230,7 +230,7 @@ impl LapceEditor {
         env: &Env,
     ) -> Size {
         let line_height = data.config.editor.line_height as f64;
-        let width = data.config.editor_text_width(text, "W");
+        let width = data.config.editor_char_width(text);
         match &data.editor.content {
             BufferContent::File(_) => {
                 if data.editor.code_lens {
@@ -1322,7 +1322,7 @@ impl LapceEditor {
             + data.editor.scroll_offset.y)
             / line_height)
             .ceil() as usize;
-        let width = data.config.editor_text_width(ctx.text(), "W");
+        let width = data.config.editor_char_width(ctx.text());
         if let Some(snippet) = data.editor.snippet.as_ref() {
             for (_, (start, end)) in snippet {
                 let paint_start_line = start_line;
@@ -1386,7 +1386,7 @@ impl LapceEditor {
             / line_height)
             .ceil() as usize;
 
-        let width = data.config.editor_text_width(ctx.text(), "W");
+        let width = data.config.editor_char_width(ctx.text());
         let mut current = None;
         let cursor_offset = data.editor.cursor.offset();
         if let Some(diagnostics) = data.diagnostics() {

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -88,7 +88,7 @@ impl Widget<LapceTabData> for LapceEditorGutter {
     ) -> Size {
         let data = data.editor_view_content(self.view_id);
         let last_line = data.buffer.last_line() + 1;
-        let char_width = data.config.editor_text_width(ctx.text(), "W");
+        let char_width = data.config.editor_char_width(ctx.text());
         self.width = (char_width * last_line.to_string().len() as f64).ceil();
         let mut width = self.width + 16.0 + char_width * 2.0;
         if data.editor.compare.is_some() {
@@ -123,7 +123,7 @@ impl LapceEditorGutter {
             (scroll_offset.y + rect.height() / line_height).ceil() as usize;
         let current_line = data.editor.cursor.current_line(&data.buffer);
         let last_line = data.buffer.last_line();
-        let width = data.config.editor_text_width(ctx.text(), "W");
+        let width = data.config.editor_char_width(ctx.text());
 
         let mut line = 0;
         for change in changes.iter() {
@@ -380,7 +380,7 @@ impl LapceEditorGutter {
             .min(last_line);
         let char_width = data
             .config
-            .char_width(ctx.text(), data.config.editor.font_size as f64);
+            .editor_char_width(ctx.text());
         let max_line_width = (last_line + 1).to_string().len() as f64 * char_width;
 
         let mut y = lens.height_of_line(start_line) as f64;
@@ -450,7 +450,7 @@ impl LapceEditorGutter {
                 let svg = get_svg("lightbulb.svg").unwrap();
                 let width = 16.0;
                 let height = 16.0;
-                let char_width = data.config.editor_text_width(ctx.text(), "W");
+                let char_width = data.config.editor_char_width(ctx.text());
                 let rect =
                     Size::new(width, height).to_rect().with_origin(Point::new(
                         self.width + char_width + 3.0,
@@ -485,7 +485,7 @@ impl LapceEditorGutter {
             let num_lines = (ctx.size().height / line_height).floor() as usize;
             let last_line = data.buffer.last_line();
             let current_line = data.editor.cursor.current_line(&data.buffer);
-            let char_width = data.config.editor_text_width(ctx.text(), "W");
+            let char_width = data.config.editor_char_width(ctx.text());
 
             let line_label_length =
                 (last_line + 1).to_string().len() as f64 * char_width;

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -326,7 +326,7 @@ impl LapceEditorView {
         let (line, col) = data
             .buffer
             .offset_to_line_col(offset, data.config.editor.tab_width);
-        let width = data.config.editor_text_width(text, "W");
+        let width = data.config.editor_char_width(text);
         let cursor_x = col as f64 * width;
         let line_height = data.config.editor.line_height as f64;
 

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -658,7 +658,7 @@ impl Widget<LapceTabData> for LapceTerminal {
         if self.width != size.width || self.height != size.height {
             self.width = size.width;
             self.height = size.height;
-            let width = data.config.editor_text_width(ctx.text(), "W");
+            let width = data.config.editor_char_width(ctx.text());
             let line_height = data.config.editor.line_height as f64;
             let width = if width > 0.0 {
                 (self.width / width).floor() as usize


### PR DESCRIPTION
Make text measurement more efficient and regularise the calls to these methods.

cc @bugadani 

There are still some direct calls to `new_text_layout` - I will tackle them in another PR if this is OK. The diff is a bit confused, you might want to look at `config.rs` by itself.