### PR TITLE
Remove `allow(unused_variables)` attributes

### DIFF
--- a/lapce-data/src/buffer.rs
+++ b/lapce-data/src/buffer.rs
@@ -838,9 +838,8 @@ impl Buffer {
         history: &str,
         line: usize,
 
-        #[allow(unused_variables)] cursor_index: Option<usize>,
-
-        bounds: [f64; 2],
+        _cursor_index: Option<usize>,
+        _bounds: [f64; 2],
         config: &Config,
     ) -> Option<PietTextLayout> {
         let rope = self.decoration.histories.get(history)?;
@@ -881,7 +880,7 @@ impl Buffer {
         line_content: &str,
         cursor_index: Option<usize>,
         font_size: usize,
-        bounds: [f64; 2],
+        _bounds: [f64; 2],
         config: &Config,
     ) -> PietTextLayout {
         let styles = self.line_style(line);

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -679,8 +679,7 @@ impl LapceTabData {
         }
     }
 
-    #[allow(unused_variables)]
-    pub fn code_action_size(&self, text: &mut PietText, env: &Env) -> Size {
+    pub fn code_action_size(&self, text: &mut PietText, _env: &Env) -> Size {
         let editor = self.main_split.active_editor();
         let editor = match editor {
             Some(editor) => editor,
@@ -775,11 +774,10 @@ impl LapceTabData {
         }
     }
 
-    #[allow(unused_variables)]
     pub fn code_action_origin(
         &self,
         text: &mut PietText,
-        tab_size: Size,
+        _tab_size: Size,
         config: &Config,
     ) -> Point {
         let line_height = self.config.editor.line_height as f64;
@@ -925,14 +923,13 @@ impl LapceTabData {
         }
     }
 
-    #[allow(unused_variables)]
     pub fn run_workbench_command(
         &mut self,
         ctx: &mut EventCtx,
         command: &LapceWorkbenchCommand,
         data: Option<serde_json::Value>,
-        count: Option<usize>,
-        env: &Env,
+        _count: Option<usize>,
+        _env: &Env,
     ) {
         match command {
             LapceWorkbenchCommand::CloseFolder => {
@@ -1451,14 +1448,13 @@ impl LapceTabData {
         }
     }
 
-    #[allow(unused_variables)]
     pub fn terminal_update_process(
         tab_id: WidgetId,
-        palette_widget_id: WidgetId,
+        _palette_widget_id: WidgetId,
         receiver: Receiver<(TermId, TermEvent)>,
         event_sink: ExtEventSink,
-        workspace: Arc<LapceWorkspace>,
-        proxy: Arc<LapceProxy>,
+        _workspace: Arc<LapceWorkspace>,
+        _proxy: Arc<LapceProxy>,
     ) {
         let mut terminals = HashMap::new();
         let mut last_redraw = std::time::Instant::now();
@@ -2588,10 +2584,9 @@ impl LapceMainSplitData {
         self.editors.insert(editor.view_id, Arc::new(editor));
     }
 
-    #[allow(unused_variables)]
     pub fn split_close(
         &mut self,
-        ctx: &mut EventCtx,
+        _ctx: &mut EventCtx,
         split_id: WidgetId,
         from_content: SplitContent,
     ) {

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1098,8 +1098,7 @@ impl LapceEditorBufferData {
     ) -> RopeDelta {
         match &self.editor.cursor.mode {
             CursorMode::Normal(_) => {}
-            #[allow(unused_variables)]
-            CursorMode::Visual { start, end, mode } => {
+            CursorMode::Visual { .. } => {
                 let data = self
                     .editor
                     .cursor
@@ -1161,8 +1160,7 @@ impl LapceEditorBufferData {
     fn edit_with_command(&mut self, command: EditCommandKind) -> Option<RopeDelta> {
         match &self.editor.cursor.mode {
             CursorMode::Normal(_) => {}
-            #[allow(unused_variables)]
-            CursorMode::Visual { start, end, mode } => {
+            CursorMode::Visual { .. } => {
                 let data = self
                     .editor
                     .cursor
@@ -1858,8 +1856,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                             Some(horiz),
                         ));
                     }
-                    #[allow(unused_variables)]
-                    CursorMode::Visual { start, end, mode } => {
+                    CursorMode::Visual { .. } => {
                         let mut selection = Selection::new();
                         for region in self
                             .editor
@@ -1950,8 +1947,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                 let register = Arc::make_mut(&mut self.main_split.register);
                 register.add_yank(data);
                 match &self.editor.cursor.mode {
-                    #[allow(unused_variables)]
-                    CursorMode::Visual { start, end, mode } => {
+                    CursorMode::Visual { start, end, .. } => {
                         let offset = *start.min(end);
                         let offset =
                             self.buffer.offset_line_end(offset, false).min(offset);
@@ -2929,8 +2925,7 @@ impl KeyPressFocus for LapceEditorBufferData {
                             )
                             .0
                     }
-                    #[allow(unused_variables)]
-                    CursorMode::Visual { start, end, mode } => {
+                    CursorMode::Visual { end, .. } => {
                         self.buffer.offset_line_end(*end, false).min(*end)
                     }
                     CursorMode::Normal(offset) => *offset,

--- a/lapce-data/src/movement.rs
+++ b/lapce-data/src/movement.rs
@@ -44,8 +44,7 @@ impl Cursor {
     pub fn offset(&self) -> usize {
         match &self.mode {
             CursorMode::Normal(offset) => *offset,
-            #[allow(unused_variables)]
-            CursorMode::Visual { start, end, mode } => *end,
+            CursorMode::Visual { end, .. } => *end,
             CursorMode::Insert(selection) => selection.get_cursor_offset(),
         }
     }
@@ -234,8 +233,7 @@ impl Cursor {
                 let line = buffer.line_of_offset(*offset);
                 (line, line)
             }
-            #[allow(unused_variables)]
-            CursorMode::Visual { start, end, mode } => {
+            CursorMode::Visual { start, end, .. } => {
                 let start_line = buffer.line_of_offset(*start.min(end));
                 let end_line = buffer.line_of_offset(*start.max(end));
                 (start_line, end_line)

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -1,22 +1,17 @@
 use alacritty_terminal::{grid::Dimensions, term::cell::Flags};
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver, Sender, TryRecvError};
-use druid::{
-    Command, ExtEventSink, Lens, Modifiers, Target,
-    WidgetId,
-};
-use druid::{
-    Data, Env, EventCtx,
-};
+use druid::{Command, ExtEventSink, Lens, Modifiers, Target, WidgetId};
+use druid::{Data, Env, EventCtx};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use itertools::Itertools;
 use lsp_types::{DocumentSymbolResponse, Range, SymbolKind};
 use serde_json;
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::cmp::Ordering;
 use uuid::Uuid;
 
 use crate::{
@@ -125,13 +120,7 @@ impl PaletteItemContent {
                     ));
                 }
             }
-            #[allow(unused_variables)]
-            PaletteItemContent::DocumentSymbol {
-                kind,
-                name,
-                range,
-                container_name,
-            } => {
+            PaletteItemContent::DocumentSymbol { range, .. } => {
                 let editor_id = if preview {
                     Some(preview_editor_id)
                 } else {
@@ -686,8 +675,7 @@ impl PaletteViewData {
         }));
     }
 
-    #[allow(unused_variables)]
-    fn get_ssh_hosts(&mut self, ctx: &mut EventCtx) {
+    fn get_ssh_hosts(&mut self, _ctx: &mut EventCtx) {
         let workspaces = Config::recent_workspaces().unwrap_or_default();
         let mut hosts = HashSet::new();
         for workspace in workspaces.iter() {
@@ -711,8 +699,7 @@ impl PaletteViewData {
             .collect();
     }
 
-    #[allow(unused_variables)]
-    fn get_workspaces(&mut self, ctx: &mut EventCtx) {
+    fn get_workspaces(&mut self, _ctx: &mut EventCtx) {
         let workspaces = Config::recent_workspaces().unwrap_or_default();
         let palette = Arc::make_mut(&mut self.palette);
         palette.items = workspaces
@@ -744,8 +731,7 @@ impl PaletteViewData {
             .collect();
     }
 
-    #[allow(unused_variables)]
-    fn get_themes(&mut self, ctx: &mut EventCtx, config: &Config) {
+    fn get_themes(&mut self, _ctx: &mut EventCtx, config: &Config) {
         let palette = Arc::make_mut(&mut self.palette);
         palette.items = config
             .themes
@@ -759,8 +745,7 @@ impl PaletteViewData {
             .collect();
     }
 
-    #[allow(unused_variables)]
-    fn get_commands(&mut self, ctx: &mut EventCtx) {
+    fn get_commands(&mut self, _ctx: &mut EventCtx) {
         const EXCLUDED_ITEMS: &[&str] = &["palette.command"];
 
         let palette = Arc::make_mut(&mut self.palette);
@@ -783,8 +768,7 @@ impl PaletteViewData {
             .collect();
     }
 
-    #[allow(unused_variables)]
-    fn get_lines(&mut self, ctx: &mut EventCtx) {
+    fn get_lines(&mut self, _ctx: &mut EventCtx) {
         if self.focus_area == FocusArea::Panel(PanelKind::Terminal) {
             if let Some(terminal) =
                 self.terminal.terminals.get(&self.terminal.active_term_id)
@@ -863,8 +847,7 @@ impl PaletteViewData {
             .collect();
     }
 
-    #[allow(unused_variables)]
-    fn get_global_search(&mut self, ctx: &mut EventCtx) {}
+    fn get_global_search(&mut self, _ctx: &mut EventCtx) {}
 
     fn get_document_symbols(&mut self, ctx: &mut EventCtx) {
         let editor = self.main_split.active_editor();
@@ -986,9 +969,8 @@ impl PaletteViewData {
         }
     }
 
-    #[allow(unused_variables)]
     fn filter_items(
-        run_id: &str,
+        _run_id: &str,
         input: &str,
         items: Vec<NewPaletteItem>,
         matcher: &SkimMatcherV2,

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -130,10 +130,6 @@ impl Handler for LapceProxy {
                     Target::Widget(self.tab_id),
                 );
             }
-            #[allow(unused_variables)]
-            ListDir { items } => {}
-            #[allow(unused_variables)]
-            DiffFiles { files } => {}
             DiffInfo { diff } => {
                 let _ = self.event_sink.submit_command(
                     LAPCE_UI_COMMAND,
@@ -168,6 +164,7 @@ impl Handler for LapceProxy {
                     Target::Widget(self.tab_id),
                 );
             }
+            ListDir { .. } | DiffFiles { .. } => {}
         }
         ControlFlow::Continue
     }

--- a/lapce-data/src/terminal.rs
+++ b/lapce-data/src/terminal.rs
@@ -42,8 +42,7 @@ pub struct TerminalSplitData {
 }
 
 impl TerminalSplitData {
-    #[allow(unused_variables)]
-    pub fn new(proxy: Arc<LapceProxy>) -> Self {
+    pub fn new(_proxy: Arc<LapceProxy>) -> Self {
         let split_id = WidgetId::next();
         let terminals = im::HashMap::new();
 

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -399,8 +399,7 @@ impl Dispatcher {
                     "result": resp,
                 }));
             }
-            #[allow(unused_variables)]
-            BufferHead { buffer_id, path } => {
+            BufferHead { path, .. } => {
                 if let Some(workspace) = self.workspace.lock().clone() {
                     let result = file_get_head(&workspace, &path);
                     if let Ok((_blob_id, content)) = result {
@@ -516,8 +515,7 @@ impl Dispatcher {
                     local_dispatcher.respond(id, result);
                 });
             }
-            #[allow(unused_variables)]
-            GetFiles { path } => {
+            GetFiles { .. } => {
                 if let Some(workspace) = self.workspace.lock().clone() {
                     let local_dispatcher = self.clone();
                     thread::spawn(move || {

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -178,11 +178,10 @@ impl LspCatalog {
         }
     }
 
-    #[allow(unused_variables)]
     pub fn get_completion(
         &self,
         id: RequestId,
-        request_id: usize,
+        _request_id: usize,
         buffer: &Buffer,
         position: Position,
     ) {
@@ -323,11 +322,10 @@ impl LspCatalog {
         }
     }
 
-    #[allow(unused_variables)]
     pub fn get_definition(
         &self,
         id: RequestId,
-        request_id: usize,
+        _request_id: usize,
         buffer: &Buffer,
         position: Position,
     ) {

--- a/lapce-ui/src/code_action.rs
+++ b/lapce-ui/src/code_action.rs
@@ -165,8 +165,7 @@ impl CodeActionData {
         }
     }
 
-    #[allow(unused_variables)]
-    pub fn previous(&mut self, ctx: &mut EventCtx) {
+    pub fn previous(&mut self, _ctx: &mut EventCtx) {
         let editor = self.main_split.active_editor();
         let editor = match editor {
             Some(editor) => editor,

--- a/lapce-ui/src/palette.rs
+++ b/lapce-ui/src/palette.rs
@@ -558,12 +558,11 @@ impl NewPaletteContent {
                 PaletteItemContent::File(path, _) => {
                     Self::file_paint_items(path, indices)
                 }
-                #[allow(unused_variables)]
                 PaletteItemContent::DocumentSymbol {
                     kind,
                     name,
-                    range,
                     container_name,
+                    ..
                 } => {
                     let text = name.to_string();
                     let hint =

--- a/lapce-ui/src/scroll.rs
+++ b/lapce-ui/src/scroll.rs
@@ -927,8 +927,7 @@ impl<T, W: Widget<T>> LapceScrollNew<T, W> {
     ///
     /// If the target region is larger than the viewport, we will display the
     /// portion that fits, prioritizing the portion closest to the origin.
-    #[allow(unused_variables)]
-    pub fn scroll_to_visible(&mut self, region: Rect, env: &Env) -> bool {
+    pub fn scroll_to_visible(&mut self, region: Rect, _env: &Env) -> bool {
         self.clip.pan_to_visible(region)
     }
 }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -859,7 +859,8 @@ impl Widget<LapceTabData> for LapceTabNew {
                             .as_ref()
                             .map(|p| {
                                 let dir = p
-                                    .file_name().unwrap_or(p.as_os_str())
+                                    .file_name()
+                                    .unwrap_or(p.as_os_str())
                                     .to_string_lossy();
                                 let dir = match &data.workspace.kind {
                                     LapceWorkspaceType::Local => dir.to_string(),
@@ -920,13 +921,12 @@ impl Widget<LapceTabData> for LapceTabNew {
                             }
                         }
                     }
-                    #[allow(unused_variables)]
                     LapceUICommand::UpdateHistoryChanges {
-                        id,
                         path,
                         rev,
                         history,
                         changes,
+                        ..
                     } => {
                         ctx.set_handled();
                         let buffer =
@@ -937,12 +937,11 @@ impl Widget<LapceTabData> for LapceTabNew {
                             changes.clone(),
                         );
                     }
-                    #[allow(unused_variables)]
                     LapceUICommand::UpdateHistoryStyle {
-                        id,
                         path,
                         history,
                         highlights,
+                        ..
                     } => {
                         ctx.set_handled();
                         let buffer =
@@ -1600,9 +1599,7 @@ impl Widget<LapceTabData> for LapceTabHeader {
             .path
             .as_ref()
             .map(|p| {
-                let dir = p
-                    .file_name().unwrap_or(p.as_os_str())
-                    .to_string_lossy();
+                let dir = p.file_name().unwrap_or(p.as_os_str()).to_string_lossy();
                 let dir = match &data.workspace.kind {
                     LapceWorkspaceType::Local => dir.to_string(),
                     LapceWorkspaceType::RemoteSSH(user, host) => {


### PR DESCRIPTION
I consider this attribute somewhat dangerous as it might hide variables that shouldn't be. This was the reason why in #426 the `tab_id` variable wasn't marked as unused, indirectly leading to a bug.