### PR TITLE
Fixed backspace in terminal erasing whole word

### DIFF
--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -602,7 +602,11 @@ impl Widget<LapceTabData> for LapceTerminal {
 
                             s
                         }
-                        KbKey::Backspace => "\x08",
+                        KbKey::Backspace => if key_event.mods.ctrl() {
+                            "\x08" // ^H
+                        } else {
+                            "\x7f" // ^?
+                        },
                         KbKey::Tab => "\x09",
                         KbKey::Enter => "\r",
                         KbKey::Escape => "\x1b",

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -603,9 +603,9 @@ impl Widget<LapceTabData> for LapceTerminal {
                             s
                         }
                         KbKey::Backspace => if key_event.mods.ctrl() {
-                            "\x08" // ^H
+                            "\x08" // backspace
                         } else {
-                            "\x7f" // ^?
+                            "\x7f" // DEL
                         },
                         KbKey::Tab => "\x09",
                         KbKey::Enter => "\r",


### PR DESCRIPTION
Closes #221 

This change reflects the behavior I get in xfce4-terminal and I tested it with both zsh and bash.