### PR TITLE
fix: set window minimal size

### DIFF
--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -113,6 +113,7 @@ where
 {
     let mut desc = WindowDesc::new_with_id(window_id, root)
         .title(LocalizedString::new("Lapce").with_placeholder("Lapce"))
+        .with_min_size(Size::new(384.0, 384.0))
         .window_size(size)
         .set_position(pos);
 


### PR DESCRIPTION
Window should define minimal size to prevent situation where user
resizes it to the point where it cannot be fixed