### PR TITLE
File explorer header UI fixes

### DIFF
--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -311,7 +311,6 @@ impl Widget<LapceTabData> for PanelSectionHeader {
         let shadow_width = 5.0;
         let rect = ctx.size().to_rect();
         ctx.with_save(|ctx| {
-            ctx.clip(rect.inflate(0.0, 100.0));
             ctx.blurred_rect(
                 rect,
                 shadow_width,
@@ -506,7 +505,6 @@ impl Widget<LapceTabData> for PanelMainHeader {
         let shadow_width = 5.0;
         let rect = ctx.size().to_rect();
         ctx.with_save(|ctx| {
-            ctx.clip(rect.inflate(0.0, 100.0));
             ctx.blurred_rect(
                 rect,
                 shadow_width,

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -82,8 +82,8 @@ impl Widget<LapceTabData> for LapcePanel {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, env: &Env) {
-        self.header.paint(ctx, data, env);
         self.split.paint(ctx, data, env);
+        self.header.paint(ctx, data, env);
     }
 }
 

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -534,7 +534,10 @@ impl Widget<LapceWindowData> for LapceWindowNew {
             }
         }
 
-        self.tabs[data.active].paint(ctx, data, env);
+        ctx.with_save(|ctx| {
+            ctx.clip(self.tabs[data.active].layout_rect());
+            self.tabs[data.active].paint(ctx, data, env);
+        });
 
         let line_color = data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER);
         if self.tabs.len() > 1 {


### PR DESCRIPTION
Before: note the drop shadow over the inactive tab, and that the hovered file overlaps the bottom drop shadow

![1](https://user-images.githubusercontent.com/977627/166971060-c00f627b-54eb-44bc-b78b-4e2ac286e33a.png)
![2](https://user-images.githubusercontent.com/977627/166971064-a843eb30-359a-45fb-bb32-0ece8ea4e652.png)

After:

![3](https://user-images.githubusercontent.com/977627/166971175-e7125d6e-9209-46a7-af38-ebf1ba237116.png)

