### PR TITLE
Golang Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,7 @@ dependencies = [
  "tree-sitter-elm",
  "tree-sitter-glimmer",
  "tree-sitter-go",
+ "tree-sitter-hare",
  "tree-sitter-haskell",
  "tree-sitter-haxe",
  "tree-sitter-hcl",
@@ -2278,6 +2279,7 @@ dependencies = [
  "jsonrpc-lite",
  "lapce-rpc",
  "locale_config",
+ "log",
  "lsp-types",
  "mio 0.6.23",
  "notify 5.0.0-pre.15",
@@ -2482,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -4601,6 +4603,16 @@ name = "tree-sitter-go"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71967701c8214be4aa77e0260e98361e6fd71ceec1d9d03abb37a22c9f60d0ff"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-hare"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbd59e015721be7de5449fad7b7d5302f0f8544b1589f818d9a38afd4ff198b"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -289,10 +289,12 @@ impl LapceEditorBufferData {
                     })
                     .collect::<Vec<(lapce_core::selection::Selection, &str)>>()
             });
-        let additional_edit: Option<Vec<_>> =
-            additional_edit.as_ref().map(|edits| {
+        let additional_edit: Vec<_> = additional_edit
+            .as_ref()
+            .map(|edits| {
                 edits.iter().map(|(selection, c)| (selection, *c)).collect()
-            });
+            })
+            .unwrap_or_default();
 
         let text_format = item
             .insert_text_format
@@ -317,7 +319,7 @@ impl LapceEditorBufferData {
                                 .do_raw_edit(
                                     &[
                                         &[(&selection, edit.new_text.as_str())][..],
-                                        &additional_edit.unwrap_or_default()[..],
+                                        &additional_edit[..],
                                     ]
                                     .concat(),
                                     lapce_core::editor::EditType::InsertChars,
@@ -340,7 +342,7 @@ impl LapceEditorBufferData {
                                 .do_raw_edit(
                                     &[
                                         &[(&selection, text.as_str())][..],
-                                        &additional_edit.unwrap_or_default()[..],
+                                        &additional_edit[..],
                                     ]
                                     .concat(),
                                     lapce_core::editor::EditType::InsertChars,
@@ -397,7 +399,7 @@ impl LapceEditorBufferData {
                     &selection,
                     item.insert_text.as_deref().unwrap_or(item.label.as_str()),
                 )][..],
-                &additional_edit.unwrap_or_default()[..],
+                &additional_edit[..],
             ]
             .concat(),
             lapce_core::editor::EditType::InsertChars,

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -33,3 +33,4 @@ home = "0.5.3"
 toml = "0.5.6"
 git2 = { version = "0.14.4", features = ["vendored-openssl"] }
 lapce-rpc = { path = "../lapce-rpc" }
+log = "0.4.17"

--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -155,6 +155,7 @@ fn language_id_from_path(path: &Path) -> Option<&str> {
     Some(match path.extension()?.to_str()? {
         "rs" => "rust",
         "go" => "go",
+        "py" => "python",
         _ => return None,
     })
 }

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -57,6 +57,7 @@ pub struct LspState {
 #[derive(Clone)]
 pub struct LspClient {
     exec_path: String,
+    binary_args: Vec<String>,
     options: Option<Value>,
     state: Arc<Mutex<LspState>>,
     dispatcher: Dispatcher,
@@ -84,13 +85,49 @@ impl LspCatalog {
         language_id: &str,
         options: Option<Value>,
     ) {
+        let binary_args = self.get_plugin_binary_args(options.clone());
         let client = LspClient::new(
             language_id.to_string(),
             exec_path,
             options,
+            binary_args.to_owned(),
             self.dispatcher.clone().unwrap(),
         );
         self.clients.insert(language_id.to_string(), client);
+    }
+
+    fn get_plugin_binary_args(&mut self, option: Option<Value>) -> Vec<String> {
+        let mut vals = Vec::new();
+
+        let option = match option {
+            Some(val) => val,
+            None => {
+                return vals;
+            }
+        };
+
+        let binary = match option["binary"].as_object() {
+            Some(binary) => binary,
+            None => return vals,
+        };
+
+        let option = match binary.get("binary_args") {
+            Some(binary_args) => binary_args,
+            None => return vals,
+        };
+
+        let option = if let Some(option) = option.as_array() {
+            option
+        } else {
+            println!("binary_args value should be of type [String].");
+            return vals;
+        };
+
+        for val in option {
+            vals.push(String::from(val.as_str().unwrap()));
+        }
+
+        return vals;
     }
 
     pub fn new_buffer(
@@ -368,15 +405,18 @@ impl LspClient {
         _language_id: String,
         exec_path: &str,
         options: Option<Value>,
+        binary_args: Vec<String>,
         dispatcher: Dispatcher,
     ) -> Arc<LspClient> {
-        let mut process = Self::process(exec_path);
+        //TODO: better handling of binary args in plugin
+        let mut process = Self::process(exec_path, binary_args.clone());
         let writer = Box::new(BufWriter::new(process.stdin.take().unwrap()));
         let stdout = process.stdout.take().unwrap();
 
         let lsp_client = Arc::new(LspClient {
             dispatcher,
             exec_path: exec_path.to_string(),
+            binary_args: binary_args,
             options,
             state: Arc::new(Mutex::new(LspState {
                 next_id: 0,
@@ -414,8 +454,12 @@ impl LspClient {
         });
     }
 
-    fn process(exec_path: &str) -> Child {
+    fn process(exec_path: &str, binary_args: Vec<String>) -> Child {
         let mut process = Command::new(exec_path);
+
+        for arg in binary_args {
+            process.arg(arg);
+        }
         #[cfg(target_os = "windows")]
         let process = process.creation_flags(0x08000000);
         process
@@ -426,7 +470,8 @@ impl LspClient {
     }
 
     fn reload(&self) {
-        let mut process = Self::process(&self.exec_path);
+        //TODO: avoid clone using a &[String] ?
+        let mut process = Self::process(&self.exec_path, self.binary_args.clone());
         let writer = Box::new(BufWriter::new(process.stdin.take().unwrap()));
         let stdout = process.stdout.take().unwrap();
 
@@ -473,9 +518,15 @@ impl LspClient {
     }
 
     pub fn handle_message(&self, message: &str) {
+        println!("Received message! {}", message);
         match JsonRpc::parse(message) {
-            Ok(JsonRpc::Request(_obj)) => {
-                // trace!("client received unexpected request: {:?}", obj)
+            Ok(value @ JsonRpc::Request(_)) => {
+                let id = value.get_id().unwrap();
+                self.handle_request(
+                    value.get_method().unwrap(),
+                    id,
+                    value.get_params().unwrap(),
+                )
             }
             Ok(value @ JsonRpc::Notification(_)) => {
                 self.handle_notification(
@@ -497,6 +548,20 @@ impl LspClient {
         }
     }
 
+    pub fn handle_request(&self, method: &str, id: Id, _params: Params) {
+        match method {
+            "window/workDoneProgress/create" => {
+                // Token is ignored as the workProgress Widget is always working
+                // In the future, for multiple workProgress Handling we should
+                // probably store the token
+                self.send_success_response(id, &json!({}));
+            }
+            method => {
+                println!("Received unhandled request {method}");
+            }
+        }
+    }
+
     pub fn handle_notification(&self, method: &str, params: Params) {
         match method {
             "textDocument/publishDiagnostics" => {
@@ -515,7 +580,19 @@ impl LspClient {
                     }),
                 );
             }
-            _ => (),
+            "window/showMessage" => {
+                // TODO: send message to display
+            }
+            "window/logMessage" => {
+                // TODO: We should log the message here. Waiting for
+                // the discussion about handling plugins logs before doing anything
+            }
+            "experimental/serverStatus" => {
+                //TODO: Logging of server status
+            }
+            method => {
+                println!("Received unhandled notification {}", method);
+            }
         }
     }
 
@@ -562,6 +639,22 @@ impl LspClient {
         };
 
         self.send_rpc(&to_value(&request).unwrap());
+    }
+
+    pub fn send_success_response(&self, id: Id, result: &Value) {
+        let response = JsonRpc::success(id, result);
+
+        self.send_rpc(&to_value(&response).unwrap());
+    }
+
+    pub fn send_error_response(
+        &self,
+        id: jsonrpc_lite::Id,
+        error: jsonrpc_lite::Error,
+    ) {
+        let response = JsonRpc::error(id, error);
+
+        self.send_rpc(&to_value(&response).unwrap());
     }
 
     fn initialize(&self) {

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -116,9 +116,10 @@ impl LspCatalog {
             }
             None => {
                 log::warn!("args value should be of type [String].");
-                return None;
             }
         };
+
+        None
     }
 
     pub fn new_buffer(

--- a/lapce-proxy/src/plugin.rs
+++ b/lapce-proxy/src/plugin.rs
@@ -171,10 +171,15 @@ impl PluginCatalog {
 
         let output = Pipe::new();
         let input = Pipe::new();
+        let env = match plugin_desc.get_plugin_env() {
+            Ok(env) => env,
+            Err(err) => return Err(err),
+        };
         let mut wasi_env = WasiState::new("Lapce")
             .map_dir("/", plugin_desc.dir.clone().unwrap())?
             .stdin(Box::new(input))
             .stdout(Box::new(output))
+            .envs(env)
             .finalize()?;
         let wasi = wasi_env.import_object(&module)?;
 

--- a/lapce-proxy/src/plugin.rs
+++ b/lapce-proxy/src/plugin.rs
@@ -171,10 +171,7 @@ impl PluginCatalog {
 
         let output = Pipe::new();
         let input = Pipe::new();
-        let env = match plugin_desc.get_plugin_env() {
-            Ok(env) => env,
-            Err(err) => return Err(err),
-        };
+        let env = plugin_desc.get_plugin_env()?;
         let mut wasi_env = WasiState::new("Lapce")
             .map_dir("/", plugin_desc.dir.clone().unwrap())?
             .stdin(Box::new(input))

--- a/lapce-rpc/src/plugin.rs
+++ b/lapce-rpc/src/plugin.rs
@@ -31,15 +31,13 @@ pub struct PluginInfo {
 
 impl PluginDescription {
     pub fn get_plugin_env(&self) -> Result<Vec<(String, String)>, Error> {
-        let mut vars = Vec::new();
-
         let conf = match &self.configuration {
             Some(val) => val,
             None => {
                 return Err(format_err!(
                     "Empty configuration for plugin {}",
                     self.display_name
-                ))
+                ));
             }
         };
 
@@ -49,14 +47,14 @@ impl PluginDescription {
                 return Err(format_err!(
                     "Empty configuration for plugin {}",
                     self.display_name
-                ))
+                ));
             }
         };
 
         let env = match conf.get("env_command") {
             Some(env) => env,
             // We do not print any error as no env is allowed.
-            None => return Ok(vars),
+            None => return Ok(vec![]),
         };
 
         let args = match env.as_str() {
@@ -65,7 +63,7 @@ impl PluginDescription {
                 return Err(format_err!(
                     "Plugin {}: env_command is not a string",
                     self.display_name
-                ))
+                ));
             }
         };
 
@@ -97,12 +95,10 @@ impl PluginDescription {
             }
         };
 
-        for l in data.lines() {
-            if let Some((key, value)) = l.split_once('=') {
-                vars.push((String::from(key), String::from(value)));
-            };
-        }
-
-        return Ok(vars);
+        Ok(data
+            .lines()
+            .filter_map(|l| l.split_once('='))
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect::<Vec<(String, String)>>())
     }
 }


### PR DESCRIPTION
This is a new version of the Golang support PR, up to date and cleaner than the old #385, as discussed with @dzhou121.
Here is a paste of the previous PR message:

## Introduction

This PR pushes the LSP client to a state where the Golang LSP server (`gopls`) is usable.
While lapce might be missing plenty of capabilities (some of which might already be implemented and wirable), the goal of this PR is not to fill this gap but to make sure the base client is robust enough for any LSP server to run without any primary issues.

This PR should allow starting proper work on #365 and #374, and any other LSP server support.

*Note: A very basic and hacky gopls plugin can be found [here](https://github.com/nheuillet/lapce-go) for the time being.* 

closes #365 

## Work
-  [X] Implement response on `window/workDoneProgress/create` request (Blocking "handshake" for gopls)
-  [X] Fix EditDocument error on gopls edit suggestion following a `textDocument/completion` request
-  [X] Fix lowercased suggestion on ui
-  [X] Implement env passing for wasi runtime
-  [x] Fix misplaced error marker  

## How to test

- Clone this PR and build the code
- Clone the [lapce-go plugin](https://github.com/nheuillet/lapce-go) wherever you want
- Build the plugin
  - I personally use these commands (see [this for cargo wasi](https://github.com/bytecodealliance/cargo-wasi)):
```bash
  # link the plugin folder to lapce plugin directory
  ln -s $PWD ~/.lapce/plugins/lapce-go
  #  build the actual wasm binary
  cargo wasi build && cp target/wasm32-wasi/debug/lapce-go.rustc.wasm lapce-go.wasm 

```
- Lapce should be able to launch the plugin without any issue. To confirm, look for the output of lapce. if "Starting lapce-go plugin!" appears, the plugin is working.
