### PR TITLE
Fix menu positions, allocate less while rendering window

### DIFF
--- a/lapce-ui/src/editor/tab_header.rs
+++ b/lapce-ui/src/editor/tab_header.rs
@@ -14,8 +14,7 @@ use lapce_data::{
 
 use crate::{
     editor::tab_header_content::LapceEditorTabHeaderContent, scroll::LapceScrollNew,
-    svg::get_svg,
-    tab::LapceIcon,
+    svg::get_svg, tab::LapceIcon,
 };
 
 pub struct LapceEditorTabHeader {
@@ -145,8 +144,8 @@ impl Widget<LapceTabData> for LapceEditorTabHeader {
             let height = 30.0;
             let size = Size::new(bc.max().width, height);
 
-            let editor_tab =
-                data.main_split.editor_tabs.get(&self.widget_id).unwrap();
+            // let editor_tab =
+            //     data.main_split.editor_tabs.get(&self.widget_id).unwrap();
 
             //    if self.is_hot || *editor_tab.content_is_hot.borrow() {
             let icon_size = 24.0;

--- a/lapce-ui/src/editor/tab_header.rs
+++ b/lapce-ui/src/editor/tab_header.rs
@@ -144,10 +144,6 @@ impl Widget<LapceTabData> for LapceEditorTabHeader {
             let height = 30.0;
             let size = Size::new(bc.max().width, height);
 
-            // let editor_tab =
-            //     data.main_split.editor_tabs.get(&self.widget_id).unwrap();
-
-            //    if self.is_hot || *editor_tab.content_is_hot.borrow() {
             let icon_size = 24.0;
             let gap = (height - icon_size) / 2.0;
             let x = size.width - ((self.icons.len() + 1) as f64) * (gap + icon_size);
@@ -182,7 +178,6 @@ impl Widget<LapceTabData> for LapceEditorTabHeader {
                 ),
             };
             self.icons.push(icon);
-            //}
 
             size
         } else {

--- a/lapce-ui/src/editor/tab_header.rs
+++ b/lapce-ui/src/editor/tab_header.rs
@@ -147,44 +147,43 @@ impl Widget<LapceTabData> for LapceEditorTabHeader {
 
             let editor_tab =
                 data.main_split.editor_tabs.get(&self.widget_id).unwrap();
-            if self.is_hot || *editor_tab.content_is_hot.borrow() {
-                let icon_size = 24.0;
-                let gap = (height - icon_size) / 2.0;
-                let x =
-                    size.width - ((self.icons.len() + 1) as f64) * (gap + icon_size);
-                let icon = LapceIcon {
-                    icon: "close.svg".to_string(),
-                    rect: Size::new(icon_size, icon_size)
-                        .to_rect()
-                        .with_origin(Point::new(x, gap)),
-                    command: Command::new(
-                        LAPCE_UI_COMMAND,
-                        LapceUICommand::SplitClose,
-                        Target::Widget(self.widget_id),
-                    ),
-                };
-                self.icons.push(icon);
 
-                let x =
-                    size.width - ((self.icons.len() + 1) as f64) * (gap + icon_size);
-                let icon = LapceIcon {
-                    icon: "split-horizontal.svg".to_string(),
-                    rect: Size::new(icon_size, icon_size)
-                        .to_rect()
-                        .with_origin(Point::new(x, gap)),
-                    command: Command::new(
-                        LAPCE_NEW_COMMAND,
-                        LapceCommandNew {
-                            cmd: LapceCommand::SplitVertical.to_string(),
-                            data: None,
-                            palette_desc: None,
-                            target: CommandTarget::Focus,
-                        },
-                        Target::Widget(self.widget_id),
-                    ),
-                };
-                self.icons.push(icon);
-            }
+            //    if self.is_hot || *editor_tab.content_is_hot.borrow() {
+            let icon_size = 24.0;
+            let gap = (height - icon_size) / 2.0;
+            let x = size.width - ((self.icons.len() + 1) as f64) * (gap + icon_size);
+            let icon = LapceIcon {
+                icon: "close.svg".to_string(),
+                rect: Size::new(icon_size, icon_size)
+                    .to_rect()
+                    .with_origin(Point::new(x, gap)),
+                command: Command::new(
+                    LAPCE_UI_COMMAND,
+                    LapceUICommand::SplitClose,
+                    Target::Widget(self.widget_id),
+                ),
+            };
+            self.icons.push(icon);
+
+            let x = size.width - ((self.icons.len() + 1) as f64) * (gap + icon_size);
+            let icon = LapceIcon {
+                icon: "split-horizontal.svg".to_string(),
+                rect: Size::new(icon_size, icon_size)
+                    .to_rect()
+                    .with_origin(Point::new(x, gap)),
+                command: Command::new(
+                    LAPCE_NEW_COMMAND,
+                    LapceCommandNew {
+                        cmd: LapceCommand::SplitVertical.to_string(),
+                        data: None,
+                        palette_desc: None,
+                        target: CommandTarget::Focus,
+                    },
+                    Target::Widget(self.widget_id),
+                ),
+            };
+            self.icons.push(icon);
+            //}
 
             size
         } else {

--- a/lapce-ui/src/menu.rs
+++ b/lapce-ui/src/menu.rs
@@ -135,6 +135,10 @@ impl Widget<LapceWindowData> for Menu {
         data: &LapceWindowData,
         _env: &Env,
     ) {
+        if !old_data.menu.origin.same(&data.menu.origin) {
+            ctx.request_layout();
+        }
+
         if !old_data.menu.items.same(&data.menu.items) {
             ctx.request_layout();
         }

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -16,8 +16,7 @@ use lapce_data::{
 use serde_json::json;
 
 use crate::{
-    scroll::LapceScrollNew, split::LapceSplitNew, tab::LapceIcon,
-    svg::get_svg,
+    scroll::LapceScrollNew, split::LapceSplitNew, svg::get_svg, tab::LapceIcon,
 };
 
 pub struct LapcePanel {
@@ -314,7 +313,6 @@ impl Widget<LapceTabData> for PanelSectionHeader {
         let shadow_width = 5.0;
         let rect = ctx.size().to_rect();
         ctx.with_save(|ctx| {
-            ctx.clip(rect.inflate(0.0, 100.0));
             ctx.blurred_rect(
                 rect,
                 shadow_width,
@@ -512,7 +510,6 @@ impl Widget<LapceTabData> for PanelMainHeader {
         let shadow_width = 5.0;
         let rect = ctx.size().to_rect();
         ctx.with_save(|ctx| {
-            ctx.clip(rect.inflate(0.0, 100.0));
             ctx.blurred_rect(
                 rect,
                 shadow_width,

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -349,7 +349,7 @@ impl Widget<LapceWindowData> for Title {
             Command::new(
                 LAPCE_UI_COMMAND,
                 LapceUICommand::ShowMenu(
-                    Point::new(command_rect.x0, command_rect.y1),
+                    ctx.to_window(Point::new(command_rect.x0, command_rect.y1)),
                     self.remote_menu_items.clone(),
                 ),
                 Target::Auto,
@@ -402,7 +402,7 @@ impl Widget<LapceWindowData> for Title {
             Command::new(
                 LAPCE_UI_COMMAND,
                 LapceUICommand::ShowMenu(
-                    Point::new(command_rect.x0, command_rect.y1),
+                    ctx.to_window(Point::new(command_rect.x0, command_rect.y1)),
                     self.workspace_menu_items.clone(),
                 ),
                 Target::Auto,
@@ -471,7 +471,7 @@ impl Widget<LapceWindowData> for Title {
                 Command::new(
                     LAPCE_UI_COMMAND,
                     LapceUICommand::ShowMenu(
-                        Point::new(command_rect.x0, command_rect.y1),
+                        ctx.to_window(Point::new(command_rect.x0, command_rect.y1)),
                         Arc::new(menu_items),
                     ),
                     Target::Auto,
@@ -503,7 +503,7 @@ impl Widget<LapceWindowData> for Title {
             Command::new(
                 LAPCE_UI_COMMAND,
                 LapceUICommand::ShowMenu(
-                    Point::new(size.width - 300.0, settings_rect.y1),
+                    ctx.to_window(Point::new(size.width - 300.0, settings_rect.y1)),
                     self.settings_menu_items.clone(),
                 ),
                 Target::Auto,

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -228,6 +228,10 @@ impl Widget<LapceWindowData> for Title {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceWindowData, _env: &Env) {
         let size = ctx.size();
         let rect = size.to_rect();
+
+        let icon_width = size.height; // icons are square
+        let icon_size = Size::new(icon_width, icon_width);
+
         ctx.fill(
             rect,
             data.config
@@ -292,7 +296,7 @@ impl Widget<LapceWindowData> for Title {
         };
 
         let remote_rect = Size::new(
-            size.height
+            icon_width
                 + 10.0
                 + remote_text
                     .as_ref()
@@ -302,6 +306,8 @@ impl Widget<LapceWindowData> for Title {
         )
         .to_rect()
         .with_origin(Point::new(x, 0.0));
+
+        // TODO: make these theme colors
         let color = match &tab.workspace.kind {
             LapceWorkspaceType::Local => Color::rgb8(64, 120, 242),
             LapceWorkspaceType::RemoteSSH(_, _) | LapceWorkspaceType::RemoteWSL => {
@@ -316,7 +322,7 @@ impl Widget<LapceWindowData> for Title {
         let remote_svg = get_svg("remote.svg").unwrap();
         ctx.draw_svg(
             &remote_svg,
-            Size::new(size.height, size.height)
+            icon_size
                 .to_rect()
                 .with_origin(Point::new(x + 5.0, 0.0))
                 .inflate(-5.0, -5.0),
@@ -354,9 +360,7 @@ impl Widget<LapceWindowData> for Title {
 
         x += 5.0;
         let folder_svg = get_svg("default_folder.svg").unwrap();
-        let folder_rect = Size::new(size.height, size.height)
-            .to_rect()
-            .with_origin(Point::new(x, 0.0));
+        let folder_rect = icon_size.to_rect().with_origin(Point::new(x, 0.0));
         ctx.draw_svg(
             &folder_svg,
             folder_rect.inflate(-5.0, -5.0),
@@ -365,7 +369,7 @@ impl Widget<LapceWindowData> for Title {
                     .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND),
             ),
         );
-        x += size.height; // FIXME: this can't possibly be correct
+        x += icon_width;
         let text = if let Some(workspace_path) = tab.workspace.path.as_ref() {
             workspace_path
                 .file_name()
@@ -414,9 +418,7 @@ impl Widget<LapceWindowData> for Title {
 
             x += 5.0;
             let folder_svg = get_svg("git-icon.svg").unwrap();
-            let folder_rect = Size::new(size.height, size.height)
-                .to_rect()
-                .with_origin(Point::new(x, 0.0));
+            let folder_rect = icon_size.to_rect().with_origin(Point::new(x, 0.0));
             ctx.draw_svg(
                 &folder_svg,
                 folder_rect.inflate(-6.5, -6.5),
@@ -425,7 +427,7 @@ impl Widget<LapceWindowData> for Title {
                         .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND),
                 ),
             );
-            x += size.height;
+            x += icon_width;
 
             let mut branch = tab.source_control.branch.clone();
             if !tab.source_control.file_diffs.is_empty() {
@@ -482,11 +484,10 @@ impl Widget<LapceWindowData> for Title {
             ctx.stroke(line, line_color, 1.0);
         }
 
-        x = size.width;
-        x -= size.height;
-        let settings_rect = Size::new(size.height, size.height)
-            .to_rect()
-            .with_origin(Point::new(x, 0.0));
+        // Right align
+        x = size.width - icon_width;
+
+        let settings_rect = icon_size.to_rect().with_origin(Point::new(x, 0.0));
         let settings_svg = get_svg("settings.svg").unwrap();
         ctx.draw_svg(
             &settings_svg,

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -293,7 +293,7 @@ impl Widget<LapceWindowData> for Title {
                     .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND),
             ),
         );
-        x += size.height;
+        x += size.height; // FIXME: this can't possibly be correct
         let text = if let Some(workspace_path) = tab.workspace.path.as_ref() {
             workspace_path
                 .file_name()

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -272,9 +272,9 @@ impl Widget<LapceWindowData> for Title {
             }
             LapceWorkspaceType::RemoteWSL => {
                 let text = match *tab.proxy_status {
-                    ProxyStatus::Connecting => "Connecting to WSL ...".to_string(),
-                    ProxyStatus::Connected => "WSL".to_string(),
-                    ProxyStatus::Disconnected => "Disconnected WSL".to_string(),
+                    ProxyStatus::Connecting => "Connecting to WSL ...",
+                    ProxyStatus::Connected => "WSL",
+                    ProxyStatus::Disconnected => "Disconnected WSL",
                 };
                 let text_layout = ctx
                     .text()

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -488,6 +488,9 @@ impl Widget<LapceWindowData> for LapceWindowNew {
         if old_tab.workspace != tab.workspace {
             ctx.request_layout();
         }
+        for tab_header in self.tab_headers.iter_mut() {
+            tab_header.update(ctx, data, env);
+        }
         for tab in self.tabs.iter_mut() {
             tab.update(ctx, data, env);
         }

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -603,7 +603,10 @@ impl Widget<LapceWindowData> for LapceWindowNew {
             1.0,
         );
 
-        self.tabs[data.active].paint(ctx, data, env);
+        ctx.with_save(|ctx| {
+            ctx.clip(self.tabs[data.active].layout_rect());
+            self.tabs[data.active].paint(ctx, data, env);
+        });
 
         self.menu.paint(ctx, data, env);
     }

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -513,6 +513,9 @@ impl Widget<LapceWindowData> for LapceWindowNew {
 
         let title_size = self.title.layout(ctx, bc, data, env);
 
+        self.title.set_origin(ctx, data, env, Point::new(0.0, y));
+        y += title_size.height;
+
         let (tab_header_height, tab_size) = if self.tabs.len() > 1 {
             let tab_height = 25.0;
             let tab_size = Size::new(
@@ -572,9 +575,6 @@ impl Widget<LapceWindowData> for LapceWindowNew {
         };
         y += tab_header_height;
 
-        self.title.set_origin(ctx, data, env, Point::new(0.0, y));
-        y += title_size.height;
-
         let bc = BoxConstraints::tight(tab_size);
         self.tabs[data.active].layout(ctx, &bc, data, env);
         self.tabs[data.active].set_origin(ctx, data, env, Point::new(0.0, y));
@@ -589,7 +589,9 @@ impl Widget<LapceWindowData> for LapceWindowNew {
         let border_color = data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER);
 
         let mut y = 0.0;
-        y += self.paint_tab_bar(ctx, data, env, y);
+
+        self.title.paint(ctx, data, env);
+        y += self.title.layout_rect().height();
 
         ctx.stroke(
             Line::new(Point::new(0.0, y - 0.5), Point::new(width, y - 0.5)),
@@ -597,8 +599,7 @@ impl Widget<LapceWindowData> for LapceWindowNew {
             1.0,
         );
 
-        self.title.paint(ctx, data, env);
-        y += self.title.layout_rect().height();
+        y += self.paint_tab_bar(ctx, data, env, y);
 
         ctx.stroke(
             Line::new(Point::new(0.0, y - 0.5), Point::new(width, y - 0.5)),


### PR DESCRIPTION
 - Title bar now displays the menu at the correct relative space, not assuming y=0
 - Commands are no longer reallocated liberally
 - Menu now uses point of origin in the equality check
 - File explorer drop shadow no longer draws outside of the editor tab area.
 - Some other cleanups