### PR TITLE
fix: don't overwrite permissions

### DIFF
--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -65,6 +65,8 @@ impl Buffer {
         for chunk in self.rope.iter_chunks(..self.rope.len()) {
             f.write_all(chunk.as_bytes())?;
         }
+        let perm = fs::metadata(&self.path)?.permissions();
+        fs::set_permissions(tmp_path, perm)?;
         fs::rename(tmp_path, &self.path)?;
         self.mod_time = get_mod_time(&self.path);
         Ok(())


### PR DESCRIPTION
Currently lapce overwrites permissions whenever file is saved
I've noticed that when my scripts lost exec bits
Don't know if it's proper fix in correct place