### PR TITLE
add Linux .desktop file and Appstream metadata

### DIFF
--- a/extra/linux/dev.lapce.lapce.desktop
+++ b/extra/linux/dev.lapce.lapce.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+
+Name=Lapce
+Comment=Lightning-fast and powerful code editor written in Rust
+Categories=Development;IDE;
+
+Icon=dev.lapce.lapce
+Exec=lapce
+Terminal=false

--- a/extra/linux/dev.lapce.lapce.metainfo.xml
+++ b/extra/linux/dev.lapce.lapce.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>dev.lapce.lapce</id>
+    <name>Lapce</name>
+    <developer_name>Dongdong Zhou, et al.</developer_name>
+    <summary>Lightning-fast and powerful code editor written in Rust</summary>
+    <metadata_license>Apache-2.0</metadata_license>
+    <project_license>Apache-2.0</project_license>
+    <url type="homepage">https://lapce.dev/</url>
+    <url type="bugtracker">https://github.com/lapce/lapce/issues</url>
+    <url type="help">https://docs.lapce.dev/</url>
+    <description>
+        <p>
+            Lapce is an open source code editor written in Rust. By utilising native GUI and GPU rendering, and with the performance Rust provides, Lapce is one of the fastest code editors out there.
+        </p>
+        <p>Features:</p>
+        <ul>
+            <li>Modal Editing (Vim like) support as first class citizen (can be turned off as well)</li>
+            <li>Built-in LSP (Language Server Protocol) support to give you code intelligence like code completion, diagnostics and code actions etc.</li>
+            <li>Built-in remote development support (inspired by VSCode Remote Development) for a seamless "local" experience, benefiting from the full power of the remote system.</li>
+            <li>Plugins can be written in programming languages that can compile to the WASI format (C, Rust, AssemblyScript)</li>
+            <li>Built-in terminal, so you can execute commands in your workspace, without leaving Lapce.</li>
+        </ul>
+    </description>
+    <content_rating type="oars-1.1" />
+    <launchable type="desktop-id">dev.lapce.lapce.desktop</launchable>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://raw.githubusercontent.com/lapce/lapce/master/extra/images/screenshot.png</image>
+        </screenshot>
+    </screenshots>
+    <releases>
+        <release version="0.1.0" date="2022-05-12"/>
+    </releases>
+</component>


### PR DESCRIPTION
During my attempt to publish [Lapce on Flathub](https://github.com/flathub/flathub/pull/3155), it was suggested to add the .desktop file and AppStream metadata upstream.
Both files can be used by all distribution maintainers and therefore make it easier to package Lapce for different Linux distributions. So it makes sense to hve these in the Lapce repository.

Here is more info on Appstream: https://www.freedesktop.org/software/appstream/docs/

There is one caveat: The release-tags in metainfo.xml should be updated with every release by adding a child like `<release version="0.1.0" date="2022-05-12"/>` ([sorted latest-to-oldest](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases), or just keep one child with the latest release).

If that isn't desired, it's fine to merge just the .desktop file.