### PR TITLE
Menu improvements

### DIFF
--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -216,11 +216,13 @@ impl LapceEditor {
                 },
             },
         ];
-        let point =
-            mouse_event.pos + editor_data.editor.window_origin.borrow().to_vec2();
+
         ctx.submit_command(Command::new(
             LAPCE_UI_COMMAND,
-            LapceUICommand::ShowMenu(point.round(), Arc::new(menu_items)),
+            LapceUICommand::ShowMenu(
+                ctx.to_window(mouse_event.pos),
+                Arc::new(menu_items),
+            ),
             Target::Auto,
         ));
     }

--- a/lapce-ui/src/menu.rs
+++ b/lapce-ui/src/menu.rs
@@ -135,6 +135,10 @@ impl Widget<LapceWindowData> for Menu {
         data: &LapceWindowData,
         _env: &Env,
     ) {
+        if !old_data.menu.origin.same(&data.menu.origin) {
+            ctx.request_layout();
+        }
+
         if !old_data.menu.items.same(&data.menu.items) {
             ctx.request_layout();
         }

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -267,7 +267,7 @@ impl Widget<LapceWindowData> for Title {
             Command::new(
                 LAPCE_UI_COMMAND,
                 LapceUICommand::ShowMenu(
-                    Point::new(command_rect.x0, command_rect.y1),
+                    ctx.to_window(Point::new(command_rect.x0, command_rect.y1)),
                     Arc::new(menu_items),
                 ),
                 Target::Auto,
@@ -346,7 +346,7 @@ impl Widget<LapceWindowData> for Title {
             Command::new(
                 LAPCE_UI_COMMAND,
                 LapceUICommand::ShowMenu(
-                    Point::new(command_rect.x0, command_rect.y1),
+                    ctx.to_window(Point::new(command_rect.x0, command_rect.y1)),
                     Arc::new(menu_items),
                 ),
                 Target::Auto,
@@ -417,7 +417,7 @@ impl Widget<LapceWindowData> for Title {
                 Command::new(
                     LAPCE_UI_COMMAND,
                     LapceUICommand::ShowMenu(
-                        Point::new(command_rect.x0, command_rect.y1),
+                        ctx.to_window(Point::new(command_rect.x0, command_rect.y1)),
                         Arc::new(menu_items),
                     ),
                     Target::Auto,
@@ -487,7 +487,7 @@ impl Widget<LapceWindowData> for Title {
             Command::new(
                 LAPCE_UI_COMMAND,
                 LapceUICommand::ShowMenu(
-                    Point::new(size.width - 300.0, settings_rect.y1),
+                    ctx.to_window(Point::new(size.width - 300.0, settings_rect.y1)),
                     Arc::new(menu_items),
                 ),
                 Target::Auto,


### PR DESCRIPTION
- Don't assume local and window coordinates are equal
- Re-layout menu if origin changes
- Use the proper transform method instead of manually implementing it