### PR TITLE
feat: parse commandline args

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -8,6 +8,9 @@ use std::{
     time::Instant,
 };
 
+#[cfg(target_os = "windows")]
+use std::env;
+
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use directories::BaseDirs;
@@ -91,7 +94,7 @@ pub struct LapceData {
 impl LapceData {
     /// Create a new `LapceData` struct by loading configuration, and state
     /// previously written to the Lapce database.
-    pub fn load(event_sink: ExtEventSink) -> Self {
+    pub fn load(event_sink: ExtEventSink, path: Option<String>) -> Self {
         let db = Arc::new(LapceDb::new().unwrap());
         let mut windows = im::HashMap::new();
         let config = Config::load(&LapceWorkspace::default()).unwrap_or_default();
@@ -100,7 +103,46 @@ impl LapceData {
             .get_panel_orders()
             .unwrap_or_else(|_| Self::default_panel_orders());
 
-        if let Ok(app) = db.get_app() {
+        if let Some(path) = path {
+            let path = PathBuf::from(path).canonicalize().unwrap();
+            if path.is_dir() {
+                #[cfg(target_os = "windows")]
+                let workspace_type =
+                    if !env::var("WSL_DISTRO_NAME").unwrap_or_default().is_empty()
+                        || !env::var("WSLENV").unwrap_or_default().is_empty()
+                        || !env::var("WSL_INTEROP").unwrap_or_default().is_empty()
+                    {
+                        LapceWorkspaceType::RemoteWSL
+                    } else {
+                        LapceWorkspaceType::Local
+                    };
+
+                #[cfg(not(target_os = "windows"))]
+                let workspace_type = LapceWorkspaceType::Local;
+
+                let info = WindowInfo {
+                    size: Size::new(800.0, 600.0),
+                    pos: Point::new(0.0, 0.0),
+                    maximised: false,
+                    tabs: TabsInfo {
+                        active_tab: 0,
+                        workspaces: vec![LapceWorkspace {
+                            kind: workspace_type,
+                            path: Some(path),
+                            last_open: 0,
+                        }],
+                    },
+                };
+                let window = LapceWindowData::new(
+                    keypress.clone(),
+                    panel_orders.clone(),
+                    event_sink.clone(),
+                    &info,
+                    db.clone(),
+                );
+                windows.insert(window.window_id, window);
+            }
+        } else if let Ok(app) = db.get_app() {
             for info in app.windows.iter() {
                 let window = LapceWindowData::new(
                     keypress.clone(),

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -865,6 +865,9 @@ struct WslRemote {
 impl Remote for WslRemote {
     fn upload_file(&self, local: impl AsRef<Path>, remote: &str) -> Result<()> {
         let mut wsl_path = Path::new(r"\\wsl.localhost\").join(&self.distro);
+        if !wsl_path.exists() {
+            wsl_path = Path::new(r#"\\wsl$"#).join(&self.distro);
+        }
         wsl_path = if remote.starts_with('~') {
             let home_dir = self.home_dir()?;
             wsl_path.join(remote.replacen('~', &home_dir, 1))


### PR DESCRIPTION
fixes #734 
fixes #157 

I decided to not add any arg handling library as we are already
heavy on deps and I don't expect much cli options for now

TODO:
- [ ] support for single files as cli arg
- [x] turns out it wasn't working because `\\wsl.localhost` doesn't exist
  - [x] terminal workdir should be same as path from args
  - [x] indicate that it's opened in WSL