### PR TITLE
Create the fastdev profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,6 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "bytemuck",
- "cc",
  "chrono",
  "config",
  "crossbeam-channel",
@@ -1959,7 +1958,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
- "threadpool",
  "tinyfiledialogs",
  "toml",
  "unicode-segmentation",
@@ -2027,7 +2025,6 @@ dependencies = [
  "anyhow",
  "base64",
  "bit-vec",
- "cc",
  "chrono",
  "config",
  "crossbeam-channel",
@@ -2060,7 +2057,6 @@ dependencies = [
  "structdesc",
  "strum",
  "strum_macros",
- "threadpool",
  "tinyfiledialogs",
  "toml",
  "unicode-segmentation",
@@ -4037,15 +4033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ path = "lapce-proxy/src/bin/lapce-proxy.rs"
 [workspace]
 members = ["lapce-ui", "lapce-proxy", "lapce-rpc", "lapce-data", "lapce-core"]
 
-# A profile which compiles all dependencies in release mode but lapce
-# code in dev mode. This gives a good debugging experience for your
+# A profile which compiles all (non-workspace) dependencies in release mode
+# but Lapce code in dev mode. This gives a good debugging experience for your
 # code and fast performance of other people's code. After the initial
 # build subsequent ones are as fast as dev mode builds.
 # See https://doc.rust-lang.org/cargo/reference/profiles.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,5 @@ members = ["lapce-ui", "lapce-proxy", "lapce-rpc", "lapce-data", "lapce-core"]
 [profile.fastdev.package."*"]
 opt-level = 3
 
-[profile.fastdev.build-override]
-opt-level = 3
-
 [profile.fastdev]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,20 @@ path = "lapce-proxy/src/bin/lapce-proxy.rs"
 
 [workspace]
 members = ["lapce-ui", "lapce-proxy", "lapce-rpc", "lapce-data", "lapce-core"]
+
+# A profile which compiles all dependencies in release mode but lapce
+# code in dev mode. This gives a good debugging experience for your
+# code and fast performance of other people's code. After the initial
+# build subsequent ones are as fast as dev mode builds.
+# See https://doc.rust-lang.org/cargo/reference/profiles.html
+# To use this profile:
+#   cargo build --profile fastdev
+#   cargo run --profile fastdev --bin lapce
+[profile.fastdev.package."*"]
+opt-level = 3
+
+[profile.fastdev.build-override]
+opt-level = 3
+
+[profile.fastdev]
+inherits = "dev"

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -56,8 +56,3 @@ lapce-core = { path = "../lapce-core" }
 lapce-rpc = { path = "../lapce-rpc" }
 lapce-proxy = { path = "../lapce-proxy" }
 bytemuck = "1.8.0"
-
-[build-dependencies]
-cc = "1"
-anyhow = "1.0.32"
-threadpool = "1.0"

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -49,8 +49,3 @@ toml = { version = "0.5.8", features = ["preserve_order"] }
 structdesc = { git = "https://github.com/lapce/structdesc" }
 lapce-data = { path = "../lapce-data" }
 lapce-rpc = { path = "../lapce-rpc" }
-
-[build-dependencies]
-cc = "1"
-anyhow = "1.0.32"
-threadpool = "1.0"


### PR DESCRIPTION
I noticed that recently the dev builds of lapce are running slower than they used to, perhaps because of the rendering engine change. It is possible to get the best of both worlds with cargo - a good debugging experience with fast builds for your own code, AND release-optimised code for your dependencies. I find this to be nice and speedy and yet still debuggable, this works well when you don't care about stepping into your dependencies.

To demonstrate, I have created a new `fastdev` profile in the root `Cargo.toml`. Alternatively, if nobody cares about stepping into the dependencies for debugging purposes, it is possible to configure the `dev` profile this way.