### PR TITLE
Improve the behaviour of Home in non-vim mode

### DIFF
--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1319,7 +1319,11 @@ impl Document {
             Movement::FirstNonBlank => {
                 let line = self.buffer.line_of_offset(offset);
                 let new_offset = self.buffer.first_non_blank_character_on_line(line);
-                (new_offset, Some(ColPosition::FirstNonBlank))
+                if offset == new_offset {
+                    (self.buffer.offset_of_line(line), Some(ColPosition::Start))
+                } else {
+                    (new_offset, Some(ColPosition::FirstNonBlank))
+                }
             }
             Movement::StartOfLine => {
                 let line = self.buffer.line_of_offset(offset);

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1318,11 +1318,20 @@ impl Document {
             }
             Movement::FirstNonBlank => {
                 let line = self.buffer.line_of_offset(offset);
-                let new_offset = self.buffer.first_non_blank_character_on_line(line);
-                if offset == new_offset {
-                    (self.buffer.offset_of_line(line), Some(ColPosition::Start))
+                let non_blank_offset =
+                    self.buffer.first_non_blank_character_on_line(line);
+                let start_line_offset = self.buffer.offset_of_line(line);
+                if offset > non_blank_offset {
+                    // Jump to the first non-whitespace character if we're strictly after it
+                    (non_blank_offset, Some(ColPosition::FirstNonBlank))
                 } else {
-                    (new_offset, Some(ColPosition::FirstNonBlank))
+                    // If we're at the start of the line, also jump to the first not blank
+                    if start_line_offset == offset {
+                        (non_blank_offset, Some(ColPosition::FirstNonBlank))
+                    } else {
+                        // Otherwise, jump to the start of the line
+                        (start_line_offset, Some(ColPosition::Start))
+                    }
                 }
             }
             Movement::StartOfLine => {


### PR DESCRIPTION
Previously, pressing <kbd>Home</kbd> would always return to the first non-indent character

However, a nicer behaviour once you are at that character is to move to the start of the line instead.
This is consistent with the behaviour of vscode.