### PR TITLE
Improve get name for new file

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2253,7 +2253,8 @@ impl LapceMainSplitData {
         // Checking just the current scratch_docs rather than all the different document
         // collections seems to be the right thing to do. The user may have genuine 'new N'
         // files tucked away somewhere in their workspace.
-        let new_num = self.scratch_docs
+        let new_num = self
+            .scratch_docs
             .values()
             .filter_map(|doc| match doc.content() {
                 BufferContent::Scratch(_, existing_name) => {
@@ -2265,7 +2266,9 @@ impl LapceMainSplitData {
                 }
                 _ => None,
             })
-            .max().unwrap_or(0) + 1;
+            .max()
+            .unwrap_or(0)
+            + 1;
 
         return format!("{}{}", PREFIX, new_num);
     }

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2249,6 +2249,10 @@ impl LapceMainSplitData {
 
     fn get_name_for_new_file(&self) -> String {
         const PREFIX: &str = "Untitled-";
+
+        // Checking just the current scratch_docs rather than all the different document
+        // collections seems to be the right thing to do. The user may have genuine 'new N'
+        // files tucked away somewhere in their workspace.
         let new_num = self.scratch_docs
             .values()
             .filter_map(|doc| match doc.content() {


### PR DESCRIPTION
No longer allocates multiple strings. It was not a big deal but I prefer to avoid allocation as a best practice when I can.