### PR TITLE
Feature/run code action

### DIFF
--- a/lapce-data/src/alert.rs
+++ b/lapce-data/src/alert.rs
@@ -73,6 +73,7 @@ impl KeyPressFocus for AlertFocusData {
                 LAPCE_COMMAND,
                 LapceCommand {
                     kind: CommandKind::Focus(FocusCommand::ModalClose),
+                    name: None,
                     data: None,
                 },
                 Target::Widget(self.alert.widget_id),

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -47,6 +47,7 @@ pub const LAPCE_UI_COMMAND: Selector<LapceUICommand> =
 #[derive(Clone, Debug)]
 pub struct LapceCommand {
     pub kind: CommandKind,
+    pub name: Option<String>,
     pub data: Option<Value>,
 }
 
@@ -118,6 +119,7 @@ pub fn lapce_internal_commands() -> IndexMap<String, LapceCommand> {
     for c in LapceWorkbenchCommand::iter() {
         let command = LapceCommand {
             kind: CommandKind::Workbench(c.clone()),
+            name: None,
             data: None,
         };
         commands.insert(c.to_string(), command);
@@ -126,6 +128,7 @@ pub fn lapce_internal_commands() -> IndexMap<String, LapceCommand> {
     for c in EditCommand::iter() {
         let command = LapceCommand {
             kind: CommandKind::Edit(c.clone()),
+            name: None,
             data: None,
         };
         commands.insert(c.to_string(), command);
@@ -134,6 +137,7 @@ pub fn lapce_internal_commands() -> IndexMap<String, LapceCommand> {
     for c in MoveCommand::iter() {
         let command = LapceCommand {
             kind: CommandKind::Move(c.clone()),
+            name: None,
             data: None,
         };
         commands.insert(c.to_string(), command);
@@ -142,6 +146,7 @@ pub fn lapce_internal_commands() -> IndexMap<String, LapceCommand> {
     for c in FocusCommand::iter() {
         let command = LapceCommand {
             kind: CommandKind::Focus(c.clone()),
+            name: None,
             data: None,
         };
         commands.insert(c.to_string(), command);
@@ -150,6 +155,7 @@ pub fn lapce_internal_commands() -> IndexMap<String, LapceCommand> {
     for c in MotionModeCommand::iter() {
         let command = LapceCommand {
             kind: CommandKind::MotionMode(c.clone()),
+            name: None,
             data: None,
         };
         commands.insert(c.to_string(), command);
@@ -158,6 +164,7 @@ pub fn lapce_internal_commands() -> IndexMap<String, LapceCommand> {
     for c in MultiSelectionCommand::iter() {
         let command = LapceCommand {
             kind: CommandKind::MultiSelection(c.clone()),
+            name: None,
             data: None,
         };
         commands.insert(c.to_string(), command);
@@ -365,6 +372,9 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "install_theme")]
     #[strum(message = "Install current theme file")]
     InstallTheme,
+
+    #[strum(serialize = "run_code")]
+    RunCode,
 }
 
 #[derive(Debug)]

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1347,6 +1347,13 @@ impl LapceTabData {
             LapceWorkbenchCommand::InstallTheme => {
                 self.main_split.install_theme(ctx, &self.config);
             }
+            LapceWorkbenchCommand::RunCode => {
+                if let Some(command) = data.and_then(|d| {
+                    serde_json::from_value::<lsp_types::Command>(d).ok()
+                }) {
+                    self.main_split.run_code(ctx, command);
+                }
+            }
         }
     }
 
@@ -1494,6 +1501,7 @@ impl LapceTabData {
                             kind: CommandKind::MultiSelection(
                                 MultiSelectionCommand::SelectAll,
                             ),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(focus_id),
@@ -2336,6 +2344,10 @@ impl LapceMainSplitData {
         }
     }
 
+    pub fn run_code(&mut self, _ctx: &mut EventCtx, command: lsp_types::Command) {
+        println!("=============================\nRunning command: {command:?}");
+    }
+
     pub fn export_theme(&mut self, ctx: &mut EventCtx, config: &Config) {
         let id = self.new_file(ctx, config);
         let doc = self.scratch_docs.get_mut(&id).unwrap();
@@ -2725,6 +2737,7 @@ impl LapceMainSplitData {
                             LAPCE_COMMAND,
                             LapceCommand {
                                 kind: CommandKind::Focus(FocusCommand::SplitClose),
+                                name: None,
                                 data: None,
                             },
                             Target::Widget(view_id),
@@ -2827,6 +2840,7 @@ impl LapceMainSplitData {
                                         kind: CommandKind::Focus(
                                             FocusCommand::SaveAndExit,
                                         ),
+                                        name: None,
                                         data: None,
                                     },
                                 ),
@@ -2837,6 +2851,7 @@ impl LapceMainSplitData {
                                         kind: CommandKind::Focus(
                                             FocusCommand::ForceExit,
                                         ),
+                                        name: None,
                                         data: None,
                                     },
                                 ),

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1034,6 +1034,7 @@ impl LapceEditorBufferData {
                 LAPCE_COMMAND,
                 LapceCommand {
                     kind: CommandKind::Focus(FocusCommand::GotoDefinition),
+                    name: None,
                     data: None,
                 },
                 Target::Widget(self.editor.view_id),
@@ -1108,6 +1109,7 @@ impl LapceEditorBufferData {
                     LAPCE_COMMAND,
                     LapceCommand {
                         kind: CommandKind::Focus(FocusCommand::SplitClose),
+                        name: None,
                         data: None,
                     },
                     Target::Widget(self.editor.view_id),
@@ -1247,6 +1249,7 @@ impl LapceEditorBufferData {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Focus(FocusCommand::ModalClose),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(self.palette.widget_id),
@@ -1355,6 +1358,7 @@ impl LapceEditorBufferData {
                                 kind: CommandKind::Focus(
                                     FocusCommand::SearchForward,
                                 ),
+                                name: None,
                                 data: None,
                             },
                             Target::Widget(parent_view_id),
@@ -1388,6 +1392,7 @@ impl LapceEditorBufferData {
                                 kind: CommandKind::Focus(
                                     FocusCommand::SearchBackward,
                                 ),
+                                name: None,
                                 data: None,
                             },
                             Target::Widget(parent_view_id),
@@ -1485,6 +1490,7 @@ impl LapceEditorBufferData {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Focus(FocusCommand::ListSelect),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(self.palette.widget_id),
@@ -1533,6 +1539,7 @@ impl LapceEditorBufferData {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Focus(FocusCommand::ListNext),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(self.palette.widget_id),
@@ -1548,6 +1555,7 @@ impl LapceEditorBufferData {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Focus(FocusCommand::ListPrevious),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(self.palette.widget_id),
@@ -1829,6 +1837,7 @@ impl LapceEditorBufferData {
                             kind: CommandKind::MultiSelection(
                                 MultiSelectionCommand::SelectAll,
                             ),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(find_view_id),

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -651,6 +651,16 @@ impl LapceProxy {
         );
     }
 
+    pub fn get_code_lens(&self, buffer_id: BufferId, f: Box<dyn Callback>) {
+        self.rpc.send_rpc_request_async(
+            "get_code_lens",
+            &json!({
+                "buffer_id": buffer_id,
+            }),
+            f,
+        );
+    }
+
     pub fn get_document_symbols(&self, buffer_id: BufferId, f: Box<dyn Callback>) {
         self.rpc.send_rpc_request_async(
             "get_document_symbols",

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -543,6 +543,11 @@ impl Dispatcher {
                 let buffer = buffers.get(&buffer_id).unwrap();
                 self.lsp.lock().get_document_formatting(id, buffer);
             }
+            GetCodeLens { buffer_id } => {
+                let buffers = self.buffers.lock();
+                let buffer = buffers.get(&buffer_id).unwrap();
+                self.lsp.lock().get_code_lens(id, buffer);
+            }
             ReadDir { path } => {
                 let local_dispatcher = self.clone();
                 thread::spawn(move || {

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -110,6 +110,9 @@ pub enum ProxyRequest {
     GetDocumentFormatting {
         buffer_id: BufferId,
     },
+    GetCodeLens {
+        buffer_id: BufferId,
+    },
     GetFiles {
         path: String,
     },

--- a/lapce-ui/src/activity.rs
+++ b/lapce-ui/src/activity.rs
@@ -49,6 +49,7 @@ impl Widget<LapceTabData> for ActivityBar {
                                         kind: CommandKind::Workbench(
                                             LapceWorkbenchCommand::TogglePanelVisual,
                                         ),
+                                        name: None,
                                         data: Some(json!(kind)),
                                     },
                                     Target::Widget(data.id),
@@ -60,6 +61,7 @@ impl Widget<LapceTabData> for ActivityBar {
                                         kind: CommandKind::Workbench(
                                             LapceWorkbenchCommand::ShowPanel,
                                         ),
+                                        name: None,
                                         data: Some(json!(kind)),
                                     },
                                     Target::Widget(data.id),

--- a/lapce-ui/src/alert.rs
+++ b/lapce-ui/src/alert.rs
@@ -172,6 +172,7 @@ impl Widget<LapceTabData> for AlertBoxContent {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Focus(FocusCommand::ModalClose),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(self.widget_id),
@@ -193,6 +194,7 @@ impl Widget<LapceTabData> for AlertBoxContent {
                             LAPCE_COMMAND,
                             LapceCommand {
                                 kind: CommandKind::Focus(FocusCommand::ModalClose),
+                                name: None,
                                 data: None,
                             },
                             Target::Widget(self.widget_id),

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -268,6 +268,7 @@ impl LapceEditor {
                 desc: None,
                 command: LapceCommand {
                     kind: CommandKind::Focus(FocusCommand::GotoDefinition),
+                    name: None,
                     data: None,
                 },
             }),
@@ -277,6 +278,7 @@ impl LapceEditor {
                     kind: CommandKind::Workbench(
                         LapceWorkbenchCommand::PaletteCommand,
                     ),
+                    name: None,
                     data: None,
                 },
             }),
@@ -285,6 +287,7 @@ impl LapceEditor {
                 desc: None,
                 command: LapceCommand {
                     kind: CommandKind::Edit(EditCommand::ClipboardCut),
+                    name: None,
                     data: None,
                 },
             }),
@@ -292,6 +295,7 @@ impl LapceEditor {
                 desc: None,
                 command: LapceCommand {
                     kind: CommandKind::Edit(EditCommand::ClipboardCopy),
+                    name: None,
                     data: None,
                 },
             }),
@@ -299,6 +303,7 @@ impl LapceEditor {
                 desc: None,
                 command: LapceCommand {
                     kind: CommandKind::Edit(EditCommand::ClipboardPaste),
+                    name: None,
                     data: None,
                 },
             }),

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -61,6 +61,7 @@ impl LapceEditorHeader {
                 LAPCE_COMMAND,
                 LapceCommand {
                     kind: CommandKind::Focus(FocusCommand::SplitClose),
+                    name: None,
                     data: None,
                 },
                 Target::Widget(self.view_id),
@@ -79,6 +80,7 @@ impl LapceEditorHeader {
                 LAPCE_COMMAND,
                 LapceCommand {
                     kind: CommandKind::Focus(FocusCommand::SplitVertical),
+                    name: None,
                     data: None,
                 },
                 Target::Widget(self.view_id),

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -323,6 +323,7 @@ impl Widget<LapceTabData> for LapceEditorTab {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Focus(FocusCommand::SplitVertical),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(editor_tab.active_child().widget_id()),

--- a/lapce-ui/src/editor/tab_header.rs
+++ b/lapce-ui/src/editor/tab_header.rs
@@ -283,6 +283,7 @@ impl Widget<LapceTabData> for LapceEditorTabHeader {
                     LAPCE_COMMAND,
                     LapceCommand {
                         kind: CommandKind::Focus(FocusCommand::SplitVertical),
+                        name: None,
                         data: None,
                     },
                     Target::Widget(self.widget_id),

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -285,6 +285,7 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Focus(FocusCommand::SplitClose),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(editor_tab.children[tab_idx].widget_id()),

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -711,6 +711,7 @@ impl Widget<LapceTabData> for LapceEditorView {
                                     kind: CommandKind::Focus(
                                         FocusCommand::ModalClose,
                                     ),
+                                    name: None,
                                     data: None,
                                 },
                                 Target::Widget(data.palette.widget_id),
@@ -801,6 +802,7 @@ impl Widget<LapceTabData> for LapceEditorView {
                     LAPCE_COMMAND,
                     LapceCommand {
                         kind: CommandKind::Edit(EditCommand::InsertMode),
+                        name: None,
                         data: None,
                     },
                     Target::Widget(self.view_id),
@@ -810,6 +812,7 @@ impl Widget<LapceTabData> for LapceEditorView {
                     LAPCE_COMMAND,
                     LapceCommand {
                         kind: CommandKind::Edit(EditCommand::NormalMode),
+                        name: None,
                         data: None,
                     },
                     Target::Widget(self.view_id),

--- a/lapce-ui/src/find.rs
+++ b/lapce-ui/src/find.rs
@@ -40,6 +40,7 @@ impl FindBox {
                     LAPCE_COMMAND,
                     LapceCommand {
                         kind: CommandKind::Focus(FocusCommand::SearchBackward),
+                        name: None,
                         data: None,
                     },
                     Target::Widget(parent_view_id),
@@ -52,6 +53,7 @@ impl FindBox {
                     LAPCE_COMMAND,
                     LapceCommand {
                         kind: CommandKind::Focus(FocusCommand::SearchForward),
+                        name: None,
                         data: None,
                     },
                     Target::Widget(parent_view_id),
@@ -64,6 +66,7 @@ impl FindBox {
                     LAPCE_COMMAND,
                     LapceCommand {
                         kind: CommandKind::Focus(FocusCommand::ClearSearch),
+                        name: None,
                         data: None,
                     },
                     Target::Widget(parent_view_id),

--- a/lapce-ui/src/palette.rs
+++ b/lapce-ui/src/palette.rs
@@ -622,17 +622,14 @@ impl PaletteContent {
                     };
                     (None, text, indices.to_vec(), "".to_string(), vec![])
                 }
-                PaletteItemContent::Command(command) => (
-                    None,
-                    command
-                        .kind
-                        .desc()
-                        .map(|m| m.to_string())
-                        .unwrap_or_else(|| "".to_string()),
-                    indices.to_vec(),
-                    "".to_string(),
-                    vec![],
-                ),
+                PaletteItemContent::Command(command) => {
+                    let name = command
+                        .name
+                        .clone()
+                        .or_else(|| command.kind.desc().map(ToString::to_string))
+                        .unwrap_or_else(String::new);
+                    (None, name, indices.to_vec(), "".to_string(), vec![])
+                }
                 PaletteItemContent::Theme(theme) => (
                     None,
                     theme.to_string(),

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -423,6 +423,7 @@ impl PanelMainHeader {
                 LAPCE_COMMAND,
                 LapceCommand {
                     kind: CommandKind::Workbench(LapceWorkbenchCommand::HidePanel),
+                    name: None,
                     data: Some(json!(self.kind)),
                 },
                 Target::Widget(data.id),
@@ -457,6 +458,7 @@ impl PanelMainHeader {
                             kind: CommandKind::Workbench(
                                 LapceWorkbenchCommand::ToggleMaximizedPanel,
                             ),
+                            name: None,
                             data: Some(json!(self.kind)),
                         },
                         Target::Widget(data.id),

--- a/lapce-ui/src/split.rs
+++ b/lapce-ui/src/split.rs
@@ -1167,6 +1167,7 @@ fn empty_editor_commands(modal: bool, has_workspace: bool) -> Vec<LapceCommand> 
         vec![
             LapceCommand {
                 kind: CommandKind::Workbench(LapceWorkbenchCommand::PaletteCommand),
+                name: None,
                 data: None,
             },
             LapceCommand {
@@ -1175,16 +1176,19 @@ fn empty_editor_commands(modal: bool, has_workspace: bool) -> Vec<LapceCommand> 
                 } else {
                     LapceWorkbenchCommand::EnableModal
                 }),
+                name: None,
                 data: None,
             },
             LapceCommand {
                 kind: CommandKind::Workbench(LapceWorkbenchCommand::OpenFolder),
+                name: None,
                 data: None,
             },
             LapceCommand {
                 kind: CommandKind::Workbench(
                     LapceWorkbenchCommand::PaletteWorkspace,
                 ),
+                name: None,
                 data: None,
             },
         ]
@@ -1192,6 +1196,7 @@ fn empty_editor_commands(modal: bool, has_workspace: bool) -> Vec<LapceCommand> 
         vec![
             LapceCommand {
                 kind: CommandKind::Workbench(LapceWorkbenchCommand::PaletteCommand),
+                name: None,
                 data: None,
             },
             if modal {
@@ -1199,16 +1204,19 @@ fn empty_editor_commands(modal: bool, has_workspace: bool) -> Vec<LapceCommand> 
                     kind: CommandKind::Workbench(
                         LapceWorkbenchCommand::DisableModal,
                     ),
+                    name: None,
                     data: None,
                 }
             } else {
                 LapceCommand {
                     kind: CommandKind::Workbench(LapceWorkbenchCommand::EnableModal),
+                    name: None,
                     data: None,
                 }
             },
             LapceCommand {
                 kind: CommandKind::Workbench(LapceWorkbenchCommand::Palette),
+                name: None,
                 data: None,
             },
         ]

--- a/lapce-ui/src/status.rs
+++ b/lapce-ui/src/status.rs
@@ -77,6 +77,7 @@ impl LapceStatus {
                         LAPCE_COMMAND,
                         LapceCommand {
                             kind: CommandKind::Workbench(cmd),
+                            name: None,
                             data: None,
                         },
                         Target::Widget(data.id),

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -466,6 +466,7 @@ impl LapceTab {
                                             kind: CommandKind::Focus(
                                                 FocusCommand::SearchInView,
                                             ),
+                                            name: None,
                                             data: None,
                                         },
                                         Target::Widget(widget_id),
@@ -721,6 +722,7 @@ impl LapceTab {
                                         kind: CommandKind::Focus(
                                             FocusCommand::SplitClose,
                                         ),
+                                        name: None,
                                         data: None,
                                     },
                                     Target::Widget(*widget_id),

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -252,6 +252,7 @@ impl Widget<LapceWindowData> for Title {
             desc: None,
             command: LapceCommand {
                 kind: CommandKind::Workbench(LapceWorkbenchCommand::ConnectSshHost),
+                name: None,
                 data: None,
             },
         })];
@@ -261,6 +262,7 @@ impl Widget<LapceWindowData> for Title {
                 desc: None,
                 command: LapceCommand {
                     kind: CommandKind::Workbench(LapceWorkbenchCommand::ConnectWsl),
+                    name: None,
                     data: None,
                 },
             }));
@@ -273,6 +275,7 @@ impl Widget<LapceWindowData> for Title {
                     kind: CommandKind::Workbench(
                         LapceWorkbenchCommand::DisconnectRemote,
                     ),
+                    name: None,
                     data: None,
                 },
             }));
@@ -339,6 +342,7 @@ impl Widget<LapceWindowData> for Title {
                 desc: None,
                 command: LapceCommand {
                     kind: CommandKind::Workbench(LapceWorkbenchCommand::OpenFolder),
+                    name: None,
                     data: None,
                 },
             }),
@@ -348,6 +352,7 @@ impl Widget<LapceWindowData> for Title {
                     kind: CommandKind::Workbench(
                         LapceWorkbenchCommand::PaletteWorkspace,
                     ),
+                    name: None,
                     data: None,
                 },
             }),
@@ -425,6 +430,7 @@ impl Widget<LapceWindowData> for Title {
                             kind: CommandKind::Workbench(
                                 LapceWorkbenchCommand::CheckoutBranch,
                             ),
+                            name: None,
                             data: Some(json!(b.to_string())),
                         },
                     })
@@ -469,6 +475,7 @@ impl Widget<LapceWindowData> for Title {
                     kind: CommandKind::Workbench(
                         LapceWorkbenchCommand::PaletteCommand,
                     ),
+                    name: None,
                     data: None,
                 },
             }),
@@ -478,6 +485,7 @@ impl Widget<LapceWindowData> for Title {
                     kind: CommandKind::Workbench(
                         LapceWorkbenchCommand::OpenSettings,
                     ),
+                    name: None,
                     data: None,
                 },
             }),
@@ -487,6 +495,7 @@ impl Widget<LapceWindowData> for Title {
                     kind: CommandKind::Workbench(
                         LapceWorkbenchCommand::OpenKeyboardShortcuts,
                     ),
+                    name: None,
                     data: None,
                 },
             }),


### PR DESCRIPTION
Hey guys! (@MinusGix)
This PR is a followup on issue #603 

I created a draft PR in order for us to have some grounds to discuss and make progress - The current work is by all means WIP.

~Another important note - since my previous pr (#615) is not yet merged, I started to work from my branch - so it contains the changes from the previous branch as well.
I'm really sorry for the inconvenience, but once #615 will be merged I'll re-arrange this PR / open a new one.
In the meanwhile - please take a look at the last commit in this PR.~

Edit (June 20th): I rebased from master so the mess is gone 🙂 (still a wip, no code changed)

---

Now that the technical notes are said, let me lay out my current work:  

1. I created a new LSP request to [`textDocument/codeLens`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens)
2. I added a command with prefix `$` to the palette, which queries the LSP for code lens and presents all possible runnable commands for the current file:
![image](https://user-images.githubusercontent.com/67855609/174502910-b8623f99-abd9-4374-b6f7-ce9f70fddd3d.png)
The debug prints at this point show the raw command returned from the LSP.

**Note** This LSP request works for every runnable entry point in the file, including `fn main()` for example:
![image](https://user-images.githubusercontent.com/67855609/174502992-3318e91d-177a-4738-80cb-4777ee270a9f.png)

3. I created a hook for when a runnable from the above palette is being chosen, which currently does nothing but debugging the command:
```
Running command: Command { title: "▶\u{fe0e} Run Tests", command: "rust-analyzer.runSingle", arguments: Some([Object({"args": Object({"cargoArgs": Array([String("test"), String("--package"), String("lapce-core"), String("--lib")]), "cargoExtraArgs": Array([]), "executableArgs": Array([String("syntax::tests"), String("--nocapture")]), "overrideCargo": Null, "workspaceRoot": String("/home/yoni/lapce")}), "kind": String("cargo"), "label": String("test-mod syntax::tests"), "location": Object({"targetRange": Object({"end": Object({"character": Number(1), "line": Number(475)}), "start": Object({"character": Number(0), "line": Number(439)})}), "targetSelectionRange": Object({"end": Object({"character": Number(9), "line": Number(440)}), "start": Object({"character": Number(4), "line": Number(440)})}), "targetUri": String("file:///home/yoni/lapce/lapce-core/src/syntax.rs")})})]) }
```

### Next steps and open questions
1. Decide on the UX / DX (developer experience) of this feature - I prefer to have a green arrow near each runnable entry (like JetBrains)
    i. If we do decide on this UX, It'd be nice if you guys could suggest some relevant code references etc. on how to implement it, because to be frank I kinda got lost a bit there 😅
    ii. Another option is to move forward with the palette option, just make it a bit more user friendly (with icons etc.)
    iii. A third option is to join the party over the `CodeActions` area (`gutter.rs` - the light bulb thingy) - and just add a `Run test` command there when relevant.  
2. Implement running the command itself - There's an LSP request for this as well, just need to pass the data all the way back through the proxy and all...

Looking forward to hearing from you guys, please lmk how do you find the current progress and what you think about the next steps! 