### PR TITLE
Show diagnostics on hover

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -505,6 +505,9 @@ impl LapceEditorBufferData {
             return;
         }
 
+        // Get the diagnostics for when we make the request
+        let diagnostics = self.diagnostics().map(Arc::clone);
+
         let mut hover = Arc::make_mut(&mut self.hover);
 
         if hover.status != HoverStatus::Inactive
@@ -527,6 +530,7 @@ impl LapceEditorBufferData {
             self.proxy.clone(),
             hover.request_id,
             self.doc.clone(),
+            diagnostics,
             self.doc.buffer().offset_to_position(start_offset),
             hover.id,
             event_sink,


### PR DESCRIPTION
This lets the user hover over a diagnostic in the editor and have the text displayed in the hover window.  
I decided to put the diagnostics before the documentation (VSCode does after) because typically they are small and more pertinent anyway, though making a config setting to support both would not be hard.  
There are some improvements that could be made, such as showing related things (ex, I believe: if you use a non-mutable variable in a way that needs it to be mutable, and rustc will provide an extra underline under the definition of that variable along with the diagnostic where you use it incorrectly), but this works as an initial impl.
I drew a rect for the separator since I don't know of any other place that uses a separator like that, so I was unsure if there was existing methods for doing it and/or colors.

![image](https://user-images.githubusercontent.com/13157904/169708106-fd3feb16-f82d-425f-b3a9-92a443f75a0d.png)
![image](https://user-images.githubusercontent.com/13157904/169708161-05cdc925-fad4-4b4b-84f7-a929267c8303.png)
  
Though, perhaps there should be a bit of margin on the top?