### PR TITLE
Impl searching for symbols in workspace

### DIFF
--- a/defaults/keymaps-macos.toml
+++ b/defaults/keymaps-macos.toml
@@ -227,5 +227,9 @@ key = "meta+O"
 command = "palette.symbol"
 
 [[keymaps]]
+key = "meta+t"
+command = "palette.workspace_symbol"
+
+[[keymaps]]
 key = "ctrl+g"
 command = "palette.line"

--- a/defaults/keymaps-nonmacos.toml
+++ b/defaults/keymaps-nonmacos.toml
@@ -222,5 +222,9 @@ key = "ctrl+O"
 command = "palette.symbol"
 
 [[keymaps]]
+key = "ctrl+t"
+command = "palette.workspace_symbol"
+
+[[keymaps]]
 key = "ctrl+g"
 command = "palette.line"

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -271,6 +271,9 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "palette.symbol")]
     PaletteSymbol,
 
+    #[strum(serialize = "palette.workspace_symbol")]
+    PaletteWorkspaceSymbol,
+
     #[strum(message = "Command Palette")]
     #[strum(serialize = "palette.command")]
     PaletteCommand,

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1100,6 +1100,13 @@ impl LapceTabData {
                     Target::Widget(self.palette.widget_id),
                 ));
             }
+            LapceWorkbenchCommand::PaletteWorkspaceSymbol => {
+                ctx.submit_command(Command::new(
+                    LAPCE_UI_COMMAND,
+                    LapceUICommand::RunPalette(Some(PaletteType::WorkspaceSymbol)),
+                    Target::Widget(self.palette.widget_id),
+                ));
+            }
             LapceWorkbenchCommand::PaletteCommand => {
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -611,6 +611,22 @@ impl LapceProxy {
         );
     }
 
+    pub fn get_workspace_symbols(
+        &self,
+        buffer_id: BufferId,
+        query: &str,
+        f: Box<dyn Callback>,
+    ) {
+        self.rpc.send_rpc_request_async(
+            "get_workspace_symbols",
+            &json!({
+                "buffer_id": buffer_id,
+                "query": query,
+            }),
+            f,
+        );
+    }
+
     pub fn get_code_actions(
         &self,
         buffer_id: BufferId,

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -525,6 +525,11 @@ impl Dispatcher {
                 let buffer = buffers.get(&buffer_id).unwrap();
                 self.lsp.lock().get_document_symbols(id, buffer);
             }
+            GetWorkspaceSymbols { query, buffer_id } => {
+                let buffers = self.buffers.lock();
+                let buffer = buffers.get(&buffer_id).unwrap();
+                self.lsp.lock().get_workspace_symbols(id, buffer, query);
+            }
             GetDocumentFormatting { buffer_id } => {
                 let buffers = self.buffers.lock();
                 let buffer = buffers.get(&buffer_id).unwrap();

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -162,6 +162,20 @@ impl LspCatalog {
         }
     }
 
+    pub fn get_workspace_symbols(
+        &self,
+        id: RequestId,
+        buffer: &Buffer,
+        query: String,
+    ) {
+        // TODO: We could collate workspace symbols from all the lsps?
+        if let Some(client) = self.clients.get(&buffer.language_id) {
+            client.request_workspace_symbols(query, move |lsp_client, result| {
+                lsp_client.dispatcher.respond(id, result);
+            });
+        }
+    }
+
     pub fn get_document_formatting(&self, id: RequestId, buffer: &Buffer) {
         if let Some(client) = self.clients.get(&buffer.language_id) {
             let uri = client.get_uri(buffer);
@@ -707,6 +721,12 @@ impl LspClient {
                 }),
                 ..Default::default()
             }),
+            workspace: Some(WorkspaceClientCapabilities {
+                symbol: Some(WorkspaceSymbolClientCapabilities {
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
             experimental: Some(json!({
                 "serverStatusNotification": true,
             })),
@@ -741,6 +761,18 @@ impl LspClient {
         };
         let params = Params::from(serde_json::to_value(params).unwrap());
         self.send_request("textDocument/documentSymbol", params, Box::new(cb));
+    }
+
+    pub fn request_workspace_symbols<CB>(&self, query: String, cb: CB)
+    where
+        CB: 'static + Send + FnOnce(&LspClient, Result<Value>),
+    {
+        let params = WorkspaceSymbolParams {
+            query,
+            ..Default::default()
+        };
+        let params = Params::from(serde_json::to_value(params).unwrap());
+        self.send_request("workspace/symbol", params, Box::new(cb));
     }
 
     pub fn request_document_formatting<CB>(&self, document_uri: Url, cb: CB)

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -100,6 +100,12 @@ pub enum ProxyRequest {
     GetDocumentSymbols {
         buffer_id: BufferId,
     },
+    GetWorkspaceSymbols {
+        /// The search query
+        query: String,
+        /// THe id of the buffer it was used in, which tells us what LSP to query
+        buffer_id: BufferId,
+    },
     GetDocumentFormatting {
         buffer_id: BufferId,
     },


### PR DESCRIPTION
This implements the ability to search for symbols in the entire workspace.  
Uses the `#` prefix and Ctrl+T keybinding, like VSCode.  
![image](https://user-images.githubusercontent.com/13157904/175061355-7bf2c9e0-cfdb-452d-92e7-b1a1fd05f580.png)


There's an LSP command for searching for a symbol in the workspace, though it behaves differently compared to document search since there can be a *lot* of symbols so it doesn't provide them all. It does some of the filtering for you. That required a bit of a different implementation of it in the palette, since it needs to resend the request whenever the input changes.  

