### PR TITLE
Implement Error Lens

### DIFF
--- a/defaults/dark-theme.toml
+++ b/defaults/dark-theme.toml
@@ -74,6 +74,13 @@ magenta = "#C678DD"
 "inlay_hint.foreground" = "#FFFFFF"
 "inlay_hint.background" = "#528bFF88"
 
+"error_lens.error.foreground" = "$red"
+"error_lens.error.background" = "#E06C7520"
+"error_lens.warning.foreground" = "$yellow"
+"error_lens.warning.background" = "#E5C07B20"
+"error_lens.other.foreground" = "#5C6370"
+"error_lens.other.background" = "#5C637020"
+
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"
 "source_control.modified" = "#0184BC32"

--- a/defaults/light-theme.toml
+++ b/defaults/light-theme.toml
@@ -99,6 +99,13 @@ magenta = "#A626A4"
 "inlay_hint.foreground" = "#000000"
 "inlay_hint.background" = "#528bFF55"
 
+"error_lens.error.foreground" = "$red"
+"error_lens.error.background" = "#E4564920"
+"error_lens.warning.foreground" = "$yellow"
+"error_lens.warning.background" = "#C1840120"
+"error_lens.other.foreground" = "#A0A1A7"
+"error_lens.other.background" = "#A0A1A720"
+
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"
 "source_control.modified" = "#0184BC32"

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -17,6 +17,10 @@ format-on-save = true
 enable-inlay-hints = true
 inlay-hint-font-family = ""
 inlay-hint-font-size = 0
+enable-error-lens = true
+error-lens-end-of-line = true
+error-lens-font-family = ""
+error-lens-font-size = 0
 
 [terminal]
 font-family = ""
@@ -111,6 +115,13 @@ magenta = "#C678DD"
 
 "inlay_hint.foreground" = "#FFFFFF"
 "inlay_hint.background" = "#528bFF88"
+
+"error_lens.error.foreground" = "$red"
+"error_lens.error.background" = "#E06C7520"
+"error_lens.warning.foreground" = "$yellow"
+"error_lens.warning.background" = "#E5C07B20"
+"error_lens.other.foreground" = "#5C6370"
+"error_lens.other.background" = "#5C637020"
 
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -51,6 +51,19 @@ impl LapceTheme {
     pub const INLAY_HINT_FOREGROUND: &'static str = "inlay_hint.foreground";
     pub const INLAY_HINT_BACKGROUND: &'static str = "inlay_hint.background";
 
+    pub const ERROR_LENS_ERROR_FOREGROUND: &'static str =
+        "error_lens.error.foreground";
+    pub const ERROR_LENS_ERROR_BACKGROUND: &'static str =
+        "error_lens.error.background";
+    pub const ERROR_LENS_WARNING_FOREGROUND: &'static str =
+        "error_lens.warning.foreground";
+    pub const ERROR_LENS_WARNING_BACKGROUND: &'static str =
+        "error_lens.warning.background";
+    pub const ERROR_LENS_OTHER_FOREGROUND: &'static str =
+        "error_lens.other.foreground";
+    pub const ERROR_LENS_OTHER_BACKGROUND: &'static str =
+        "error_lens.other.background";
+
     pub const SOURCE_CONTROL_ADDED: &'static str = "source_control.added";
     pub const SOURCE_CONTROL_REMOVED: &'static str = "source_control.removed";
     pub const SOURCE_CONTROL_MODIFIED: &'static str = "source_control.modified";
@@ -172,6 +185,20 @@ pub struct EditorConfig {
         desc = "Set the inlay hint font size. If less than 5 or greater than editor font size, it uses the editor font size."
     )]
     pub inlay_hint_font_size: usize,
+    #[field_names(desc = "If diagnostics should be displayed inline")]
+    pub enable_error_lens: bool,
+    #[field_names(
+        desc = "Whether error lens should go to the end of view line, or only to the end of the diagnostic"
+    )]
+    pub error_lens_end_of_line: bool,
+    #[field_names(
+        desc = "Set error lens font family. If empty, it uses the inlay hint font family."
+    )]
+    pub error_lens_font_family: String,
+    #[field_names(
+        desc = "Set the error lens font size. If 0 it uses the inlay hint font size."
+    )]
+    pub error_lens_font_size: usize,
 }
 
 impl EditorConfig {
@@ -187,13 +214,29 @@ impl EditorConfig {
         }
     }
 
-    pub fn inlay_hint_font_size(&self) -> f64 {
+    pub fn inlay_hint_font_size(&self) -> usize {
         if self.inlay_hint_font_size < 5
             || self.inlay_hint_font_size > self.font_size
         {
-            self.font_size as f64
+            self.font_size
         } else {
-            self.inlay_hint_font_size as f64
+            self.inlay_hint_font_size
+        }
+    }
+
+    pub fn error_lens_font_family(&self) -> FontFamily {
+        if self.error_lens_font_family.is_empty() {
+            self.inlay_hint_font_family()
+        } else {
+            FontFamily::new_unchecked(self.error_lens_font_family.clone())
+        }
+    }
+
+    pub fn error_lens_font_size(&self) -> usize {
+        if self.error_lens_font_size == 0 {
+            self.inlay_hint_font_size()
+        } else {
+            self.error_lens_font_size
         }
     }
 }

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -437,13 +437,7 @@ impl LapceEditorView {
     fn cursor_region(data: &LapceEditorBufferData, text: &mut PietText) -> Rect {
         let offset = data.editor.cursor.offset();
         let (line, col) = data.doc.buffer().offset_to_line_col(offset);
-        let inlay_hints = data
-            .config
-            .editor
-            .enable_inlay_hints
-            .then_some(())
-            .and_then(|_| data.doc.line_inlay_hints(line))
-            .unwrap_or_default();
+        let inlay_hints = data.doc.line_phantom_text(&data.config, line);
         let col = inlay_hints.col_at(col);
 
         let width = data.config.editor_char_width(text);

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -988,9 +988,18 @@ impl LapceTab {
                                     + 1,
                             })
                             .collect();
-                        data.main_split
-                            .diagnostics
-                            .insert(path, Arc::new(diagnostics));
+                        let diagnostics: Arc<Vec<EditorDiagnostic>> =
+                            Arc::new(diagnostics);
+
+                        // inform the document about the diagnostics
+                        if let Some(document) =
+                            data.main_split.open_docs.get_mut(&path)
+                        {
+                            let document = Arc::make_mut(document);
+                            document.diagnostics = Some(diagnostics.clone());
+                        }
+
+                        data.main_split.diagnostics.insert(path, diagnostics);
 
                         let mut errors = 0;
                         let mut warnings = 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13157904/179153328-bf4e7589-d056-479d-bea1-34c50cd6ece9.png)
![image](https://user-images.githubusercontent.com/13157904/179146755-7f28eeb9-43aa-4807-9a1d-9123c8d80547.png)
Closes #747. Partially improves the state of #721, making it easier for a more general phantom text to be created (such as for plugins); primarily it would just be a case of making it have an enum rather than a single type.
It has a setting for whether the error lens background should go to the end of the view's line or to the end of the diagnostic, since I prefer the latter. End of the view's line is the default, since it is the default in VSCode (unsure about other editors).