### PR TITLE
Add support for more C++ extensions

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -52,8 +52,8 @@ pub enum LapceLanguage {
 
 impl LapceLanguage {
     pub fn from_path(path: &Path) -> Option<LapceLanguage> {
-        let extension = path.extension()?.to_str()?;
-        Some(match extension {
+        let extension = path.extension()?.to_str()?.to_lowercase();
+        Some(match extension.as_str() {
             "rs" => LapceLanguage::Rust,
             "js" => LapceLanguage::Javascript,
             "jsx" => LapceLanguage::Jsx,
@@ -65,7 +65,9 @@ impl LapceLanguage {
             "php" => LapceLanguage::Php,
             "ex" | "exs" => LapceLanguage::Elixir,
             "c" | "h" => LapceLanguage::C,
-            "cpp" | "cxx" | "cc" | "hpp" | "hxx" => LapceLanguage::Cpp,
+            "cpp" | "cxx" | "cc" | "c++" | "hpp" | "hxx" | "hh" | "h++" => {
+                LapceLanguage::Cpp
+            }
             "json" => LapceLanguage::Json,
             _ => return None,
         })

--- a/lapce-ui/src/svg.rs
+++ b/lapce-ui/src/svg.rs
@@ -49,12 +49,17 @@ pub fn get_svg(name: &str) -> Option<Svg> {
 }
 
 pub fn file_svg_new(path: &Path) -> Svg {
+    let extension = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_lowercase();
     let file_type = match path.file_name().and_then(|f| f.to_str()).unwrap_or("") {
         "LICENSE" => "license",
-        _ => match path.extension().and_then(|s| s.to_str()).unwrap_or("") {
+        _ => match extension.as_str() {
             "rs" => "rust",
             "md" => "markdown",
-            "cc" => "cpp",
+            "cxx" | "cc" | "c++" => "cpp",
             s => s,
         },
     };


### PR DESCRIPTION
Lapce should recognize more C++ file extensions, this PR adds those missing extensions.

This is the most "official" list I could find for C++ extensions: https://gcc.gnu.org/onlinedocs/gcc-4.4.1/gcc/Overall-Options.html#index-file-name-suffix-71 and I've basically only added the extensions that are recognized by other popular editors (specifically VSCode).

