### PR TITLE
Remove some unnecessary calls of to_string when calling new_text_layout

### DIFF
--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -553,13 +553,7 @@ impl Config {
     /// Calculate the width of the character "W" (being the widest character)
     /// in the editor's current font family and current font size.
     pub fn editor_char_width(&self, text: &mut PietText) -> f64 {
-        Self::editor_text_size_internal(
-            self.editor.font_family(),
-            self.editor.font_size as f64,
-            text,
-            "W",
-        )
-        .width
+        self.char_width(text, self.editor.font_size as f64)
     }
 
     /// Calculate the width of `text_to_measure` in the editor's current font family and font size.

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -608,6 +608,10 @@ impl Config {
         // always dropped inside this function, and hence its lifetime is always stricly less
         // than the lifetime of `text_to_measure`, irrespective of whether `text_to_measure`
         // is actually static or not.
+        //
+        // Note that this technique also assumes that `new_text_layout` does not stash
+        // its parameter away somewhere, such as a global cache. If it did, this would
+        // break and we would have to go back to calling `to_string` on the parameter.
         let static_str: &'static str =
             unsafe { std::mem::transmute(text_to_measure) };
 

--- a/lapce-ui/src/keymap.rs
+++ b/lapce-ui/src/keymap.rs
@@ -488,7 +488,7 @@ impl Widget<LapceTabData> for LapceKeymap {
                 );
             let text = ctx
                 .text()
-                .new_text_layout("Save".to_string())
+                .new_text_layout("Save")
                 .font(FontFamily::SYSTEM_UI, 13.0)
                 .text_color(
                     data.config
@@ -524,7 +524,7 @@ impl Widget<LapceTabData> for LapceKeymap {
                 );
             let text = ctx
                 .text()
-                .new_text_layout("Cancel".to_string())
+                .new_text_layout("Cancel")
                 .font(FontFamily::SYSTEM_UI, 13.0)
                 .text_color(
                     data.config
@@ -612,7 +612,7 @@ impl Widget<LapceTabData> for LapceKeymapHeader {
 
         let text_layout = ctx
             .text()
-            .new_text_layout("Command".to_string())
+            .new_text_layout("Command")
             .font(FontFamily::SYSTEM_UI, 14.0)
             .default_attribute(TextAttribute::Weight(FontWeight::BOLD))
             .text_color(
@@ -630,7 +630,7 @@ impl Widget<LapceTabData> for LapceKeymapHeader {
 
         let text_layout = ctx
             .text()
-            .new_text_layout("Keybinding".to_string())
+            .new_text_layout("Keybinding")
             .font(FontFamily::SYSTEM_UI, 14.0)
             .default_attribute(TextAttribute::Weight(FontWeight::BOLD))
             .text_color(
@@ -651,7 +651,7 @@ impl Widget<LapceTabData> for LapceKeymapHeader {
 
         let text_layout = ctx
             .text()
-            .new_text_layout("When".to_string())
+            .new_text_layout("When")
             .font(FontFamily::SYSTEM_UI, 14.0)
             .default_attribute(TextAttribute::Weight(FontWeight::BOLD))
             .text_color(
@@ -679,7 +679,7 @@ impl Widget<LapceTabData> for LapceKeymapHeader {
         if data.config.lapce.modal {
             let text_layout = ctx
                 .text()
-                .new_text_layout("Modes".to_string())
+                .new_text_layout("Modes")
                 .font(FontFamily::SYSTEM_UI, 14.0)
                 .default_attribute(TextAttribute::Weight(FontWeight::BOLD))
                 .text_color(

--- a/lapce-ui/src/palette.rs
+++ b/lapce-ui/src/palette.rs
@@ -493,9 +493,7 @@ impl Widget<PaletteViewData> for NewPaletteInput {
             && data.palette.palette_type == PaletteType::SshHost
         {
             ctx.text()
-                .new_text_layout(
-                    "Enter your SSH details, like user@host".to_string(),
-                )
+                .new_text_layout("Enter your SSH details, like user@host")
                 .font(FontFamily::SYSTEM_UI, 14.0)
                 .text_color(
                     data.config

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -357,15 +357,15 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
                     .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
             );
 
-            static SETTINGS_SECTIONS: [&str; 3] = ["Core Settings", "Editor Settings", "Keybindings"];
+            const SETTINGS_SECTIONS: [&str; 3] = ["Core Settings", "Editor Settings", "Keybindings"];
 
             for (i, text) in SETTINGS_SECTIONS
-                .iter()
+                .into_iter()
                 .enumerate()
             {
                 let text_layout = ctx
                     .text()
-                    .new_text_layout(*text)
+                    .new_text_layout(text)
                     .font(FontFamily::SYSTEM_UI, 14.0)
                     .text_color(
                         data.config

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -357,13 +357,15 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
                     .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
             );
 
-            for (i, text) in ["Core Settings", "Editor Settings", "Keybindings"]
+            static SETTINGS_SECTIONS: [&str; 3] = ["Core Settings", "Editor Settings", "Keybindings"];
+
+            for (i, text) in SETTINGS_SECTIONS
                 .iter()
                 .enumerate()
             {
                 let text_layout = ctx
                     .text()
-                    .new_text_layout(text.to_string())
+                    .new_text_layout(*text)
                     .font(FontFamily::SYSTEM_UI, 14.0)
                     .text_color(
                         data.config
@@ -393,7 +395,7 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
             );
             let text_layout = ctx
                 .text()
-                .new_text_layout("Settings".to_string())
+                .new_text_layout("Settings")
                 .font(FontFamily::SYSTEM_UI, 16.0)
                 .text_color(
                     data.config


### PR DESCRIPTION
Such calls are not necessary when passing a static string.
I also included a few comments from my previous PR that I intended to do but it was merged before I could get round to it :-)