### PR TITLE
Don't draw shortcut names outside of the cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "piet-wgpu"
 version = "0.1.0"
-source = "git+https://github.com/lapce/piet-wgpu?branch=opengl#3a165da09256fe9234af51075e28db2b1bfef307"
+source = "git+https://github.com/lapce/piet-wgpu?branch=opengl#15384c8bc3128e6f6985c4d228c9dd46ac44e5de"
 dependencies = [
  "bytemuck",
  "glam",

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1735,7 +1735,7 @@ impl Lens<LapceData, LapceWindowData> for LapceWindowLens {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SplitContent {
     EditorTab(WidgetId),
     Split(WidgetId),

--- a/lapce-data/src/split.rs
+++ b/lapce-data/src/split.rs
@@ -1,5 +1,6 @@
 use crate::keypress::KeyPress;
 
+use druid::Size;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
@@ -14,6 +15,22 @@ pub enum SplitMoveDirection {
 pub enum SplitDirection {
     Vertical,
     Horizontal,
+}
+
+impl SplitDirection {
+    pub fn main_size(self, size: Size) -> f64 {
+        match self {
+            SplitDirection::Vertical => size.width,
+            SplitDirection::Horizontal => size.height,
+        }
+    }
+
+    pub fn cross_size(self, size: Size) -> f64 {
+        match self {
+            SplitDirection::Vertical => size.height,
+            SplitDirection::Horizontal => size.width,
+        }
+    }
 }
 
 pub fn keybinding_to_string(keypress: &KeyPress) -> String {

--- a/lapce-ui/src/keymap.rs
+++ b/lapce-ui/src/keymap.rs
@@ -263,28 +263,38 @@ impl Widget<LapceTabData> for LapceKeymap {
             if i < commands_with_keymap_len {
                 let keymap = &commands_with_keymap[i];
                 if let Some(cmd) = data.keypress.commands.get(&keymap.command) {
-                    let text_layout = ctx
-                        .text()
-                        .new_text_layout(
-                            cmd.kind.desc().unwrap_or_else(|| cmd.kind.str()),
-                        )
-                        .font(FontFamily::SYSTEM_UI, 13.0)
-                        .text_color(
-                            data.config
-                                .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
-                                .clone(),
-                        )
-                        .build()
-                        .unwrap();
-                    let text_size = text_layout.size();
-                    ctx.draw_text(
-                        &text_layout,
-                        Point::new(
-                            10.0,
-                            i as f64 * self.line_height
-                                + (self.line_height - text_size.height) / 2.0,
-                        ),
-                    );
+                    ctx.with_save(|ctx| {
+                        ctx.clip(Rect::new(
+                            0.0,
+                            i as f64 * self.line_height,
+                            size.width / 2.0 - keypress_width,
+                            (i + 1) as f64 * self.line_height,
+                        ));
+                        let text_layout = ctx
+                            .text()
+                            .new_text_layout(
+                                cmd.kind.desc().unwrap_or_else(|| cmd.kind.str()),
+                            )
+                            .font(FontFamily::SYSTEM_UI, 13.0)
+                            .text_color(
+                                data.config
+                                    .get_color_unchecked(
+                                        LapceTheme::EDITOR_FOREGROUND,
+                                    )
+                                    .clone(),
+                            )
+                            .build()
+                            .unwrap();
+                        let text_size = text_layout.size();
+                        ctx.draw_text(
+                            &text_layout,
+                            Point::new(
+                                10.0,
+                                i as f64 * self.line_height
+                                    + (self.line_height - text_size.height) / 2.0,
+                            ),
+                        );
+                    });
                 }
 
                 let origin = Point::new(
@@ -351,31 +361,41 @@ impl Widget<LapceTabData> for LapceKeymap {
             } else {
                 let j = i - commands_with_keymap_len;
                 if let Some(command) = commands_without_keymap.get(j) {
-                    let text_layout = ctx
-                        .text()
-                        .new_text_layout(
-                            command
-                                .kind
-                                .desc()
-                                .unwrap_or_else(|| command.kind.str()),
-                        )
-                        .font(FontFamily::SYSTEM_UI, 13.0)
-                        .text_color(
-                            data.config
-                                .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
-                                .clone(),
-                        )
-                        .build()
-                        .unwrap();
-                    let text_size = text_layout.size();
-                    ctx.draw_text(
-                        &text_layout,
-                        Point::new(
-                            10.0,
-                            i as f64 * self.line_height
-                                + (self.line_height - text_size.height) / 2.0,
-                        ),
-                    )
+                    ctx.with_save(|ctx| {
+                        ctx.clip(Rect::new(
+                            0.0,
+                            i as f64 * self.line_height,
+                            size.width / 2.0 - keypress_width,
+                            (i + 1) as f64 * self.line_height,
+                        ));
+                        let text_layout = ctx
+                            .text()
+                            .new_text_layout(
+                                command
+                                    .kind
+                                    .desc()
+                                    .unwrap_or_else(|| command.kind.str()),
+                            )
+                            .font(FontFamily::SYSTEM_UI, 13.0)
+                            .text_color(
+                                data.config
+                                    .get_color_unchecked(
+                                        LapceTheme::EDITOR_FOREGROUND,
+                                    )
+                                    .clone(),
+                            )
+                            .build()
+                            .unwrap();
+                        let text_size = text_layout.size();
+                        ctx.draw_text(
+                            &text_layout,
+                            Point::new(
+                                10.0,
+                                i as f64 * self.line_height
+                                    + (self.line_height - text_size.height) / 2.0,
+                            ),
+                        );
+                    });
                 }
             }
         }
@@ -628,7 +648,7 @@ impl Widget<LapceTabData> for LapceKeymapHeader {
 
         let text_layout = ctx
             .text()
-            .new_text_layout("Keybinding")
+            .new_text_layout("Key Binding")
             .font(FontFamily::SYSTEM_UI, 14.0)
             .default_attribute(TextAttribute::Weight(FontWeight::BOLD))
             .text_color(


### PR DESCRIPTION
This isn't an ideal solution as there is no way to see the end of the command names, but it's still a lot better than the ugly overdrawing that existed previously.

![image](https://user-images.githubusercontent.com/977627/167291713-16619526-171b-436b-bab3-d203f08694bb.png)
