### PR TITLE
Implement inlay hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_json",
  "sled",
+ "smallvec",
  "structdesc",
  "strum 0.24.1",
  "strum_macros 0.24.0",

--- a/defaults/dark-theme.toml
+++ b/defaults/dark-theme.toml
@@ -71,6 +71,8 @@ magenta = "#C678DD"
 "editor.current_line" = "#2C313C"
 "editor.link" = "$cyan"
 
+"inlay_hint.foreground" = "#5C6370"
+
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"
 "source_control.modified" = "#0184BC32"

--- a/defaults/light-theme.toml
+++ b/defaults/light-theme.toml
@@ -96,6 +96,8 @@ magenta = "#A626A4"
 "editor.current_line" = "#F2F2F2"
 "editor.link" = "$cyan"
 
+"inlay_hint.foreground" = "$gray"
+
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"
 "source_control.modified" = "#0184BC32"

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -14,6 +14,9 @@ scroll-beyond-last-line = true
 hover-delay = 300             # ms
 modal-mode-relative-line-numbers = true
 format-on-save = true
+enable-inlay-hints = true
+inlay-hint-font-family = ""
+inlay-hint-font-size = 0
 
 [terminal]
 font-family = ""
@@ -91,6 +94,8 @@ magenta = "#C678DD"
 "editor.selection" = "$grey"
 "editor.current_line" = "#2C313C"
 "editor.link" = "$cyan"
+
+"inlay_hint.foreground" = "$grey"
 
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -57,3 +57,4 @@ lapce-proxy = { path = "../lapce-proxy" }
 bytemuck = "1.8.0"
 # For parsing markdown data, such as in hovers
 pulldown-cmark = "0.9.1"
+smallvec = "1.8.0"

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -14,7 +14,8 @@ use lapce_rpc::{
 };
 use lsp_types::{
     CodeActionOrCommand, CodeActionResponse, CompletionItem, CompletionResponse,
-    Location, Position, ProgressParams, PublishDiagnosticsParams, TextEdit,
+    InlayHint, Location, Position, ProgressParams, PublishDiagnosticsParams,
+    TextEdit,
 };
 use serde_json::Value;
 use strum::{self, EnumMessage, IntoEnumIterator};
@@ -441,6 +442,11 @@ pub enum LapceUICommand {
     ResolveCompletion(BufferId, u64, usize, Box<CompletionItem>),
     UpdateCompletion(usize, String, CompletionResponse),
     UpdateHover(usize, Arc<Vec<RichText>>),
+    UpdateInlayHints {
+        path: PathBuf,
+        rev: u64,
+        hints: Vec<InlayHint>,
+    },
     UpdateCodeActions(PathBuf, u64, usize, CodeActionResponse),
     CancelPalette,
     RunCodeAction(CodeActionOrCommand),

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -48,6 +48,8 @@ impl LapceTheme {
     pub const EDITOR_CURRENT_LINE: &'static str = "editor.current_line";
     pub const EDITOR_LINK: &'static str = "editor.link";
 
+    pub const INLAY_HINT_FOREGROUND: &'static str = "inlay_hint.foreground";
+
     pub const SOURCE_CONTROL_ADDED: &'static str = "source_control.added";
     pub const SOURCE_CONTROL_REMOVED: &'static str = "source_control.removed";
     pub const SOURCE_CONTROL_MODIFIED: &'static str = "source_control.modified";
@@ -159,11 +161,37 @@ pub struct EditorConfig {
         desc = "Whether it should format the document on save (if there is an available formatter)"
     )]
     pub format_on_save: bool,
+    #[field_names(desc = "If inlay hints should be displayed")]
+    pub enable_inlay_hints: bool,
+    #[field_names(
+        desc = "Set the inlay hint font family. If empty, it uses the editor font family."
+    )]
+    pub inlay_hint_font_family: String,
+    #[field_names(
+        desc = "Set the inlay hint font size. If 0, it uses 0.8 * the editor's font size."
+    )]
+    pub inlay_hint_font_size: usize,
 }
 
 impl EditorConfig {
     pub fn font_family(&self) -> FontFamily {
         FontFamily::new_unchecked(self.font_family.clone())
+    }
+
+    pub fn inlay_hint_font_family(&self) -> FontFamily {
+        if self.inlay_hint_font_family.is_empty() {
+            self.font_family()
+        } else {
+            FontFamily::new_unchecked(self.inlay_hint_font_family.clone())
+        }
+    }
+
+    pub fn inlay_hint_font_size(&self) -> f64 {
+        if self.inlay_hint_font_size == 0 {
+            self.font_size as f64 * 0.8
+        } else {
+            self.inlay_hint_font_size as f64
+        }
     }
 }
 

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -700,6 +700,16 @@ impl LapceProxy {
         );
     }
 
+    pub fn get_inlay_hints(&self, buffer_id: BufferId, f: Box<dyn Callback>) {
+        self.rpc.send_rpc_request_async(
+            "get_inlay_hints",
+            &json!({
+                "buffer_id": buffer_id,
+            }),
+            f,
+        );
+    }
+
     pub fn get_code_actions(
         &self,
         buffer_id: BufferId,

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -551,6 +551,11 @@ impl Dispatcher {
                     .lock()
                     .get_definition(id, request_id, buffer, position);
             }
+            GetInlayHints { buffer_id } => {
+                let buffers = self.buffers.lock();
+                let buffer = buffers.get(&buffer_id).unwrap();
+                self.lsp.lock().get_inlay_hints(id, buffer);
+            }
             GetCodeActions {
                 buffer_id,
                 position,

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -101,6 +101,9 @@ pub enum ProxyRequest {
         buffer_id: BufferId,
         position: Position,
     },
+    GetInlayHints {
+        buffer_id: BufferId,
+    },
     GetCodeActions {
         buffer_id: BufferId,
         position: Position,

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -626,6 +626,7 @@ impl Widget<LapceTabData> for LapceEditorView {
                 editor_data.sync_buffer_position(
                     self.editor.widget().editor.widget().inner().offset(),
                 );
+                editor_data.get_inlay_hints(ctx);
                 editor_data.get_code_actions(ctx);
 
                 data.keypress = keypress.clone();

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1200,6 +1200,13 @@ impl LapceTab {
                         }
                         ctx.set_handled();
                     }
+                    LapceUICommand::UpdateInlayHints { path, rev, hints } => {
+                        if let Some(doc) = data.main_split.open_docs.get_mut(path) {
+                            if doc.rev() == *rev {
+                                Arc::make_mut(doc).update_inlay_hints(hints.into());
+                            }
+                        }
+                    }
                     LapceUICommand::UpdateCodeActions(path, rev, offset, resp) => {
                         if let Some(doc) = data.main_split.open_docs.get_mut(path) {
                             if doc.rev() == *rev {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13157904/176828640-fc1c75c9-641c-4727-80f6-5764361d6de6.png)
This PR implements inlay hints.  
Question: Where is the best place to initialize inlay hints on open documents? Currently it waits until you press a key, but that's not the best time to do it. Adding the code for when an editor-view is opened could work, but would also want it to work on editor views that are open before the LSP begins initializing?  
Notes:  
 - This does not implement a custom background color for inlay hints. The code provides an iterator so it would be relatively easy to implement later.
 - Does not implement commands that are activated by clicking on the inlay hints; does not implement tooltips for inlay hints
 - Adds `smallvec` as a direct dependency. This makes the code nicer and lets us avoid extra allocs in an area where speed is nice.