### PR TITLE
Highlight active file on tab change, pt 1

### DIFF
--- a/lapce-core/src/syntax.rs
+++ b/lapce-core/src/syntax.rs
@@ -37,6 +37,21 @@ pub struct Syntax {
     pub styles: Option<Arc<Spans<Style>>>,
 }
 
+impl std::fmt::Debug for Syntax {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Syntax")
+            .field("rev", &self.rev)
+            .field("language", &self.language)
+            .field("text", &self.text)
+            .field("tree", &self.tree)
+            .field("normal_lines", &self.normal_lines)
+            .field("line_height", &self.line_height)
+            .field("lens_height", &self.lens_height)
+            .field("styles", &self.styles)
+            .finish()
+    }
+}
+
 impl Syntax {
     pub fn init(path: &Path) -> Option<Syntax> {
         LapceLanguage::from_path(path).map(|l| Syntax {

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -560,6 +560,7 @@ pub enum EnsureVisiblePosition {
     CenterOfWindow,
 }
 
+#[derive(Debug)]
 pub enum LapceUICommand {
     InitChildren,
     InitTerminalPanel(bool),
@@ -704,4 +705,7 @@ pub enum LapceUICommand {
     GotoDefinition(WidgetId, usize, EditorLocationNew),
     PaletteReferences(usize, Vec<Location>),
     GotoLocation(Location),
+    ActiveFileChanged {
+        path: Option<PathBuf>,
+    },
 }

--- a/lapce-data/src/explorer.rs
+++ b/lapce-data/src/explorer.rs
@@ -22,7 +22,7 @@ pub struct FileExplorerData {
     pub tab_id: WidgetId,
     pub widget_id: WidgetId,
     pub workspace: Option<FileNodeItem>,
-    pub active_selected: usize,
+    pub active_selected: Option<PathBuf>,
 
     #[allow(dead_code)]
     count: usize,
@@ -82,7 +82,7 @@ impl FileExplorerData {
                 children: HashMap::new(),
                 children_open_count: 0,
             }),
-            active_selected: 0,
+            active_selected: None,
             count: 0,
         }
     }

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -6,7 +6,7 @@ use druid::{
     Rect, RenderContext, Size, Target, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 use lapce_data::{
-    buffer::BufferContent,
+    buffer::{BufferContent, LocalBufferKind},
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     config::LapceTheme,
     data::{
@@ -351,6 +351,13 @@ impl Widget<LapceTabData> for LapceEditorTab {
                             let active = &tab.children[tab.active];
                             let EditorTabChildInfo::Editor(info) =
                                 active.child_info(data, 4);
+
+                            if info.content
+                                == BufferContent::Local(LocalBufferKind::Empty)
+                            {
+                                // File has not yet been loaded, most likely.
+                                return;
+                            }
 
                             ctx.submit_command(Command::new(
                                 LAPCE_UI_COMMAND,

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -6,14 +6,15 @@ use druid::{
     Rect, RenderContext, Size, Target, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 use lapce_data::{
+    buffer::BufferContent,
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     config::LapceTheme,
     data::{
         DragContent, EditorTabChild, LapceEditorTabData, LapceTabData, SplitContent,
     },
+    db::EditorTabChildInfo,
     editor::TabRect,
     split::{SplitDirection, SplitMoveDirection},
-    
 };
 
 use crate::editor::{
@@ -342,6 +343,30 @@ impl Widget<LapceTabData> for LapceEditorTab {
                             Target::Widget(widget_id),
                         ));
                         return;
+                    }
+                    LapceUICommand::EnsureEditorTabActiveVisble => {
+                        if let Some(tab) =
+                            data.main_split.editor_tabs.get(&self.widget_id)
+                        {
+                            let active = &tab.children[tab.active];
+                            let EditorTabChildInfo::Editor(info) =
+                                active.child_info(data, 4);
+
+                            ctx.submit_command(Command::new(
+                                LAPCE_UI_COMMAND,
+                                LapceUICommand::ActiveFileChanged {
+                                    path: if let BufferContent::File(path) =
+                                        info.content
+                                    {
+                                        Some(path.clone())
+                                    } else {
+                                        None
+                                    },
+                                },
+                                Target::Widget(data.file_explorer.widget_id),
+                            ));
+                            return;
+                        }
                     }
                     _ => (),
                 }

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -103,6 +103,11 @@ impl LapceEditorTab {
             if focus {
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
+                    LapceUICommand::EnsureEditorTabActiveVisble,
+                    Target::Widget(editor_tab.widget_id),
+                ));
+                ctx.submit_command(Command::new(
+                    LAPCE_UI_COMMAND,
                     LapceUICommand::Focus,
                     Target::Widget(editor_tab.children[new_index].widget_id()),
                 ));

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -48,7 +48,7 @@ pub fn paint_file_node_item(
     if current + item.children_open_count < min {
         return current + item.children_open_count;
     }
-    if current >= min && current <= max {
+    if current >= min {
         let background = if current == active {
             Some(LapceTheme::PANEL_CURRENT)
         } else if Some(current) == hovered {

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -367,6 +367,16 @@ impl Widget<LapceTabData> for FileExplorerFileList {
         data: &mut LapceTabData,
         _env: &Env,
     ) {
+        match event {
+            Event::Command(cmd) if cmd.is(LAPCE_UI_COMMAND) => {
+                let command = cmd.get_unchecked(LAPCE_UI_COMMAND);
+
+                if let LapceUICommand::ActiveFileChanged { path } = command {
+                    println!("{path:?}");
+                }
+            }
+            _ => {}
+        }
         if !ctx.is_hot() {
             return;
         }

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -49,17 +49,15 @@ pub fn paint_file_node_item(
         return current + item.children_open_count;
     }
     if current >= min && current <= max {
-        if current == active {
-            ctx.fill(
-                Rect::ZERO
-                    .with_origin(Point::new(
-                        0.0,
-                        current as f64 * line_height - line_height,
-                    ))
-                    .with_size(Size::new(width, line_height)),
-                config.get_color_unchecked(LapceTheme::PANEL_CURRENT),
-            );
+        let background = if current == active {
+            Some(LapceTheme::PANEL_CURRENT)
         } else if Some(current) == hovered {
+            Some(LapceTheme::PANEL_HOVERED)
+        } else {
+            None
+        };
+
+        if let Some(background) = background {
             ctx.fill(
                 Rect::ZERO
                     .with_origin(Point::new(
@@ -67,9 +65,10 @@ pub fn paint_file_node_item(
                         current as f64 * line_height - line_height,
                     ))
                     .with_size(Size::new(width, line_height)),
-                config.get_color_unchecked(LapceTheme::PANEL_HOVERED),
+                config.get_color_unchecked(background),
             );
         }
+
         let y = current as f64 * line_height - line_height;
         let svg_y = y + 4.0;
         let svg_size = 15.0;

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -450,6 +450,13 @@ impl Widget<LapceTabData> for FileExplorerFileList {
                             LapceUICommand::OpenFile(node.path_buf.clone()),
                             Target::Widget(data.id),
                         ));
+                        ctx.submit_command(Command::new(
+                            LAPCE_UI_COMMAND,
+                            LapceUICommand::ActiveFileChanged {
+                                path: Some(node.path_buf.clone()),
+                            },
+                            Target::Widget(file_explorer.widget_id),
+                        ));
                     }
                 }
             }

--- a/lapce-ui/src/picker.rs
+++ b/lapce-ui/src/picker.rs
@@ -13,16 +13,16 @@ use druid::{
 };
 use lapce_data::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
-    config::LapceTheme,
+    config::{Config, LapceTheme},
     data::LapceTabData,
 };
 use lapce_rpc::file::FileNodeItem;
 
 use crate::{
     editor::view::LapceEditorView,
-    explorer::{get_item_children, get_item_children_mut, paint_file_node_item},
+    explorer::{get_item_children, get_item_children_mut},
     scroll::LapceScrollNew,
-    svg::get_svg,
+    svg::{file_svg_new, get_svg},
     tab::LapceButton,
 };
 
@@ -683,7 +683,7 @@ impl Widget<LapceTabData> for FilePickerExplorer {
         if let Some(item) = data.picker.get_file_node(&data.picker.pwd) {
             let mut i = 0;
             for item in item.sorted_children() {
-                i = paint_file_node_item(
+                i = paint_file_node_item_by_index(
                     ctx,
                     item,
                     min,
@@ -703,6 +703,137 @@ impl Widget<LapceTabData> for FilePickerExplorer {
             }
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn paint_file_node_item_by_index(
+    ctx: &mut PaintCtx,
+    item: &FileNodeItem,
+    min: usize,
+    max: usize,
+    line_height: f64,
+    width: f64,
+    level: usize,
+    current: usize,
+    active: usize,
+    hovered: Option<usize>,
+    config: &Config,
+    toggle_rects: &mut HashMap<usize, Rect>,
+) -> usize {
+    if current > max {
+        return current;
+    }
+    if current + item.children_open_count < min {
+        return current + item.children_open_count;
+    }
+    if current >= min {
+        let background = if current == active {
+            Some(LapceTheme::PANEL_CURRENT)
+        } else if Some(current) == hovered {
+            Some(LapceTheme::PANEL_HOVERED)
+        } else {
+            None
+        };
+
+        if let Some(background) = background {
+            ctx.fill(
+                Rect::ZERO
+                    .with_origin(Point::new(
+                        0.0,
+                        current as f64 * line_height - line_height,
+                    ))
+                    .with_size(Size::new(width, line_height)),
+                config.get_color_unchecked(background),
+            );
+        }
+
+        let y = current as f64 * line_height - line_height;
+        let svg_y = y + 4.0;
+        let svg_size = 15.0;
+        let padding = 15.0 * level as f64;
+        if item.is_dir {
+            let icon_name = if item.open {
+                "chevron-down.svg"
+            } else {
+                "chevron-right.svg"
+            };
+            let svg = get_svg(icon_name).unwrap();
+            let rect = Size::new(svg_size, svg_size)
+                .to_rect()
+                .with_origin(Point::new(1.0 + padding, svg_y));
+            ctx.draw_svg(
+                &svg,
+                rect,
+                Some(config.get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)),
+            );
+            toggle_rects.insert(current, rect);
+
+            let icon_name = if item.open {
+                "default_folder_opened.svg"
+            } else {
+                "default_folder.svg"
+            };
+            let svg = get_svg(icon_name).unwrap();
+            let rect = Size::new(svg_size, svg_size)
+                .to_rect()
+                .with_origin(Point::new(1.0 + 16.0 + padding, svg_y));
+            ctx.draw_svg(&svg, rect, None);
+        } else {
+            let svg = file_svg_new(&item.path_buf);
+            let rect = Size::new(svg_size, svg_size)
+                .to_rect()
+                .with_origin(Point::new(1.0 + 16.0 + padding, svg_y));
+            ctx.draw_svg(&svg, rect, None);
+        }
+        let text_layout = ctx
+            .text()
+            .new_text_layout(
+                item.path_buf
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            )
+            .font(FontFamily::SYSTEM_UI, 13.0)
+            .text_color(
+                config
+                    .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+                    .clone(),
+            )
+            .build()
+            .unwrap();
+        ctx.draw_text(
+            &text_layout,
+            Point::new(
+                38.0 + padding,
+                y + (line_height - text_layout.size().height) / 2.0,
+            ),
+        );
+    }
+    let mut i = current;
+    if item.open {
+        for item in item.sorted_children() {
+            i = paint_file_node_item_by_index(
+                ctx,
+                item,
+                min,
+                max,
+                line_height,
+                width,
+                level + 1,
+                i + 1,
+                active,
+                hovered,
+                config,
+                toggle_rects,
+            );
+            if i > max {
+                return i;
+            }
+        }
+    }
+    i
 }
 
 pub struct FilePickerControl {


### PR DESCRIPTION
Part 1 of #383

This PR adds an event that is fired when the user clicka file in file explorer, or switches tabs. This event is handled by the file explorer file list, and sets the active highlighted file's path.

This PR does not open a folder structure if the file is in a closed folder.