### PR TITLE
Implement 'new N' names for scratch buffers.

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -823,7 +823,7 @@ impl LapceTabData {
                 *editor.window_origin.borrow()
                     - self.window_origin.borrow().to_vec2()
             }
-            BufferContent::File(_) | BufferContent::Scratch(_, _) => {
+            BufferContent::File(_) | BufferContent::Scratch(..) => {
                 let doc = self.main_split.editor_doc(editor.view_id);
                 let offset = self.completion.offset;
                 let (line, col) = doc.buffer().offset_to_line_col(offset);
@@ -879,7 +879,7 @@ impl LapceTabData {
                 *editor.window_origin.borrow()
                     - self.window_origin.borrow().to_vec2()
             }
-            BufferContent::File(_) | BufferContent::Scratch(_, _) => {
+            BufferContent::File(_) | BufferContent::Scratch(..) => {
                 let doc = self.main_split.editor_doc(editor.view_id);
                 let offset = self.hover.offset;
                 let (line, col) = doc.buffer().offset_to_line_col(offset);
@@ -2306,7 +2306,7 @@ impl LapceMainSplitData {
             BufferContent::File(path) => path != &location.path,
             BufferContent::Local(_) => true,
             BufferContent::Value(_) => true,
-            BufferContent::Scratch(_, _) => true,
+            BufferContent::Scratch(..) => true,
         };
         if new_buffer {
             self.db.save_doc_position(&self.workspace, &doc);
@@ -2709,7 +2709,7 @@ impl LapceMainSplitData {
         force: bool,
     ) {
         let editor = self.editors.get(&view_id).unwrap();
-        if let BufferContent::File(_) | BufferContent::Scratch(_, _) =
+        if let BufferContent::File(_) | BufferContent::Scratch(..) =
             &editor.content
         {
             let doc = self.editor_doc(view_id);

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -701,7 +701,7 @@ impl LapceTabData {
             BufferContent::File(path) => {
                 self.main_split.open_docs.get(path).unwrap().clone()
             }
-            BufferContent::Scratch(id) => {
+            BufferContent::Scratch(id, _) => {
                 self.main_split.scratch_docs.get(id).unwrap().clone()
             }
             BufferContent::Local(kind) => {
@@ -742,7 +742,7 @@ impl LapceTabData {
                 let offset = editor.new_cursor.offset();
                 doc.code_action_size(text, offset, &self.config)
             }
-            BufferContent::Scratch(id) => {
+            BufferContent::Scratch(id, _) => {
                 let doc = self.main_split.scratch_docs.get(id).unwrap();
                 let offset = editor.new_cursor.offset();
                 doc.code_action_size(text, offset, &self.config)
@@ -781,7 +781,7 @@ impl LapceTabData {
                         .open_docs
                         .insert(path.clone(), editor_buffer_data.doc);
                 }
-                BufferContent::Scratch(id) => {
+                BufferContent::Scratch(id, _) => {
                     self.main_split
                         .scratch_docs
                         .insert(*id, editor_buffer_data.doc);
@@ -823,7 +823,7 @@ impl LapceTabData {
                 *editor.window_origin.borrow()
                     - self.window_origin.borrow().to_vec2()
             }
-            BufferContent::File(_) | BufferContent::Scratch(_) => {
+            BufferContent::File(_) | BufferContent::Scratch(_, _) => {
                 let doc = self.main_split.editor_doc(editor.view_id);
                 let offset = self.completion.offset;
                 let (line, col) = doc.buffer().offset_to_line_col(offset);
@@ -879,7 +879,7 @@ impl LapceTabData {
                 *editor.window_origin.borrow()
                     - self.window_origin.borrow().to_vec2()
             }
-            BufferContent::File(_) | BufferContent::Scratch(_) => {
+            BufferContent::File(_) | BufferContent::Scratch(_, _) => {
                 let doc = self.main_split.editor_doc(editor.view_id);
                 let offset = self.hover.offset;
                 let (line, col) = doc.buffer().offset_to_line_col(offset);
@@ -1764,7 +1764,7 @@ impl LapceMainSplitData {
             BufferContent::File(path) => self.open_docs.get(path).unwrap().clone(),
             BufferContent::Local(kind) => self.local_docs.get(kind).unwrap().clone(),
             BufferContent::Value(name) => self.value_docs.get(name).unwrap().clone(),
-            BufferContent::Scratch(id) => self.scratch_docs.get(id).unwrap().clone(),
+            BufferContent::Scratch(id, _) => self.scratch_docs.get(id).unwrap().clone(),
         }
     }
 
@@ -2244,11 +2244,34 @@ impl LapceMainSplitData {
         editor_view_id
     }
 
+    fn get_name_for_new_file(&self) -> String {
+        let mut i = 0;
+        loop {
+            i += 1;
+            let potential_name = format!("new {}", i);
+
+            // Checking just the current scratch_docs rather than all the different document
+            // collections seems to be the right thing to do. The user may have genuine 'new N'
+            // files tucked away somewhere in their workspace.
+            if self.scratch_docs.values().any(|doc| match doc.content() {
+                BufferContent::Scratch(_, existing_name) => {
+                    *existing_name == potential_name
+                }
+                _ => false,
+            }) {
+                continue;
+            }
+
+            return potential_name;
+        }
+    }
+
     pub fn new_file(&mut self, ctx: &mut EventCtx, config: &Config) {
         let tab_id = *self.tab_id;
         let proxy = self.proxy.clone();
         let buffer_id = BufferId::next();
-        let content = BufferContent::Scratch(buffer_id);
+        let content =
+            BufferContent::Scratch(buffer_id, self.get_name_for_new_file());
         let doc =
             Document::new(content.clone(), tab_id, ctx.get_external_handle(), proxy);
         self.scratch_docs.insert(buffer_id, Arc::new(doc));
@@ -2283,7 +2306,7 @@ impl LapceMainSplitData {
             BufferContent::File(path) => path != &location.path,
             BufferContent::Local(_) => true,
             BufferContent::Value(_) => true,
-            BufferContent::Scratch(_) => true,
+            BufferContent::Scratch(_, _) => true,
         };
         if new_buffer {
             self.db.save_doc_position(&self.workspace, &doc);
@@ -2589,12 +2612,12 @@ impl LapceMainSplitData {
         exit: bool,
     ) {
         match content {
-            BufferContent::Scratch(id) => {
+            BufferContent::Scratch(id, scratch_doc_name) => {
                 let doc = self.scratch_docs.get(id).unwrap();
                 if doc.rev() == rev {
                     let new_content = BufferContent::File(path.to_path_buf());
                     for (_, editor) in self.editors.iter_mut() {
-                        if editor.content == BufferContent::Scratch(*id) {
+                        if editor.content== BufferContent::Scratch(*id, scratch_doc_name.to_string()) {
                             Arc::make_mut(editor).content = new_content.clone();
                         }
                     }
@@ -2630,7 +2653,7 @@ impl LapceMainSplitData {
         exit: bool,
     ) {
         match content {
-            BufferContent::Scratch(id) => {
+            BufferContent::Scratch(id, _) => {
                 let event_sink = ctx.get_external_handle();
                 let doc = self.scratch_docs.get(id).unwrap();
                 let rev = doc.rev();
@@ -2686,7 +2709,9 @@ impl LapceMainSplitData {
         force: bool,
     ) {
         let editor = self.editors.get(&view_id).unwrap();
-        if let BufferContent::File(_) | BufferContent::Scratch(_) = &editor.content {
+        if let BufferContent::File(_) | BufferContent::Scratch(_, _) =
+            &editor.content
+        {
             let doc = self.editor_doc(view_id);
             if !force && !doc.buffer().is_pristine() {
                 let exits = self.editors.iter().any(|(_, e)| {
@@ -3229,7 +3254,7 @@ impl LapceEditorData {
     }
 
     pub fn editor_info(&self, data: &LapceTabData) -> EditorInfo {
-        let unsaved = if let BufferContent::Scratch(id) = &self.content {
+        let unsaved = if let BufferContent::Scratch(id, _) = &self.content {
             let doc = data.main_split.scratch_docs.get(id).unwrap();
             Some(doc.buffer().text().to_string())
         } else {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1764,7 +1764,9 @@ impl LapceMainSplitData {
             BufferContent::File(path) => self.open_docs.get(path).unwrap().clone(),
             BufferContent::Local(kind) => self.local_docs.get(kind).unwrap().clone(),
             BufferContent::Value(name) => self.value_docs.get(name).unwrap().clone(),
-            BufferContent::Scratch(id, _) => self.scratch_docs.get(id).unwrap().clone(),
+            BufferContent::Scratch(id, _) => {
+                self.scratch_docs.get(id).unwrap().clone()
+            }
         }
     }
 
@@ -2617,7 +2619,12 @@ impl LapceMainSplitData {
                 if doc.rev() == rev {
                     let new_content = BufferContent::File(path.to_path_buf());
                     for (_, editor) in self.editors.iter_mut() {
-                        if editor.content== BufferContent::Scratch(*id, scratch_doc_name.to_string()) {
+                        if editor.content
+                            == BufferContent::Scratch(
+                                *id,
+                                scratch_doc_name.to_string(),
+                            )
+                        {
                             Arc::make_mut(editor).content = new_content.clone();
                         }
                     }
@@ -2709,8 +2716,7 @@ impl LapceMainSplitData {
         force: bool,
     ) {
         let editor = self.editors.get(&view_id).unwrap();
-        if let BufferContent::File(_) | BufferContent::Scratch(..) =
-            &editor.content
+        if let BufferContent::File(_) | BufferContent::Scratch(..) = &editor.content
         {
             let doc = self.editor_doc(view_id);
             if !force && !doc.buffer().is_pristine() {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2250,7 +2250,7 @@ impl LapceMainSplitData {
         let mut i = 0;
         loop {
             i += 1;
-            let potential_name = format!("new {}", i);
+            let potential_name = format!("Untitled-{}", i);
 
             // Checking just the current scratch_docs rather than all the different document
             // collections seems to be the right thing to do. The user may have genuine 'new N'

--- a/lapce-data/src/db.rs
+++ b/lapce-data/src/db.rs
@@ -296,7 +296,7 @@ impl EditorInfo {
                 ));
                 data.open_docs.insert(path.clone(), doc);
             }
-        } else if let BufferContent::Scratch(id) = &self.content {
+        } else if let BufferContent::Scratch(id, _) = &self.content {
             if !data.scratch_docs.contains_key(id) {
                 let mut doc = Document::new(
                     self.content.clone(),

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -120,7 +120,7 @@ impl BufferContent {
                 LocalBufferKind::Empty => false,
             },
             BufferContent::Value(_) => true,
-            BufferContent::Scratch(_, _) => false,
+            BufferContent::Scratch(..) => false,
         }
     }
 
@@ -136,7 +136,7 @@ impl BufferContent {
                 LocalBufferKind::Empty | LocalBufferKind::SourceControl => false,
             },
             BufferContent::Value(_) => true,
-            BufferContent::Scratch(_, _) => false,
+            BufferContent::Scratch(..) => false,
         }
     }
 
@@ -144,7 +144,7 @@ impl BufferContent {
         match &self {
             BufferContent::File(_) => false,
             BufferContent::Value(_) => false,
-            BufferContent::Scratch(_, _) => false,
+            BufferContent::Scratch(..) => false,
             BufferContent::Local(local) => matches!(local, LocalBufferKind::Search),
         }
     }
@@ -154,7 +154,7 @@ impl BufferContent {
             BufferContent::File(_) => false,
             BufferContent::Value(_) => true,
             BufferContent::Local(_) => false,
-            BufferContent::Scratch(_, _) => false,
+            BufferContent::Scratch(..) => false,
         }
     }
 
@@ -202,7 +202,7 @@ impl Document {
             BufferContent::File(path) => Syntax::init(path),
             BufferContent::Local(_) => None,
             BufferContent::Value(_) => None,
-            BufferContent::Scratch(_, _) => None,
+            BufferContent::Scratch(..) => None,
         };
         let id = match &content {
             BufferContent::Scratch(id, _) => *id,
@@ -245,7 +245,7 @@ impl Document {
             BufferContent::File(path) => Syntax::init(path),
             BufferContent::Local(_) => None,
             BufferContent::Value(_) => None,
-            BufferContent::Scratch(_, _) => None,
+            BufferContent::Scratch(..) => None,
         };
         self.on_update(None);
     }
@@ -473,7 +473,7 @@ impl Document {
     fn notify_special(&self) {
         match &self.content {
             BufferContent::File(_) => {}
-            BufferContent::Scratch(_, _) => {}
+            BufferContent::Scratch(..) => {}
             BufferContent::Local(local) => {
                 let s = self.buffer.text().to_string();
                 match local {

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -99,7 +99,7 @@ pub enum BufferContent {
     File(PathBuf),
     Local(LocalBufferKind),
     Value(String),
-    Scratch(BufferId),
+    Scratch(BufferId, String),
 }
 
 impl BufferContent {
@@ -120,7 +120,7 @@ impl BufferContent {
                 LocalBufferKind::Empty => false,
             },
             BufferContent::Value(_) => true,
-            BufferContent::Scratch(_) => false,
+            BufferContent::Scratch(_, _) => false,
         }
     }
 
@@ -136,7 +136,7 @@ impl BufferContent {
                 LocalBufferKind::Empty | LocalBufferKind::SourceControl => false,
             },
             BufferContent::Value(_) => true,
-            BufferContent::Scratch(_) => false,
+            BufferContent::Scratch(_, _) => false,
         }
     }
 
@@ -144,7 +144,7 @@ impl BufferContent {
         match &self {
             BufferContent::File(_) => false,
             BufferContent::Value(_) => false,
-            BufferContent::Scratch(_) => false,
+            BufferContent::Scratch(_, _) => false,
             BufferContent::Local(local) => matches!(local, LocalBufferKind::Search),
         }
     }
@@ -154,7 +154,7 @@ impl BufferContent {
             BufferContent::File(_) => false,
             BufferContent::Value(_) => true,
             BufferContent::Local(_) => false,
-            BufferContent::Scratch(_) => false,
+            BufferContent::Scratch(_, _) => false,
         }
     }
 
@@ -163,7 +163,7 @@ impl BufferContent {
             BufferContent::File(p) => {
                 p.file_name().and_then(|f| f.to_str()).unwrap_or("")
             }
-            BufferContent::Scratch(_) => "[Untitled]",
+            BufferContent::Scratch(_, scratch_doc_name) => scratch_doc_name,
             _ => "",
         }
     }
@@ -202,10 +202,10 @@ impl Document {
             BufferContent::File(path) => Syntax::init(path),
             BufferContent::Local(_) => None,
             BufferContent::Value(_) => None,
-            BufferContent::Scratch(_) => None,
+            BufferContent::Scratch(_, _) => None,
         };
         let id = match &content {
-            BufferContent::Scratch(id) => *id,
+            BufferContent::Scratch(id, _) => *id,
             _ => BufferId::next(),
         };
 
@@ -245,7 +245,7 @@ impl Document {
             BufferContent::File(path) => Syntax::init(path),
             BufferContent::Local(_) => None,
             BufferContent::Value(_) => None,
-            BufferContent::Scratch(_) => None,
+            BufferContent::Scratch(_, _) => None,
         };
         self.on_update(None);
     }
@@ -473,7 +473,7 @@ impl Document {
     fn notify_special(&self) {
         match &self.content {
             BufferContent::File(_) => {}
-            BufferContent::Scratch(_) => {}
+            BufferContent::Scratch(_, _) => {}
             BufferContent::Local(local) => {
                 let s = self.buffer.text().to_string();
                 match local {

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1175,7 +1175,7 @@ impl LapceEditorBufferData {
                     Target::Auto,
                 );
             });
-        } else if let BufferContent::Scratch(_) = self.doc.content() {
+        } else if let BufferContent::Scratch(_, _) = self.doc.content() {
             let content = self.doc.content().clone();
             let view_id = self.editor.view_id;
             self.main_split.current_save_as =
@@ -1945,7 +1945,7 @@ impl KeyPressFocus for LapceEditorBufferData {
             "input_focus" => self.editor.content.is_input(),
             "editor_focus" => match self.editor.content {
                 BufferContent::File(_) => true,
-                BufferContent::Scratch(_) => true,
+                BufferContent::Scratch(_, _) => true,
                 BufferContent::Local(_) => false,
                 BufferContent::Value(_) => false,
             },

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1175,7 +1175,7 @@ impl LapceEditorBufferData {
                     Target::Auto,
                 );
             });
-        } else if let BufferContent::Scratch(_, _) = self.doc.content() {
+        } else if let BufferContent::Scratch(..) = self.doc.content() {
             let content = self.doc.content().clone();
             let view_id = self.editor.view_id;
             self.main_split.current_save_as =
@@ -1945,7 +1945,7 @@ impl KeyPressFocus for LapceEditorBufferData {
             "input_focus" => self.editor.content.is_input(),
             "editor_focus" => match self.editor.content {
                 BufferContent::File(_) => true,
-                BufferContent::Scratch(_, _) => true,
+                BufferContent::Scratch(..) => true,
                 BufferContent::Local(_) => false,
                 BufferContent::Value(_) => false,
             },

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -285,7 +285,7 @@ impl LapceEditor {
         let width = data.config.editor_char_width(text);
         match &data.editor.content {
             BufferContent::File(_)
-            | BufferContent::Scratch(_)
+            | BufferContent::Scratch(_, _)
             | BufferContent::Local(LocalBufferKind::Empty) => {
                 if data.editor.code_lens {
                     if let Some(syntax) = data.doc.syntax() {

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -285,7 +285,7 @@ impl LapceEditor {
         let width = data.config.editor_char_width(text);
         match &data.editor.content {
             BufferContent::File(_)
-            | BufferContent::Scratch(_, _)
+            | BufferContent::Scratch(..)
             | BufferContent::Local(LocalBufferKind::Empty) => {
                 if data.editor.code_lens {
                     if let Some(syntax) = data.doc.syntax() {

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -135,14 +135,12 @@ impl LapceEditorHeader {
                 clip_rect.x1 = icon.rect.x0;
             }
         }
-        if let BufferContent::File(_) | BufferContent::Scratch(_) =
+        if let BufferContent::File(_) | BufferContent::Scratch(_, _) =
             data.doc.content()
         {
             let mut path = match data.doc.content() {
                 BufferContent::File(path) => path.to_path_buf(),
-                BufferContent::Scratch(_) => {
-                    PathBuf::from(data.doc.content().file_name())
-                }
+                BufferContent::Scratch(_, scratch_doc_name) => scratch_doc_name.into(),
                 _ => PathBuf::from(""),
             };
 

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -135,7 +135,7 @@ impl LapceEditorHeader {
                 clip_rect.x1 = icon.rect.x0;
             }
         }
-        if let BufferContent::File(_) | BufferContent::Scratch(_, _) =
+        if let BufferContent::File(_) | BufferContent::Scratch(..) =
             data.doc.content()
         {
             let mut path = match data.doc.content() {

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -140,7 +140,9 @@ impl LapceEditorHeader {
         {
             let mut path = match data.doc.content() {
                 BufferContent::File(path) => path.to_path_buf(),
-                BufferContent::Scratch(_, scratch_doc_name) => scratch_doc_name.into(),
+                BufferContent::Scratch(_, scratch_doc_name) => {
+                    scratch_doc_name.into()
+                }
                 _ => PathBuf::from(""),
             };
 

--- a/lapce-ui/src/editor/tab_header.rs
+++ b/lapce-ui/src/editor/tab_header.rs
@@ -116,7 +116,7 @@ impl LapceEditorTabHeader {
                         .and_then(|s| s.to_str())
                         .unwrap_or("")
                         .to_string();
-                } else if let BufferContent::Scratch(_) =
+                } else if let BufferContent::Scratch(..) =
                     &editor_buffer.editor.content
                 {
                     text = editor_buffer.editor.content.file_name().to_string();

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -364,7 +364,7 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
                                 text = s.to_string();
                             }
                         }
-                    } else if let BufferContent::Scratch(_) = &editor.content {
+                    } else if let BufferContent::Scratch(_, _) = &editor.content {
                         text = editor.content.file_name().to_string();
                     }
                 }

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -364,7 +364,7 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
                                 text = s.to_string();
                             }
                         }
-                    } else if let BufferContent::Scratch(_, _) = &editor.content {
+                    } else if let BufferContent::Scratch(..) = &editor.content {
                         text = editor.content.file_name().to_string();
                     }
                 }

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -120,7 +120,7 @@ impl LapceEditorView {
             ));
         }
         match &editor.content {
-            BufferContent::File(_) | BufferContent::Scratch(_) => {
+            BufferContent::File(_) | BufferContent::Scratch(_, _) => {
                 data.focus_area = FocusArea::Editor;
                 data.main_split.active = Arc::new(Some(self.view_id));
                 data.main_split.active_tab = Arc::new(editor.tab_id);

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -120,7 +120,7 @@ impl LapceEditorView {
             ));
         }
         match &editor.content {
-            BufferContent::File(_) | BufferContent::Scratch(_, _) => {
+            BufferContent::File(_) | BufferContent::Scratch(..) => {
                 data.focus_area = FocusArea::Editor;
                 data.main_split.active = Arc::new(Some(self.view_id));
                 data.main_split.active_tab = Arc::new(editor.tab_id);


### PR DESCRIPTION
This PR addresses [my comment](https://github.com/lapce/lapce/issues/447#issuecomment-1128085250) in #447 about using unique buffer names for the scratch buffers.

I basically just added a String to the `BufferContent::Scratch` enum and fixed the compilation errors, discards being all that was required with the exception of the `save_as_success` function in `data.rs`.


