### PR TITLE
Remove the sources of some warnings, and log to stderr

### DIFF
--- a/lapce-data/src/keypress/keypress.rs
+++ b/lapce-data/src/keypress/keypress.rs
@@ -141,6 +141,7 @@ impl KeyPress {
                         "meta" => mods.set(Modifiers::META, true),
                         "shift" => mods.set(Modifiers::SHIFT, true),
                         "alt" => mods.set(Modifiers::ALT, true),
+                        "" => (),
                         other => log::warn!("Invalid key modifier: {}", other),
                     }
                 }

--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -38,14 +38,17 @@ pub fn launch() {
         } else {
             log::LevelFilter::Off
         })
-        .level_for("piet_wgpu", log::LevelFilter::Info);
+        .chain(std::io::stderr());
 
     if let Some(log_file) = Config::log_file().and_then(|f| fern::log_file(f).ok()) {
         log_dispatch = log_dispatch.chain(log_file);
     }
 
     log_dispatch = override_log_levels(log_dispatch);
-    let _ = log_dispatch.apply();
+    match log_dispatch.apply() {
+        Ok(()) => (),
+        Err(e) => eprintln!("Initialising logging failed {e:?}"),
+    }
 
     let mut launcher = AppLauncher::new().delegate(LapceAppDelegate::new());
     let data = LapceData::load(launcher.get_external_handle());

--- a/lapce-ui/src/split.rs
+++ b/lapce-ui/src/split.rs
@@ -1087,6 +1087,7 @@ impl Widget<LapceTabData> for LapceSplit {
                     data,
                     env,
                 );
+                child.widget.set_origin(ctx, data, env, next_origin);
                 let cross_size = self.direction.cross_size(size);
                 if cross_size > max_other_axis {
                     max_other_axis = cross_size;


### PR DESCRIPTION
There are still a few 'missing set_layout' warnings which I haven't tracked down, but this significantly improves visibility.