### PR TITLE
Add a setting to toggle relative line numbering in modal mode

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -12,6 +12,7 @@ tab-width = 4
 show-tab = true
 scroll-beyond-last-line = true
 hover-delay = 300             # ms
+modal-mode-relative-line-numbers = true
 
 [terminal]
 font-family = ""

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -151,6 +151,10 @@ pub struct EditorConfig {
         desc = "How long (in ms) it should take before the hover information appears"
     )]
     pub hover_delay: u64,
+    #[field_names(
+        desc = "If modal mode should have relative line numbers (though, not in insert mode)"
+    )]
+    pub modal_mode_relative_line_numbers: bool,
 }
 
 impl EditorConfig {

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -541,7 +541,8 @@ impl LapceEditorGutter {
 
             let sequential_line_numbers = *data.main_split.active
                 != Some(data.view_id)
-                || data.editor.cursor.is_insert();
+                || data.editor.cursor.is_insert()
+                || !data.config.editor.modal_mode_relative_line_numbers;
 
             let font_family = data.config.editor.font_family();
 


### PR DESCRIPTION
Fixed #35  
This just allows the user to change the line numbering in modal mode to the more typical sequential method.  
This leaves the default as relative, like it is now.  
Though, I do think it would be a nice future feature to have this more customizable (ex: relative line mode in insert mode?), but this covers the case where people want it always sequential.