### PR TITLE
Impl discarding git changes per file/workspace

### DIFF
--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -367,6 +367,14 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "source_control_commit")]
     SourceControlCommit,
 
+    #[strum(message = "Source Control: Discard File Changes")]
+    #[strum(serialize = "source_control_discard_active_file_changes")]
+    SourceControlDiscardActiveFileChanges,
+
+    #[strum(message = "Source Control: Discard Workspace Changes")]
+    #[strum(serialize = "source_control_discard_workspace_changes")]
+    SourceControlDiscardWorkspaceChanges,
+
     #[strum(serialize = "export_current_theme_settings")]
     #[strum(message = "Export current settings to a theme file")]
     ExportCurrentThemeSettings,

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1387,6 +1387,16 @@ impl LapceTabData {
                     Cursor::new(CursorMode::Insert(Selection::caret(0)), None, None)
                 };
             }
+            LapceWorkbenchCommand::SourceControlDiscardActiveFileChanges => {
+                if let Some(editor) = self.main_split.active_editor() {
+                    if let BufferContent::File(path) = &editor.content {
+                        self.proxy.git_discard_file_changes(path);
+                    }
+                }
+            }
+            LapceWorkbenchCommand::SourceControlDiscardWorkspaceChanges => {
+                self.proxy.git_discard_workspace_changes();
+            }
             LapceWorkbenchCommand::CheckoutBranch => match data {
                 Some(Value::String(branch)) => self.proxy.git_checkout(&branch),
                 _ => log::error!("checkout called without a branch"), // TODO: How do I show a result to the user here?

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -405,6 +405,29 @@ impl LapceProxy {
         )
     }
 
+    pub fn git_discard_file_changes(&self, file: &Path) {
+        self.rpc.send_rpc_notification(
+            "git_discard_file_changes",
+            &json!({
+                "file": file,
+            }),
+        );
+    }
+
+    pub fn git_discard_files_changes(&self, files: Vec<PathBuf>) {
+        self.rpc.send_rpc_notification(
+            "git_discard_files_changes",
+            &json!({
+                "files": files,
+            }),
+        );
+    }
+
+    pub fn git_discard_workspace_changes(&self) {
+        self.rpc
+            .send_rpc_notification("git_discard_workspace_changes", &json!({}));
+    }
+
     pub fn install_plugin(&self, plugin: &PluginDescription) {
         self.rpc
             .send_rpc_notification("install_plugin", &json!({ "plugin": plugin }));

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -37,6 +37,13 @@ pub enum ProxyNotification {
     GitCheckout {
         branch: String,
     },
+    GitDiscardFileChanges {
+        file: PathBuf,
+    },
+    GitDiscardFilesChanges {
+        files: Vec<PathBuf>,
+    },
+    GitDiscardWorkspaceChanges {},
     GitInit {},
     TerminalWrite {
         term_id: TermId,


### PR DESCRIPTION
Related to #682 but does not add the ability to apply it to files (such as in the context menu) but adds the code to handle multiple files at once for when that's added.
I am unsure as to if this is the most correct method for resetting uncommitted files back to what they were, but it appears to work in my tests.  