### PR TITLE
Added result numbers to the FindBox widget.

### DIFF
--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1396,11 +1396,14 @@ impl LapceEditor {
             + data.editor.scroll_offset.y)
             / line_height)
             .ceil() as usize;
+
         let start_offset = data.doc.buffer().offset_of_line(start_line);
         let end_offset = data.doc.buffer().offset_of_line(end_line + 1);
         let cursor_offset = data.editor.cursor.offset();
 
-        data.doc.update_find(&data.find, start_line, end_line);
+        // Update the find with the whole document, so the count will be accurate in the widget
+        data.doc
+            .update_find(&data.find, 0, data.doc.buffer().last_line());
         if data.find.search_string.is_some() {
             for region in data
                 .doc

--- a/lapce-ui/src/find.rs
+++ b/lapce-ui/src/find.rs
@@ -247,14 +247,17 @@ impl Widget<LapceTabData> for FindBox {
         let text_layout = ctx
             .text()
             .new_text_layout(if buffer.doc.find.borrow().occurrences().len() > 0 {
-                format!(
-                    "{}/{}",
-                    match index {
-                        Some(index) => format!("{}", index + 1),
-                        None => "?".to_string(),
-                    },
-                    buffer.doc.find.borrow().occurrences().len()
-                )
+                match index {
+                    Some(index) => format!(
+                        "{}/{}",
+                        index + 1,
+                        buffer.doc.find.borrow().occurrences().len()
+                    ),
+                    None => format!(
+                        "{} results",
+                        buffer.doc.find.borrow().occurrences().len()
+                    ),
+                }
             } else {
                 "No results".to_string()
             })


### PR DESCRIPTION
Added the amount of results found for the query into the `FindBox` widget in this fashion:
![image](https://user-images.githubusercontent.com/56396750/174307524-ac43b33e-b0d5-4746-b9f6-7fb9e03cfa2e.png)

Does not relate to any github issue I can find, but was a thing someone was looking for.