### PR TITLE
Add shift-delete/shift-backspace to keymaps

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -22,7 +22,17 @@ command = "delete_forward"
 mode = "i"
 
 [[keymaps]]
+key = "shift+Delete"
+command = "delete_forward"
+mode = "i"
+
+[[keymaps]]
 key = "backspace"
+command = "delete_backward"
+mode = "i"
+
+[[keymaps]]
+key = "shift+backspace"
 command = "delete_backward"
 mode = "i"
 


### PR DESCRIPTION
Fixes #662 
(I'm assuming these keybinds are the same on MacOS?)