### PR TITLE
Handle unicode characters in palette line-search

### DIFF
--- a/lapce-ui/src/palette.rs
+++ b/lapce-ui/src/palette.rs
@@ -675,14 +675,31 @@ impl PaletteContent {
                     .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
                     .clone(),
             );
-        for i in &text_indices {
-            let i = *i;
+        for &i_start in &text_indices {
+            let i_end = full_text
+                .char_indices()
+                .find(|(i, _)| *i == i_start)
+                .map(|(_, c)| c.len_utf8() + i_start);
+            let i_end = if let Some(i_end) = i_end {
+                i_end
+            } else {
+                // Log a warning, but continue as we don't want to crash on a bug
+                log::warn!(
+                    "Invalid text indices in palette: text: '{}', i_start: {}",
+                    text,
+                    i_start
+                );
+                continue;
+            };
+
             text_layout = text_layout.range_attribute(
-                i..i + 1,
+                i_start..i_end,
                 TextAttribute::TextColor(focus_color.clone()),
             );
-            text_layout = text_layout
-                .range_attribute(i..i + 1, TextAttribute::Weight(FontWeight::BOLD));
+            text_layout = text_layout.range_attribute(
+                i_start..i_end,
+                TextAttribute::Weight(FontWeight::BOLD),
+            );
         }
 
         if !hint.is_empty() {


### PR DESCRIPTION
Fixes #614 
The issue was that it was just having the end of the range `i+1` rather than the length of the character which panics (though the docs for `range_attribute` only indirectly allude to indexing like a slice) on multibyte characters.  
There's still a bit of a bug (unicode characters will hit that `log::warn`) because of fuzzy-matcher's indices not working for unicode, which I mentioned in the discord, but that just stops it from highlighting them properly.