### PR TITLE
added basic disambiguation of same name files

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -2002,6 +2002,7 @@ pub struct TabRect {
     pub rect: Rect,
     pub close_rect: Rect,
     pub text_layout: PietTextLayout,
+    pub path_layout: PietTextLayout,
 }
 
 #[derive(Clone)]

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -605,6 +605,13 @@ impl TabRectRenderer for TabRect {
             &self.text_layout,
             Point::new(rect.x1 + 5.0, (size.height - text_size.height) / 2.0),
         );
+        ctx.draw_text(
+            &self.path_layout,
+            Point::new(
+                rect.x1 + text_size.width + 5.0,
+                (size.height - text_size.height) / 2.0,
+            ),
+        );
         let x = self.rect.x1;
         ctx.stroke(
             Line::new(

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -258,14 +258,14 @@ impl LapceEditorTabHeaderContent {
         let workspace_path = match workspace_path {
             Some(p) => p,
             None => {
-                let mut file_path_str = match file_path.to_str() {
-                    Some(p) => p.to_string(),
-                    None => return "".to_string(),
-                };
-
-                file_path_str.truncate(20);
-
-                return file_path_str;
+                // file_path.truncate(20);
+                let file_path = file_path
+                    .to_string_lossy()
+                    .char_indices()
+                    .filter(|(i, _)| *i < 20)
+                    .map(|(_, ch)| ch)
+                    .collect::<String>();
+                return file_path;
             }
         };
 
@@ -278,7 +278,7 @@ impl LapceEditorTabHeaderContent {
             // We dont need to keep the file name, only the parents.
             file_path_mut.pop();
 
-            while file_path_mut.cmp(&workspace_path) != Ordering::Equal {
+            while file_path_mut != workspace_path {
                 let file_name = file_path_mut.file_name().unwrap();
                 let file_name_str = file_name.to_str().unwrap().to_string();
 
@@ -575,6 +575,15 @@ mod test {
         let f4 = PathBuf::from("/home/user/proj/file.rs");
         let f5 = PathBuf::from("/home/user/toolongprojectshouldtruncate/file.rs");
         let f6 = PathBuf::from("/home/user/myproject/file.rs");
+        let f7 = PathBuf::from(
+            "/home/user/myproject/🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆",
+        );
+        let f8 = PathBuf::from(
+            "/home/user/proj/🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆",
+        );
+        let f9 = PathBuf::from(
+            "/home/user/myproject/🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆/🎉🎉🎉🎉🎉🎉🎉/🎊",
+        );
 
         let mut tab = LapceEditorTabHeaderContent::new(WidgetId::next());
 
@@ -584,6 +593,9 @@ mod test {
         let r4 = tab.get_effective_path(workspace_path.clone(), &f4);
         let r5 = tab.get_effective_path(workspace_path.clone(), &f5);
         let r6 = tab.get_effective_path(workspace_path.clone(), &f6);
+        let r7 = tab.get_effective_path(workspace_path.clone(), &f7);
+        let r8 = tab.get_effective_path(workspace_path.clone(), &f8);
+        let r9 = tab.get_effective_path(workspace_path.clone(), &f9);
 
         assert_eq!(r1, "folder1");
         assert_eq!(r2, "folder2");
@@ -591,5 +603,8 @@ mod test {
         assert_eq!(r4, "/home/user/proj");
         assert_eq!(r5, "/home/user");
         assert_eq!(r6, "./");
+        assert_eq!(r7, "./");
+        assert_eq!(r8, "/home/user/proj");
+        assert_eq!(r9, "🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆🎆/🎉🎉🎉🎉🎉🎉🎉");
     }
 }


### PR DESCRIPTION
This PR introduces some visual syntactic sugar around same name files from different folders.

* Every path created is truncated to 20 characters, which is completely arbitrary and can be discussed/changed*
- When two same-name files are open, a path hint will appear for as long as multiple same name files are opened
- When two files from the same workspace are open, the names of the folders (full path minus workspace root) are used
- When a file from outside of the workspace is opened, the full path is used
- When a file at the workspace root is opened, `./` is used


The implementation is not as efficient as it could be (some clones and a lot of conversions), but I am no Rust expert, so feel free to show me how to improve :)


closes #551 