### PR TITLE
Add various tree-sitter languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,19 +2180,24 @@ dependencies = [
  "tree-sitter-cpp",
  "tree-sitter-elixir",
  "tree-sitter-elm",
+ "tree-sitter-glimmer",
  "tree-sitter-go",
  "tree-sitter-haskell",
+ "tree-sitter-haxe",
+ "tree-sitter-hcl",
  "tree-sitter-highlight",
  "tree-sitter-html",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-json",
  "tree-sitter-md",
+ "tree-sitter-ocaml",
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-ql",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scss",
  "tree-sitter-swift",
  "tree-sitter-toml",
  "tree-sitter-typescript",
@@ -4583,6 +4588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-glimmer"
+version = "0.0.1"
+source = "git+https://github.com/VixieTSQ/tree-sitter-glimmer#726c956eafa1ddc1d453292716c1e6a3ee7a33c4"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4596,6 +4610,24 @@ dependencies = [
 name = "tree-sitter-haskell"
 version = "0.14.0"
 source = "git+https://github.com/tree-sitter/tree-sitter-haskell#14bf3061a3fbcadab428fb5e50eb2c5b1f9be0c3"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-haxe"
+version = "0.0.1"
+source = "git+https://github.com/VixieTSQ/tree-sitter-haxe#a3e23bc0f84a53371eb5d86229782ec6c21d3729"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "0.0.1"
+source = "git+https://github.com/VixieTSQ/tree-sitter-hcl#fee8bab54172f972121d4e51f7de131d24922fa9"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -4661,6 +4693,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-ocaml"
+version = "0.20.0"
+source = "git+https://github.com/tree-sitter/tree-sitter-ocaml#cc26b1ef111100f26a137bcbcd39fd4e35be9a59"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-php"
 version = "0.19.1"
 source = "git+https://github.com/tree-sitter/tree-sitter-php.git#ead3e4cc5f54602a6b54826c5d6881c9a9da15af"
@@ -4702,6 +4743,15 @@ name = "tree-sitter-rust"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df540a493d754015d22eaf57c38f58804be3713a22f6062db983ec15f85c3c9"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-scss"
+version = "0.0.1"
+source = "git+https://github.com/VixieTSQ/tree-sitter-scss?branch=patch-1#3aac3391ede5098edbf4cc8a9f6d0cfdfe28e5dc"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-glimmer"
 version = "0.0.1"
-source = "git+https://github.com/VixieTSQ/tree-sitter-glimmer#726c956eafa1ddc1d453292716c1e6a3ee7a33c4"
+source = "git+https://github.com/VixieTSQ/tree-sitter-glimmer#d8a41791e83d445ef52748429cea6fed974908e7"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-hcl"
 version = "0.0.1"
-source = "git+https://github.com/VixieTSQ/tree-sitter-hcl#fee8bab54172f972121d4e51f7de131d24922fa9"
+source = "git+https://github.com/VixieTSQ/tree-sitter-hcl#f4aa4553344e03e149ec459549a7f686d6846626"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -34,6 +34,11 @@ tree-sitter-elm = { version = "5.6.0", optional = true }
 tree-sitter-swift = { version = "0.3.0", optional = true }
 tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql", version = "0.19.0", optional = true }
 tree-sitter-haskell = { git = "https://github.com/tree-sitter/tree-sitter-haskell", version = "0.14.0", optional = true }
+tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", version = "0.20.0", optional = true }
+tree-sitter-glimmer = { git = "https://github.com/VixieTSQ/tree-sitter-glimmer", version = "0.0.1", optional = true }
+tree-sitter-haxe = { git = "https://github.com/VixieTSQ/tree-sitter-haxe", version = "0.0.1", optional = true }
+tree-sitter-hcl = { git = "https://github.com/VixieTSQ/tree-sitter-hcl", version = "0.0.1", optional = true }
+tree-sitter-scss = { git = "https://github.com/VixieTSQ/tree-sitter-scss", version = "0.0.1", branch = "patch-1", optional = true }
 lsp-types = { version = "0.89.2", features = ["proposed"] }
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
 lapce-rpc = { path = "../lapce-rpc" }
@@ -62,3 +67,8 @@ lang-elm = ["dep:tree-sitter-elm"]
 lang-swift = ["dep:tree-sitter-swift"]
 lang-ql = ["dep:tree-sitter-ql"]
 lang-haskell = ["dep:tree-sitter-haskell"]
+lang-ocaml = ["dep:tree-sitter-ocaml"]
+lang-glimmer = ["dep:tree-sitter-glimmer"]
+lang-haxe = ["dep:tree-sitter-haxe"]
+lang-hcl = ["dep:tree-sitter-hcl"]
+lang-scss = ["dep:tree-sitter-scss"]

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -138,6 +138,18 @@ pub enum LapceLanguage {
     QL,
     #[cfg(feature = "lang-haskell")]
     Haskell,
+    #[cfg(feature = "lang-glimmer")]
+    Glimmer,
+    #[cfg(feature = "lang-haxe")]
+    Haxe,
+    #[cfg(feature = "lang-hcl")]
+    HCL,
+    #[cfg(feature = "lang-ocaml")]
+    OCaml,
+    #[cfg(feature = "lang-ocaml")]
+    OCamlInterface,
+    #[cfg(feature = "lang-scss")]
+    SCSS,
 }
 
 // NOTE: Elements in the array must be in the same order as the enum variants of
@@ -376,6 +388,66 @@ const LANGUAGES: &[SyntaxProperties] = &[
         code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
         extensions: &["hs"],
     },
+    #[cfg(feature = "lang-glimmer")]
+    SyntaxProperties {
+        id: LapceLanguage::Glimmer,
+        language: tree_sitter_glimmer::language,
+        highlight: tree_sitter_glimmer::HIGHLIGHTS_QUERY,
+        comment: "{{!",
+        indent: "  ",
+        code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
+        extensions: &["hbs"],
+    },
+    #[cfg(feature = "lang-haxe")]
+    SyntaxProperties {
+        id: LapceLanguage::Haxe,
+        language: tree_sitter_haxe::language,
+        highlight: tree_sitter_haxe::HIGHLIGHTS_QUERY,
+        comment: "//",
+        indent: "  ",
+        code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
+        extensions: &["hx"],
+    },
+    #[cfg(feature = "lang-hcl")]
+    SyntaxProperties {
+        id: LapceLanguage::HCL,
+        language: tree_sitter_hcl::language,
+        highlight: tree_sitter_hcl::HIGHLIGHTS_QUERY,
+        comment: "//",
+        indent: "  ",
+        code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
+        extensions: &["hcl"],
+    },
+    #[cfg(feature = "lang-ocaml")]
+    SyntaxProperties {
+        id: LapceLanguage::OCaml,
+        language: tree_sitter_ocaml::language_ocaml,
+        highlight: tree_sitter_ocaml::HIGHLIGHTS_QUERY,
+        comment: "(*",
+        indent: "  ",
+        code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
+        extensions: &["ml"],
+    },
+    #[cfg(feature = "lang-ocaml")]
+    SyntaxProperties {
+        id: LapceLanguage::OCaml,
+        language: tree_sitter_ocaml::language_ocaml_interface,
+        highlight: tree_sitter_ocaml::HIGHLIGHTS_QUERY,
+        comment: "(*",
+        indent: "  ",
+        code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
+        extensions: &["mli"],
+    },
+    #[cfg(feature = "lang-scss")]
+    SyntaxProperties {
+        id: LapceLanguage::SCSS,
+        language: tree_sitter_scss::language,
+        highlight: tree_sitter_scss::HIGHLIGHTS_QUERY,
+        comment: "//",
+        indent: "  ",
+        code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
+        extensions: &["scss"],
+    },
 ];
 
 impl LapceLanguage {
@@ -613,5 +685,26 @@ mod test {
     #[cfg(feature = "lang-haskell")]
     fn test_haskell_lang() {
         assert_language(LapceLanguage::Haskell, &["hs"]);
+    }
+    #[cfg(feature = "lang-glimmer")]
+    fn test_glimmer_lang() {
+        assert_language(LapceLanguage::Glimmer, &["hbs"]);
+    }
+    #[cfg(feature = "lang-haxe")]
+    fn test_haxe_lang() {
+        assert_language(LapceLanguage::Haxe, &["hx"]);
+    }
+    #[cfg(feature = "lang-hcl")]
+    fn test_hcl_lang() {
+        assert_language(LapceLanguage::HCL, &["hcl"]);
+    }
+    #[cfg(feature = "lang-ocaml")]
+    fn test_ocaml_lang() {
+        assert_language(LapceLanguage::OCaml, &["ml"]);
+        assert_language(LapceLanguage::OCamlInterface, &["mli"]);
+    }
+    #[cfg(feature = "lang-scss")]
+    fn test_scss_lang() {
+        assert_language(LapceLanguage::SCSS, &["scss"]);
     }
 }

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -81,7 +81,13 @@ all-languages = [
     "lang-swift",
     "lang-ql",
     "lang-haskell",
+    "lang-ocaml",
+    "lang-glimmer",
+    "lang-haxe",
+    "lang-hcl",
+    "lang-scss"
 ]
+
 lang-rust = ["lapce-core/lang-rust"]
 lang-go = ["lapce-core/lang-go"]
 lang-javascript= ["lapce-core/lang-javascript"]
@@ -101,3 +107,8 @@ lang-elm = ["lapce-core/lang-elm"]
 lang-swift = ["lapce-core/lang-swift"]
 lang-ql = ["lapce-core/lang-ql"]
 lang-haskell = ["lapce-core/lang-haskell"]
+lang-ocaml = ["lapce-core/lang-ocaml"]
+lang-glimmer = ["lapce-core/lang-glimmer"]
+lang-haxe = ["lapce-core/lang-haxe"]
+lang-hcl = ["lapce-core/lang-hcl"]
+lang-scss = ["lapce-core/lang-scss"]


### PR DESCRIPTION
Partially fixes https://github.com/lapce/lapce/issues/272. 

I haven't tested any of these, and they really should be tested. We could @ some people in the discord server who have the OS testing roles but I doubt a lot of them read that the roles were for testing... 