### PR TITLE
Add an executable icon on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,6 +2346,7 @@ dependencies = [
  "toml",
  "unicode-segmentation",
  "unicode-width",
+ "winres",
  "xi-rope",
  "xi-unicode",
 ]
@@ -5496,6 +5497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "winres"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+dependencies = [
+ "toml",
 ]
 
 [[package]]

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -51,6 +51,9 @@ lapce-core = { path = "../lapce-core" }
 lapce-data = { path = "../lapce-data" }
 lapce-rpc = { path = "../lapce-rpc" }
 
+[target.'cfg(windows)'.build-dependencies]
+winres = "0.1.12"
+
 [features]
 default = ["all-languages"]
 # To build lapce with only some of the supported languages, for example:

--- a/lapce-ui/build.rs
+++ b/lapce-ui/build.rs
@@ -1,0 +1,13 @@
+#[cfg(windows)]
+fn main() {
+    let mut res = winres::WindowsResource::new();
+    res.set("ProductName", "lapce");
+    res.set("FileDescription", "lapce");
+    res.set("LegalCopyright", "Copyright (C) 2022");
+    res.set_icon("../extra/windows/lapce.ico");
+    res.compile()
+        .expect("Failed to run the Windows resource compiler (rc.exe)");
+}
+
+#[cfg(not(windows))]
+fn main() {}


### PR DESCRIPTION
This uses the `winres` crate https://docs.rs/winres/latest/winres/ to set an icon.

I based this on nu's usage - see https://github.com/nushell/nushell/blob/9f07bcc66f50f8dd63471f3ae6b697e6832ce89f/build.rs

This brings the 'portable' version to parity with the installer based version, as well as manually installed versions.