### PR TITLE
Add an option for whether to format on save

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -13,6 +13,7 @@ show-tab = true
 scroll-beyond-last-line = true
 hover-delay = 300             # ms
 modal-mode-relative-line-numbers = true
+format-on-save = true
 
 [terminal]
 font-family = ""

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -463,6 +463,7 @@ pub enum LapceUICommand {
     ApplyEditsAndSave(usize, u64, Result<Value>),
     DocumentFormat(PathBuf, u64, Result<Value>),
     DocumentFormatAndSave(PathBuf, u64, Result<Value>, Option<WidgetId>),
+    DocumentSave(PathBuf, Option<WidgetId>),
     BufferSave(PathBuf, u64, Option<WidgetId>),
     UpdateSemanticStyles(BufferId, PathBuf, u64, Arc<Spans<Style>>),
     UpdateTerminalTitle(TermId, String),

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -155,6 +155,10 @@ pub struct EditorConfig {
         desc = "If modal mode should have relative line numbers (though, not in insert mode)"
     )]
     pub modal_mode_relative_line_numbers: bool,
+    #[field_names(
+        desc = "Whether it should format the document on save (if there is an available formatter)"
+    )]
+    pub format_on_save: bool,
 }
 
 impl EditorConfig {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1844,7 +1844,15 @@ impl LapceMainSplitData {
         exit_widget_id: Option<WidgetId>,
     ) {
         self.document_format(path, rev, result);
+        self.document_save(ctx, path, exit_widget_id);
+    }
 
+    pub fn document_save(
+        &mut self,
+        ctx: &mut EventCtx,
+        path: &Path,
+        exit_widget_id: Option<WidgetId>,
+    ) {
         let doc = self.open_docs.get(path).unwrap();
         let rev = doc.rev();
         let buffer_id = doc.id();

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -678,6 +678,10 @@ impl LapceTab {
 
                         ctx.set_handled();
                     }
+                    LapceUICommand::DocumentSave(path, exit) => {
+                        data.main_split.document_save(ctx, path, *exit);
+                        ctx.set_handled();
+                    }
                     LapceUICommand::DocumentFormatAndSave(
                         path,
                         rev,


### PR DESCRIPTION
This gives the user the ability to decide whether they want the editor to format the document when they save the file. It keeps the current default of `true`.