### PR TITLE
feat: add terminal as a build-time feature

### DIFF
--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { version = "0.11", features = ["blocking", "json", "socks"] }
 hashbrown = "0.11.2"
 sled = "0.34.7"
 base64 = "0.13.0"
-alacritty_terminal = "0.16"
+alacritty_terminal = { version = "0.16", optional = true }
 config = "0.11"
 indexmap = "1.7.0"
 directories = "4.0.1"
@@ -58,3 +58,7 @@ bytemuck = "1.8.0"
 # For parsing markdown data, such as in hovers
 pulldown-cmark = "0.9.1"
 smallvec = "1.8.0"
+
+[features]
+default = ["terminal"]
+terminal = ["dep:alacritty_terminal"]

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -8,9 +8,11 @@ use lapce_core::command::{
     EditCommand, FocusCommand, MotionModeCommand, MoveCommand, MultiSelectionCommand,
 };
 use lapce_core::syntax::Syntax;
+#[cfg(feature = "terminal")]
+use lapce_rpc::terminal::TermId;
 use lapce_rpc::{
     buffer::BufferId, file::FileNodeItem, plugin::PluginDescription,
-    source_control::DiffInfo, style::Style, terminal::TermId,
+    source_control::DiffInfo, style::Style,
 };
 use lsp_types::{
     CodeActionOrCommand, CodeActionResponse, CompletionItem, CompletionResponse,
@@ -314,6 +316,7 @@ pub enum LapceWorkbenchCommand {
     TogglePanelBottomVisual,
 
     // Focus toggle commands
+    #[cfg(feature = "terminal")]
     #[strum(message = "Toggle Terminal Focus")]
     #[strum(serialize = "toggle_terminal_focus")]
     ToggleTerminalFocus,
@@ -338,6 +341,7 @@ pub enum LapceWorkbenchCommand {
     ToggleSearchFocus,
 
     // Visual toggle commands
+    #[cfg(feature = "terminal")]
     #[strum(serialize = "toggle_terminal_visual")]
     ToggleTerminalVisual,
 
@@ -359,6 +363,7 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "focus_editor")]
     FocusEditor,
 
+    #[cfg(feature = "terminal")]
     #[strum(serialize = "focus_terminal")]
     FocusTerminal,
 
@@ -504,6 +509,7 @@ pub enum LapceUICommand {
     DocumentSave(PathBuf, Option<WidgetId>),
     BufferSave(PathBuf, u64, Option<WidgetId>),
     UpdateSemanticStyles(BufferId, PathBuf, u64, Arc<Spans<Style>>),
+    #[cfg(feature = "terminal")]
     UpdateTerminalTitle(TermId, String),
     UpdateHistoryStyle {
         id: BufferId,
@@ -541,8 +547,11 @@ pub enum LapceUICommand {
     HomeDir(PathBuf),
     FileChange(notify::Event),
     ProxyUpdateStatus(ProxyStatus),
+    #[cfg(feature = "terminal")]
     CloseTerminal(TermId),
+    #[cfg(feature = "terminal")]
     SplitTerminal(bool, WidgetId),
+    #[cfg(feature = "terminal")]
     SplitTerminalClose(TermId, WidgetId),
     SplitEditor(bool, WidgetId),
     SplitEditorMove(SplitMoveDirection, WidgetId),

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "terminal")]
 use alacritty_terminal::{grid::Dimensions, term::cell::Flags};
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver, Sender, TryRecvError};
@@ -22,8 +23,11 @@ use crate::command::CommandKind;
 use crate::data::{LapceWorkspace, LapceWorkspaceType};
 use crate::document::BufferContent;
 use crate::editor::EditorLocation;
+#[cfg(feature = "terminal")]
 use crate::panel::PanelKind;
 use crate::proxy::path_from_url;
+#[cfg(feature = "terminal")]
+use crate::terminal::TerminalSplitData;
 use crate::{
     command::LAPCE_UI_COMMAND,
     command::{CommandExecuted, LAPCE_COMMAND},
@@ -33,7 +37,6 @@ use crate::{
     find::Find,
     keypress::{KeyPressData, KeyPressFocus},
     proxy::LapceProxy,
-    terminal::TerminalSplitData,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -295,6 +298,7 @@ pub struct PaletteViewData {
     pub keypress: Arc<KeyPressData>,
     pub config: Arc<Config>,
     pub focus_area: FocusArea,
+    #[cfg(feature = "terminal")]
     pub terminal: Arc<TerminalSplitData>,
 }
 
@@ -915,6 +919,7 @@ impl PaletteViewData {
     }
 
     fn get_lines(&mut self, _ctx: &mut EventCtx) {
+        #[cfg(feature = "terminal")]
         if self.focus_area == FocusArea::Panel(PanelKind::Terminal) {
             if let Some(terminal) =
                 self.terminal.terminals.get(&self.terminal.active_term_id)

--- a/lapce-data/src/panel.rs
+++ b/lapce-data/src/panel.rs
@@ -8,6 +8,7 @@ pub enum PanelKind {
     FileExplorer,
     SourceControl,
     Plugin,
+    #[cfg(feature = "terminal")]
     Terminal,
     Search,
     Problem,
@@ -29,6 +30,7 @@ impl PanelKind {
             PanelKind::FileExplorer => "file-explorer.svg",
             PanelKind::SourceControl => "git-icon.svg",
             PanelKind::Plugin => "plugin-icon.svg",
+            #[cfg(feature = "terminal")]
             PanelKind::Terminal => "terminal.svg",
             PanelKind::Search => "search.svg",
             PanelKind::Problem => "error.svg",

--- a/lapce-data/src/terminal.rs
+++ b/lapce-data/src/terminal.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "terminal")]
 use std::sync::Arc;
 
 use alacritty_terminal::{

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -18,7 +18,7 @@ wasmer-wasi = "2.1.1"
 directories = "4.0.1"
 locale_config = "0.3.0"
 base64 = "0.13.0"
-alacritty_terminal = "0.16"
+alacritty_terminal = { version = "0.16", optional = true }
 mio = "0.6.20"
 hotwatch = "0.4.6"
 notify = "5.0.0-pre.13"
@@ -36,3 +36,7 @@ git2 = { version = "0.14.4", features = ["vendored-openssl"] }
 lapce-rpc = { path = "../lapce-rpc" }
 trash = "2.1"
 log = "0.4.17"
+
+[features]
+default = ["terminal"]
+terminal = ["dep:alacritty_terminal"]

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "terminal")]
+
 use std::{
     borrow::Cow,
     collections::VecDeque,

--- a/lapce-rpc/Cargo.toml
+++ b/lapce-rpc/Cargo.toml
@@ -14,3 +14,7 @@ jsonrpc-lite = "0.5.0"
 crossbeam-channel = "0.5.0"
 lsp-types = { version = "0.93", features = ["proposed"] }
 xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
+
+[features]
+default = ["terminal"]
+terminal = []

--- a/lapce-rpc/src/core.rs
+++ b/lapce-rpc/src/core.rs
@@ -2,9 +2,10 @@ use lsp_types::{ProgressParams, PublishDiagnosticsParams};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 
+#[cfg(feature = "terminal")]
+use crate::terminal::TermId;
 use crate::{
     file::FileNodeItem, plugin::PluginDescription, source_control::DiffInfo,
-    terminal::TermId,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,10 +46,12 @@ pub enum CoreNotification {
     DiffInfo {
         diff: DiffInfo,
     },
+    #[cfg(feature = "terminal")]
     UpdateTerminal {
         term_id: TermId,
         content: String,
     },
+    #[cfg(feature = "terminal")]
     CloseTerminal {
         term_id: TermId,
     },

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -6,8 +6,11 @@ use xi_rope::RopeDelta;
 
 use crate::{
     buffer::BufferId, file::FileNodeItem, plugin::PluginDescription,
-    source_control::FileDiff, terminal::TermId,
+    source_control::FileDiff,
 };
+
+#[cfg(feature = "terminal")]
+use crate::terminal::TermId;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -21,11 +24,6 @@ pub enum ProxyNotification {
         buffer_id: BufferId,
         delta: RopeDelta,
         rev: u64,
-    },
-    NewTerminal {
-        term_id: TermId,
-        cwd: Option<PathBuf>,
-        shell: String,
     },
     InstallPlugin {
         plugin: PluginDescription,
@@ -45,15 +43,24 @@ pub enum ProxyNotification {
     },
     GitDiscardWorkspaceChanges {},
     GitInit {},
+    #[cfg(feature = "terminal")]
+    NewTerminal {
+        term_id: TermId,
+        cwd: Option<PathBuf>,
+        shell: String,
+    },
+    #[cfg(feature = "terminal")]
     TerminalWrite {
         term_id: TermId,
         content: String,
     },
+    #[cfg(feature = "terminal")]
     TerminalResize {
         term_id: TermId,
         width: usize,
         height: usize,
     },
+    #[cfg(feature = "terminal")]
     TerminalClose {
         term_id: TermId,
     },

--- a/lapce-rpc/src/terminal.rs
+++ b/lapce-rpc/src/terminal.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "terminal")]
 use serde::{Deserialize, Serialize};
 
 use crate::counter::Counter;

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -17,7 +17,7 @@ flate2 = "1.0.22"
 hashbrown = "0.11.2"
 sled = "0.34.7"
 base64 = "0.13.0"
-alacritty_terminal = "0.16"
+alacritty_terminal = { version = "0.16", optional = true }
 config = "0.11"
 indexmap = "1.7.0"
 directories = "4.0.1"
@@ -55,7 +55,11 @@ lapce-rpc = { path = "../lapce-rpc" }
 winres = "0.1.12"
 
 [features]
-default = ["all-languages"]
+default = [
+    "all-languages",
+    "terminal"
+]
+terminal = ["dep:alacritty_terminal"]
 # To build lapce with only some of the supported languages, for example:
 #
 #   cargo build --no-default-features -p lapce-ui \

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -917,6 +917,7 @@ impl PanelSwitcher {
                 LapceWorkbenchCommand::ToggleSourceControlVisual
             }
             PanelKind::Plugin => LapceWorkbenchCommand::TogglePluginVisual,
+            #[cfg(feature = "terminal")]
             PanelKind::Terminal => LapceWorkbenchCommand::ToggleTerminalVisual,
             PanelKind::Search => LapceWorkbenchCommand::ToggleSearchVisual,
             PanelKind::Problem => LapceWorkbenchCommand::ToggleProblemVisual,

--- a/lapce-ui/src/split.rs
+++ b/lapce-ui/src/split.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "terminal")]
+use crate::terminal::LapceTerminalView;
 use crate::{
     editor::{tab::LapceEditorTab, view::LapceEditorView},
     settings::LapceSettingsPanel,
-    terminal::LapceTerminalView,
 };
 use std::sync::Arc;
 
@@ -15,6 +16,8 @@ use druid::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
     PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget, WidgetExt, WidgetPod,
 };
+#[cfg(feature = "terminal")]
+use lapce_data::terminal::LapceTerminalData;
 use lapce_data::{
     command::{
         CommandKind, LapceCommand, LapceUICommand, LapceWorkbenchCommand,
@@ -28,8 +31,8 @@ use lapce_data::{
     keypress::{Alignment, DefaultKeyPressHandler, KeyMap},
     panel::PanelKind,
     split::{SplitDirection, SplitMoveDirection},
-    terminal::LapceTerminalData,
 };
+#[cfg(feature = "terminal")]
 use lapce_rpc::terminal::TermId;
 
 struct LapceDynamicSplit {
@@ -486,6 +489,7 @@ impl LapceSplit {
         }
     }
 
+    #[cfg(feature = "terminal")]
     pub fn split_terminal(
         &mut self,
         ctx: &mut EventCtx,
@@ -523,6 +527,7 @@ impl LapceSplit {
         ctx.children_changed();
     }
 
+    #[cfg(feature = "terminal")]
     pub fn split_terminal_close(
         &mut self,
         ctx: &mut EventCtx,
@@ -899,12 +904,15 @@ impl Widget<LapceTabData> for LapceSplit {
                     LapceUICommand::SplitEditorClose(widget_id) => {
                         self.split_editor_close(ctx, data, *widget_id);
                     }
+                    #[cfg(feature = "terminal")]
                     LapceUICommand::SplitTerminal(vertical, widget_id) => {
                         self.split_terminal(ctx, data, *vertical, *widget_id);
                     }
+                    #[cfg(feature = "terminal")]
                     LapceUICommand::SplitTerminalClose(term_id, widget_id) => {
                         self.split_terminal_close(ctx, data, *term_id, *widget_id);
                     }
+                    #[cfg(feature = "terminal")]
                     LapceUICommand::InitTerminalPanel(focus) => {
                         if data.terminal.terminals.is_empty() {
                             let terminal_data = Arc::new(LapceTerminalData::new(

--- a/lapce-ui/src/status.rs
+++ b/lapce-ui/src/status.rs
@@ -8,9 +8,11 @@ use lapce_core::mode::Mode;
 use lapce_data::{
     command::{CommandKind, LapceCommand, LapceWorkbenchCommand, LAPCE_COMMAND},
     config::{Config, LapceTheme},
-    data::{FocusArea, LapceTabData},
-    panel::{PanelContainerPosition, PanelKind},
+    data::LapceTabData,
+    panel::PanelContainerPosition,
 };
+#[cfg(feature = "terminal")]
+use lapce_data::{data::FocusArea, panel::PanelKind};
 
 use crate::{svg::get_svg, tab::LapceIcon};
 
@@ -323,6 +325,7 @@ impl Widget<LapceTabData> for LapceStatus {
         let mut _right = 0.0;
 
         if data.config.lapce.modal {
+            #[cfg(feature = "terminal")]
             let mode = if data.focus_area == FocusArea::Panel(PanelKind::Terminal) {
                 data.terminal
                     .terminals
@@ -331,6 +334,9 @@ impl Widget<LapceTabData> for LapceStatus {
             } else {
                 data.main_split.active_editor().map(|e| e.cursor.get_mode())
             };
+
+            #[cfg(not(feature = "terminal"))]
+            let mode = data.main_split.active_editor().map(|e| e.cursor.get_mode());
 
             let (mode, color) = match mode.unwrap_or(Mode::Normal) {
                 Mode::Normal => ("Normal", LapceTheme::STATUS_MODAL_NORMAL),

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -42,13 +42,15 @@ use lsp_types::DiagnosticSeverity;
 use serde::Deserialize;
 use xi_rope::Rope;
 
+#[cfg(feature = "terminal")]
+use crate::terminal::TerminalPanel;
 use crate::{
     alert::AlertBox, completion::CompletionContainer, explorer::FileExplorer,
     hover::HoverContainer, palette::Palette, panel::PanelContainer,
     picker::FilePicker, plugin::Plugin, problem::new_problem_panel,
     search::new_search_panel, settings::LapceSettingsPanel,
     source_control::new_source_control_panel, split::split_data_widget,
-    status::LapceStatus, svg::get_svg, terminal::TerminalPanel,
+    status::LapceStatus, svg::get_svg,
 };
 
 pub struct LapceIcon {
@@ -139,6 +141,7 @@ impl LapceTab {
                             WidgetPod::new(Plugin::new_panel(data).boxed()),
                         );
                     }
+                    #[cfg(feature = "terminal")]
                     PanelKind::Terminal => {
                         panel.insert_panel(
                             *kind,
@@ -854,6 +857,7 @@ impl LapceTab {
                         doc.load_history(version, content.clone());
                         ctx.set_handled();
                     }
+                    #[cfg(feature = "terminal")]
                     LapceUICommand::UpdateTerminalTitle(term_id, title) => {
                         let terminal_panel = Arc::make_mut(&mut data.terminal);
                         if let Some(terminal) =
@@ -879,6 +883,7 @@ impl LapceTab {
                         data.handle_file_change(ctx, event);
                         ctx.set_handled();
                     }
+                    #[cfg(feature = "terminal")]
                     LapceUICommand::CloseTerminal(id) => {
                         let terminal_panel = Arc::make_mut(&mut data.terminal);
                         if let Some(terminal) = terminal_panel.terminals.get_mut(id)
@@ -1179,6 +1184,7 @@ impl LapceTab {
                         );
                         ctx.set_handled();
                     }
+                    #[cfg(feature = "terminal")]
                     LapceUICommand::TerminalJumpToLine(line) => {
                         if let Some(terminal) = data
                             .terminal

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "terminal")]
 use std::sync::Arc;
 
 use alacritty_terminal::{


### PR DESCRIPTION
sprinkled `#[cfg(feature...)]` across whole repo so lapce can be used on Windows versions that don't have pseudo console API (but the change is universal, so terminal can be removed on linux/macos as well)