### PR TITLE
Implement event-subscription API for plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,6 +2223,7 @@ dependencies = [
  "jsonrpc-lite",
  "lapce-core",
  "lapce-data",
+ "lapce-proxy",
  "lapce-rpc",
  "lazy_static",
  "libloading",

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -13,6 +13,7 @@ use druid::Target;
 use druid::{ExtEventSink, WidgetId};
 use flate2::read::GzDecoder;
 use lapce_proxy::dispatch::Dispatcher;
+use lapce_proxy::plugin::PluginEvent;
 use lapce_rpc::buffer::BufferId;
 use lapce_rpc::core::{CoreNotification, CoreRequest};
 use lapce_rpc::plugin::PluginDescription;
@@ -398,6 +399,12 @@ impl LapceProxy {
     pub fn install_plugin(&self, plugin: &PluginDescription) {
         self.rpc
             .send_rpc_notification("install_plugin", &json!({ "plugin": plugin }));
+    }
+
+    /// Broadcast an event to plugins which are subscribed to it
+    pub fn plugin_broadcast(&self, event: PluginEvent) {
+        self.rpc
+            .send_rpc_notification("plugin_broadcast", &json!({ "event": event }));
     }
 
     pub fn get_buffer_head(

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -1,6 +1,6 @@
 use crate::buffer::{get_mod_time, load_file, Buffer};
 use crate::lsp::LspCatalog;
-use crate::plugin::PluginCatalog;
+use crate::plugin::{PluginCatalog, PluginEvent};
 use crate::terminal::Terminal;
 use crate::watcher::{FileWatcher, Notify, WatchToken};
 use alacritty_terminal::event_loop::Msg;
@@ -330,6 +330,12 @@ impl Dispatcher {
                 if let Some(content_change) = buffer.update(&delta, rev) {
                     self.lsp.lock().update(buffer, &content_change, buffer.rev);
                 }
+            }
+            PluginBroadcast { event } => {
+                if let Ok(event) = serde_json::from_value::<PluginEvent>(event) {
+                    self.plugins.lock().broadcast_event(event);
+                }
+                // TODO: log warning on error?
             }
             InstallPlugin { plugin } => {
                 let catalog = self.plugins.clone();

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -30,6 +30,9 @@ pub enum ProxyNotification {
     InstallPlugin {
         plugin: PluginDescription,
     },
+    PluginBroadcast {
+        event: serde_json::Value,
+    },
     GitCommit {
         message: String,
         diffs: Vec<FileDiff>,

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -50,6 +50,7 @@ structdesc = { git = "https://github.com/lapce/structdesc" }
 lapce-core = { path = "../lapce-core" }
 lapce-data = { path = "../lapce-data" }
 lapce-rpc = { path = "../lapce-rpc" }
+lapce-proxy = { path = "../lapce-proxy" }
 
 [features]
 default = ["all-languages"]


### PR DESCRIPTION
Related: https://github.com/lapce/lapce-plugin-rust/pull/2  
This implements a basic event system, where plugins can subscribe to specific `PluginEventKind`s and then receive them whenever they occur.
A plugin can subscribe to events even after initialization, at least at the moment. This seems useful to me, since you may only want to subscribe to events that you are handling, and perhaps a plugin only cares about certain events for specific projects or settings.  
This does not add a method for unsubscribing from events, but that could be added without issue.  
  
This pull-request does not actually implement all that much, leaving other specific features of the plugin system for later pull-requests, but would hopefully serve as the foundation to begin adding plugin functionality. The basic events added can serve as examples, too.  
  
Current questions/open problems:
 - This adds a debug_log notification, though the companion PR for lapce-plugin-rust does not add a function for calling it directly. I think there should be some way of logging from the extension, though perhaps it should go to the log file, but I don't think lapce-proxy has access to that?
 - I dislike serializing the `PluginEvent` to the rpc, then deserializing it, then reserializing it for the plugin
   - Possible methods to avoid this:
     - Synchronize the subscribed events between the proxy and lapce, so that lapce can check that some plugin actually wants the event (which avoids making this feature somewhat costly for users without notable plugins)
       - This avoids unneeded serialization in the first place, which is nice
     - Rather than deserializing it, get the field in the json for the name and get the `PluginEventKind` via that
   - I'll put this off for now
 - I'd like to share types between lapce and lapce-plugin-rust, since the `PluginEvent` and `PluginEventKind` should be the same
   - Lapce could depend directly on lapce-plugin-rust (putting plugin/wasm specific things behind a feature flag that is by default on, so we don't have to depend on them?)
 - `PluginEvent::FileEditorClosed` has the path stored as a `PathBuf`, but is this safe to transmit over JSON (since it is backed by an `OsString`) and deserialize on a different platform (proxy host os -> wasm)?
 - We may want events that are broadcast to all plugins regardless of whether they subscribe
   - Ex: Shutdown
   - This is pretty easy to add, if needed
 - `PluginDesc` is cloned several times (since `PluginEnv`/`PluginNew` are cloned to move instances into other threads), but we could avoid this with an `Arc` around it. Should I implement that?
 - `broadcast_event` could be improved by serializing the event to a string once, and then giving out a `&str` to a `PluginNew::send_event_str` function.
   - However, this has the issue of being able to pass it into the thread due to lifetimes. Is it reasonable to do `wasi_write_string` before starting the thread?