### PR TITLE
Change Appstream metadata license

### DIFF
--- a/extra/linux/dev.lapce.lapce.metainfo.xml
+++ b/extra/linux/dev.lapce.lapce.metainfo.xml
@@ -4,7 +4,7 @@
     <name>Lapce</name>
     <developer_name>Dongdong Zhou, et al.</developer_name>
     <summary>Lightning-fast and powerful code editor written in Rust</summary>
-    <metadata_license>Apache-2.0</metadata_license>
+    <metadata_license>MIT</metadata_license>
     <project_license>Apache-2.0</project_license>
     <url type="homepage">https://lapce.dev/</url>
     <url type="bugtracker">https://github.com/lapce/lapce/issues</url>


### PR DESCRIPTION
It appears that AppStream metadata must be under certain reviewed licenses:
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-metadata_license

Therefore `flatpak run org.freedesktop.appstream-glib validate extra/linux/dev.lapce.lapce.metainfo.xml` complains when Apache-2.0 is used.

This change is solely for the metadata, the project license remains unaffected.