### PR TITLE
Doc: do not specify a transitional package

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The guidelines about contributing to Lapce can be found in
 ### Dependencies
 #### Ubuntu
 ```sh
-sudo apt install cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
+sudo apt install cmake pkg-config libfreetype6-dev libfontconfig-dev libxcb-xfixes0-dev libxkbcommon-dev python3
 ```
 ### Building
 ```sh


### PR DESCRIPTION
On Ubuntu 22.04 LTS:

```
$ apt show libfontconfig1-dev 
Package: libfontconfig1-dev
Version: 2.13.1-4.2ubuntu5
Priority: optional
Section: libdevel
Source: fontconfig
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian freedesktop.org maintainers <pkg-freedesktop-maintainers@lists.alioth.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 26.6 kB
Depends: libfontconfig-dev (= 2.13.1-4.2ubuntu5)
Homepage: https://www.freedesktop.org/wiki/Software/fontconfig/
Download-Size: 1,836 B
APT-Sources: http://us.archive.ubuntu.com/ubuntu jammy/main amd64 Packages
Description: generic font configuration library - dummy package
 Fontconfig is a font configuration and customization library, which
 does not depend on the X Window System. It is designed to locate
 fonts within the system and select them according to requirements
 specified by applications.
 .
 This is a transitional package for libfontconfig-dev. It can be safely
 uninstalled
```