### PR TITLE
Add GetCompletion command to display completion even with no input

### DIFF
--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -238,6 +238,8 @@ pub enum FocusCommand {
     BottomOfWindow,
     #[strum(serialize = "show_code_actions")]
     ShowCodeActions,
+    #[strum(serialize = "get_completion")]
+    GetCompletion,
     /// This will close a modal, such as the settings window or completion
     #[strum(message = "Close Modal")]
     #[strum(serialize = "modal.close")]


### PR DESCRIPTION
This adds the ability to use `ctrl+space` (and meta+space) to display the completions without having any text.  
I believe Lapce had this before, and there was already keymaps for it in the code, but I guess it got removed?  
Though, this is imperfect, because the sorting that Rust Analyzer provides for us by default isn't great. See #628   
