### PR TITLE
fix: Terminal should swallow interactions

### DIFF
--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -38,7 +38,7 @@ const DEFAULT_KEYMAPS_MACOS: &str =
 const DEFAULT_KEYMAPS_NONMACOS: &str =
     include_str!("../../../defaults/keymaps-nonmacos.toml");
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 enum KeymapMatch {
     Full(String),
     Multiple(Vec<String>),

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -609,6 +609,7 @@ impl Widget<LapceTabData> for LapceTerminal {
                         term_data.receive_char(ctx, &s);
                     }
                 }
+                ctx.set_handled();
                 data.keypress = keypress.clone();
             }
             Event::Command(cmd) if cmd.is(LAPCE_UI_COMMAND) => {


### PR DESCRIPTION
As the terminal current only has one mode to consider it should handle all interactions that are addressed to it.
Because the terminal is not handling all interactions some commands that should not be called (such as palette.line) are being handled by another dialogue and thus executed even if the mode is not supported.

Fixes: #423 