### PR TITLE
Speed up CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/cargo@v1
+      - name: Build
+        uses: actions-rs/cargo@v1
         with:
           command: build
   
@@ -49,6 +50,7 @@ jobs:
           toolchain: stable
           override: true
       - run: rustup component add rustfmt
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -67,6 +69,7 @@ jobs:
       - run: rustup component add clippy
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install cmake pkg-config libgtk-3-dev
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
 
-      - name: Build
-        uses: actions-rs/cargo@v1
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions-rs/cargo@v1
         with:
           command: build
   

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,8 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
 
+      - uses: Swatinem/rust-cache@v1
+
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -43,6 +45,7 @@ jobs:
           toolchain: stable
           override: true
       - run: rustup component add rustfmt
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: fmt


### PR DESCRIPTION
This patch adds GitHub Actions steps for caching. For example, rust-cache action sets `CARGO_INCREMENTAL: 0` to disable incremental compilation.

ref: Fast Rust Builds - https://matklad.github.io/2021/09/04/fast-rust-builds.html