### PR TITLE
Introduce `ReadOnlyString`

### DIFF
--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -223,7 +223,7 @@ impl FileExplorer {
             data.file_explorer.widget_id,
             split_id,
             SplitDirection::Vertical,
-            PanelHeaderKind::Simple("File Explorer".to_string()),
+            PanelHeaderKind::Simple("File Explorer".into()),
             vec![(
                 split_id,
                 PanelHeaderKind::None,

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use druid::{
-    piet::{Text, TextLayout, TextLayoutBuilder},
+    piet::{Text, TextLayout, TextLayoutBuilder, TextStorage},
     BoxConstraints, Command, Env, Event, EventCtx, FontFamily, LayoutCtx, LifeCycle,
     LifeCycleCtx, MouseEvent, PaintCtx, Point, RenderContext, Size, Target,
     UpdateCtx, Widget, WidgetExt, WidgetId, WidgetPod,
@@ -122,7 +124,7 @@ impl LapcePanel {
         }
         let header = match header {
             PanelHeaderKind::None => {
-                PanelMainHeader::new(widget_id, kind, "".to_string()).boxed()
+                PanelMainHeader::new(widget_id, kind, "".into()).boxed()
             }
             PanelHeaderKind::Simple(s) => {
                 PanelMainHeader::new(widget_id, kind, s).boxed()
@@ -137,9 +139,37 @@ impl LapcePanel {
     }
 }
 
+/// An immutable piece of string that is cheap to clone.
+#[derive(Clone)]
+pub enum ReadOnlyString {
+    Static(&'static str),
+    String(Arc<str>),
+}
+
+impl From<&'static str> for ReadOnlyString {
+    fn from(str: &'static str) -> Self {
+        Self::Static(str)
+    }
+}
+
+impl From<String> for ReadOnlyString {
+    fn from(str: String) -> Self {
+        Self::String(Arc::from(str))
+    }
+}
+
+impl TextStorage for ReadOnlyString {
+    fn as_str(&self) -> &str {
+        match self {
+            ReadOnlyString::Static(str) => *str,
+            ReadOnlyString::String(str) => str.as_ref(),
+        }
+    }
+}
+
 pub enum PanelHeaderKind {
     None,
-    Simple(String),
+    Simple(ReadOnlyString),
     Widget(Box<dyn Widget<LapceTabData>>),
 }
 
@@ -166,7 +196,7 @@ impl PanelSection {
 
     pub fn new_simple(
         widget_id: WidgetId,
-        header: String,
+        header: ReadOnlyString,
         content: Box<dyn Widget<LapceTabData>>,
     ) -> Self {
         let header = PanelSectionHeader::new(header).boxed();
@@ -260,11 +290,11 @@ impl Widget<LapceTabData> for PanelSection {
 }
 
 pub struct PanelSectionHeader {
-    text: String,
+    text: ReadOnlyString,
 }
 
 impl PanelSectionHeader {
-    pub fn new(text: String) -> Self {
+    pub fn new(text: ReadOnlyString) -> Self {
         Self { text }
     }
 }
@@ -344,7 +374,7 @@ impl Widget<LapceTabData> for PanelSectionHeader {
 /// This struct is used as the outer container for a panel,
 /// it contains the heading such as "Terminal" or "File Explorer".
 pub struct PanelMainHeader {
-    text: String,
+    text: ReadOnlyString,
     icons: Vec<LapceIcon>,
 
     #[allow(dead_code)]
@@ -354,7 +384,11 @@ pub struct PanelMainHeader {
 }
 
 impl PanelMainHeader {
-    pub fn new(panel_widget_id: WidgetId, kind: PanelKind, text: String) -> Self {
+    pub fn new(
+        panel_widget_id: WidgetId,
+        kind: PanelKind,
+        text: ReadOnlyString,
+    ) -> Self {
         Self {
             panel_widget_id,
             kind,

--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -55,7 +55,7 @@ impl Plugin {
             data.plugin.widget_id,
             split_id,
             SplitDirection::Vertical,
-            PanelHeaderKind::Simple("Plugin".to_string()),
+            PanelHeaderKind::Simple("Plugin".into()),
             vec![(split_id, PanelHeaderKind::None, Self::new().boxed(), None)],
         )
     }

--- a/lapce-ui/src/problem.rs
+++ b/lapce-ui/src/problem.rs
@@ -29,17 +29,17 @@ pub fn new_problem_panel(data: &ProblemData) -> LapcePanel {
         data.widget_id,
         data.split_id,
         SplitDirection::Vertical,
-        PanelHeaderKind::Simple("Problem".to_string()),
+        PanelHeaderKind::Simple("Problem".into()),
         vec![
             (
                 data.error_widget_id,
-                PanelHeaderKind::Simple("Errors".to_string()),
+                PanelHeaderKind::Simple("Errors".into()),
                 ProblemContent::new(DiagnosticSeverity::Error).boxed(),
                 None,
             ),
             (
                 data.warning_widget_id,
-                PanelHeaderKind::Simple("Warnings".to_string()),
+                PanelHeaderKind::Simple("Warnings".into()),
                 ProblemContent::new(DiagnosticSeverity::Warning).boxed(),
                 None,
             ),

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -56,7 +56,7 @@ pub fn new_search_panel(data: &LapceTabData) -> LapcePanel {
         data.search.widget_id,
         data.search.split_id,
         SplitDirection::Vertical,
-        PanelHeaderKind::Simple("Search".to_string()),
+        PanelHeaderKind::Simple("Search".into()),
         vec![(
             data.search.split_id,
             PanelHeaderKind::None,
@@ -103,7 +103,7 @@ impl SearchData {
             self.widget_id,
             self.split_id,
             SplitDirection::Vertical,
-            PanelHeaderKind::Simple("Search".to_string()),
+            PanelHeaderKind::Simple("Search".into()),
             vec![(self.split_id, PanelHeaderKind::None, split.boxed(), None)],
         )
     }

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -40,7 +40,7 @@ pub fn new_source_control_panel(data: &LapceTabData) -> LapcePanel {
         data.source_control.widget_id,
         data.source_control.split_id,
         data.source_control.split_direction,
-        PanelHeaderKind::Simple("Source Control".to_string()),
+        PanelHeaderKind::Simple("Source Control".into()),
         vec![
             (
                 editor_data.view_id,
@@ -50,7 +50,7 @@ pub fn new_source_control_panel(data: &LapceTabData) -> LapcePanel {
             ),
             (
                 data.source_control.file_list_id,
-                PanelHeaderKind::Simple("Changes".to_string()),
+                PanelHeaderKind::Simple("Changes".into()),
                 content.boxed(),
                 None,
             ),

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use druid::{
-    kurbo::Line,
     piet::{PietTextLayout, Text, TextLayout, TextLayoutBuilder},
     BoxConstraints, Command, Data, Env, Event, EventCtx, FontFamily,
     InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Point, Rect,

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -100,7 +100,7 @@ impl TerminalPanel {
             data.terminal.widget_id,
             split_id,
             SplitDirection::Vertical,
-            PanelHeaderKind::Simple("Terminal".to_string()),
+            PanelHeaderKind::Simple("Terminal".into()),
             vec![(
                 split_id,
                 PanelHeaderKind::None,


### PR DESCRIPTION
There are probably more places where this could be used, but for now, Panel headers only.

This PR introduces a read-only string type that is either a `&'static str` or a cheap to clone `Arc<str>`. This PR implements `TextStorage` for this type so it can be used in text layouts.