### PR TITLE
allow to disable auto check for plugins

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -4,6 +4,9 @@ color-theme = "Lapce Dark"
 icon-theme = ""
 terminal-shell = ""
 
+[plugins]
+auto-check = true
+
 [editor]
 font-family = "Cascadia Code"
 font-size = 13

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -329,10 +329,18 @@ impl Themes {
     }
 }
 
+#[derive(FieldNames, Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct PluginsConfig {
+    #[field_names(desc = "Check for plugins automatically")]
+    pub auto_check: bool,
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     pub lapce: LapceConfig,
     pub editor: EditorConfig,
+    pub plugins: PluginsConfig,
     #[serde(skip)]
     pub themes: Themes,
     #[serde(skip)]


### PR DESCRIPTION
Also corrected a couple of spelling errors in the existing function names.

I am not sure if this single boolean setting deserves a group by its own. It could have been named as "auto-check-plugins" and added in the "lapce" (aka core) group.