### PR TITLE
Add setting for hover font family/size

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -33,6 +33,8 @@ tab-min-width = 100
 scroll-width = 10
 drop-shadow-width = 0
 custom-titlebar = false
+hover-font-family = ""
+hover-font-size = 0
 
 [theme]
 name = ""

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -230,6 +230,13 @@ pub struct UIConfig {
         desc = "Enable customised titlebar and disable OS native one (Windows only)"
     )]
     custom_titlebar: bool,
+
+    #[field_names(
+        desc = "Set the hover font family. If empty, it uses the UI font family"
+    )]
+    hover_font_family: String,
+    #[field_names(desc = "Set the hover font size. If 0, uses the UI font size")]
+    hover_font_size: usize,
 }
 
 impl UIConfig {
@@ -269,6 +276,22 @@ impl UIConfig {
 
     pub fn custom_titlebar(&self) -> bool {
         self.custom_titlebar
+    }
+
+    pub fn hover_font_family(&self) -> FontFamily {
+        if self.hover_font_family.is_empty() {
+            self.font_family()
+        } else {
+            FontFamily::new_unchecked(self.hover_font_family.clone())
+        }
+    }
+
+    pub fn hover_font_size(&self) -> usize {
+        if self.hover_font_size == 0 {
+            self.font_size()
+        } else {
+            self.hover_font_size
+        }
     }
 }
 

--- a/lapce-ui/src/hover.rs
+++ b/lapce-ui/src/hover.rs
@@ -268,8 +268,8 @@ impl Widget<LapceTabData> for Hover {
                     .set_text(RichText::new(ArcStr::from("")));
             }
 
-            let font = FontDescriptor::new(data.config.ui.font_family())
-                .with_size(data.config.ui.font_size() as f64);
+            let font = FontDescriptor::new(data.config.ui.hover_font_family())
+                .with_size(data.config.ui.hover_font_size() as f64);
             let text_color = data
                 .config
                 .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)


### PR DESCRIPTION
This adds a setting to change the hover's font family and/or font size.  
This still uses the editor font inside the code blocks.