### PR TITLE
[TreeSitter] Add ruby language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,6 +1871,7 @@ dependencies = [
  "tree-sitter-json",
  "tree-sitter-php",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-toml",
  "tree-sitter-typescript",
@@ -4147,6 +4148,15 @@ name = "tree-sitter-python"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83c46916553ebc2a5b23763cd2da8d2b104c515c8f828eb678d1477ccd8c379c"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.19.0"
+source = "git+https://github.com/Liberatys/tree-sitter-ruby.git?branch=chore/allow-range-of-tree-sitter#26086eeb072266abf51273af631a2cb62d0fd1e8"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -19,6 +19,7 @@ tree-sitter-python = "0.19.1"
 tree-sitter-toml = "0.20.0"
 tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir.git", version = "0.19.0" }
 tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", version = "0.19.1" }
+tree-sitter-ruby = { git = "https://github.com/Liberatys/tree-sitter-ruby.git", branch = "chore/allow-range-of-tree-sitter" }
 tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
 tree-sitter-json = "0.19.0"

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -48,6 +48,7 @@ pub enum LapceLanguage {
     C,
     Cpp,
     Json,
+    Ruby,
 }
 
 impl LapceLanguage {
@@ -69,6 +70,7 @@ impl LapceLanguage {
                 LapceLanguage::Cpp
             }
             "json" => LapceLanguage::Json,
+            "rb" => LapceLanguage::Ruby,
             _ => return None,
         })
     }
@@ -88,6 +90,7 @@ impl LapceLanguage {
             LapceLanguage::C => "//",
             LapceLanguage::Cpp => "//",
             LapceLanguage::Json => "",
+            LapceLanguage::Ruby => "#",
         }
     }
 
@@ -106,6 +109,7 @@ impl LapceLanguage {
             LapceLanguage::C => "  ",
             LapceLanguage::Cpp => "    ",
             LapceLanguage::Json => "    ",
+            LapceLanguage::Ruby => "  ",
         }
     }
 
@@ -126,6 +130,7 @@ impl LapceLanguage {
             LapceLanguage::C => tree_sitter_c::language(),
             LapceLanguage::Cpp => tree_sitter_cpp::language(),
             LapceLanguage::Json => tree_sitter_json::language(),
+            LapceLanguage::Ruby => tree_sitter_ruby::language(),
         }
     }
 
@@ -152,6 +157,7 @@ impl LapceLanguage {
             LapceLanguage::C => tree_sitter_c::HIGHLIGHT_QUERY,
             LapceLanguage::Cpp => tree_sitter_cpp::HIGHLIGHT_QUERY,
             LapceLanguage::Json => tree_sitter_json::HIGHLIGHT_QUERY,
+            LapceLanguage::Ruby => tree_sitter_ruby::HIGHLIGHT_QUERY,
         };
 
         HighlightConfiguration::new(language, query, "", "").unwrap()


### PR DESCRIPTION
Add the tree-sitter crate for ruby and integrate into the language setup.

Currently against a fork of 'tree-sitter-ruby' till a pr to bump the pinned tree-sitter version.