### PR TITLE
Add fedora spec for packaging

### DIFF
--- a/lapce.spec
+++ b/lapce.spec
@@ -21,8 +21,8 @@ It is designed with Rope Science from the Xi-Editor which makes for lightning-fa
 cargo build --profile release-lto
 
 %install
-install -Dm755 target/release-lto/%{name} %{buildroot}%{_bindir}/lapce
-install -Dm755 target/release-lto/%{name}-proxy %{buildroot}%{_bindir}/lapce-proxy
+install -Dm755 target/release-lto/lapce %{buildroot}%{_bindir}/lapce
+install -Dm755 target/release-lto/lapce-proxy %{buildroot}%{_bindir}/lapce-proxy
 install -Dm755 extra/linux/dev.lapce.lapce.desktop %{buildroot}/usr/share/applications/dev.lapce.lapce.desktop
 install -Dm766 extra/linux/dev.lapce.lapce.metainfo.xml %{buildroot}/usr/share/metainfo/dev.lapce.lapce.metainfo.xml
 install -Dm766 extra/images/logo.png %{buildroot}/usr/share/pixmaps/dev.lapce.lapce.png

--- a/lapce.spec
+++ b/lapce.spec
@@ -15,7 +15,7 @@ Lapce is written in pure Rust with a UI in Druid (which is also written in Rust)
 It is designed with Rope Science from the Xi-Editor which makes for lightning-fast computation, and leverages OpenGL for rendering.
 
 %prep
-%autosetup
+{{{ git_dir_setup_macro }}}
 
 %build
 cargo build --profile release-lto

--- a/lapce.spec
+++ b/lapce.spec
@@ -1,0 +1,38 @@
+Name:           lapce
+Version:        0.1.3.{{{ git_dir_version }}}
+Release:        1
+Summary:        Lightning-fast and Powerful Code Editor written in Rust
+License:        Apache-2.0
+URL:            https://github.com/lapce/lapce
+VCS:            {{{ git_dir_vcs }}}
+Source:        	{{{ git_dir_pack }}}
+BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel gcc g++ perl-lib perl-File-Compare
+
+%description
+Lapce is written in pure Rust with a UI in Druid (which is also written in Rust).
+It is designed with Rope Science from the Xi-Editor which makes for lightning-fast computation, and leverages OpenGL for rendering.
+
+%prep
+%autosetup
+
+%build
+cargo build --profile release-lto
+
+%install
+install -Dm755 target/release-lto/%{name} %{buildroot}%{_bindir}/%{name}
+install -Dm755 target/release-lto/%{name}-proxy %{buildroot}%{_bindir}/%{name}-proxy
+install -Dm755 extra/linux/dev.lapce.lapce.desktop %{buildroot}/usr/share/applications/dev.lapce.lapce.desktop
+install -Dm766 extra/linux/dev.lapce.lapce.metainfo.xml %{buildroot}/usr/share/metainfo/dev.lapce.lapce.metainfo.xml
+install -Dm766 extra/images/logo.png %{buildroot}/usr/share/pixmaps/dev.lapce.lapce.png
+
+%files
+%license LICENSE*
+%doc *.md
+%{_bindir}/%{name}
+%{_bindir}/%{name}-proxy
+/usr/share/applications/dev.lapce.lapce.desktop
+/usr/share/metainfo/dev.lapce.lapce.metainfo.xml
+/usr/share/pixmaps/dev.lapce.lapce.png
+
+%changelog
+{{{ git_dir_changelog }}}

--- a/lapce.spec
+++ b/lapce.spec
@@ -4,7 +4,10 @@ Release:        1
 Summary:        Lightning-fast and Powerful Code Editor written in Rust
 License:        Apache-2.0
 URL:            https://github.com/lapce/lapce
-Source:        	https://github.com/lapce/lapce.git
+
+VCS:            {{{ git_dir_vcs }}}
+Source:        	{{{ git_dir_pack }}}
+
 BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel gcc g++ perl-lib perl-File-Compare
 
 %description

--- a/lapce.spec
+++ b/lapce.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/lapce/lapce
 VCS:            {{{ git_dir_vcs }}}
 Source:        	{{{ git_dir_pack }}}
 
-BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel gcc g++ perl-lib perl-File-Compare mold
+BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel perl-lib perl-File-Compare mold clang
 
 %description
 Lapce is written in pure Rust with a UI in Druid (which is also written in Rust).
@@ -18,7 +18,7 @@ It is designed with Rope Science from the Xi-Editor which makes for lightning-fa
 {{{ git_dir_setup_macro }}}
 
 %build
-RUSTFLAGS="-C link-arg=-fuse-ld=/usr/bin/mold" cargo build --profile release-lto
+RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=mold" cargo build --profile release-lto
 
 %install
 install -Dm755 target/release-lto/lapce %{buildroot}%{_bindir}/lapce

--- a/lapce.spec
+++ b/lapce.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/lapce/lapce
 VCS:            {{{ git_dir_vcs }}}
 Source:        	{{{ git_dir_pack }}}
 
-BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel gcc g++ perl-lib perl-File-Compare
+BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel gcc g++ perl-lib perl-File-Compare mold
 
 %description
 Lapce is written in pure Rust with a UI in Druid (which is also written in Rust).
@@ -18,7 +18,7 @@ It is designed with Rope Science from the Xi-Editor which makes for lightning-fa
 {{{ git_dir_setup_macro }}}
 
 %build
-cargo build --profile release-lto
+RUSTFLAGS="-C link-arg=-fuse-ld=/usr/bin/mold" cargo build --profile release-lto
 
 %install
 install -Dm755 target/release-lto/lapce %{buildroot}%{_bindir}/lapce

--- a/lapce.spec
+++ b/lapce.spec
@@ -21,8 +21,8 @@ It is designed with Rope Science from the Xi-Editor which makes for lightning-fa
 cargo build --profile release-lto
 
 %install
-install -Dm755 target/release-lto/%{name} %{buildroot}%{_bindir}/%{name}
-install -Dm755 target/release-lto/%{name}-proxy %{buildroot}%{_bindir}/%{name}-proxy
+install -Dm755 target/release-lto/%{name} %{buildroot}%{_bindir}/lapce
+install -Dm755 target/release-lto/%{name}-proxy %{buildroot}%{_bindir}/lapce-proxy
 install -Dm755 extra/linux/dev.lapce.lapce.desktop %{buildroot}/usr/share/applications/dev.lapce.lapce.desktop
 install -Dm766 extra/linux/dev.lapce.lapce.metainfo.xml %{buildroot}/usr/share/metainfo/dev.lapce.lapce.metainfo.xml
 install -Dm766 extra/images/logo.png %{buildroot}/usr/share/pixmaps/dev.lapce.lapce.png
@@ -30,8 +30,8 @@ install -Dm766 extra/images/logo.png %{buildroot}/usr/share/pixmaps/dev.lapce.la
 %files
 %license LICENSE*
 %doc *.md
-%{_bindir}/%{name}
-%{_bindir}/%{name}-proxy
+%{_bindir}/lapce
+%{_bindir}/lapce-proxy
 /usr/share/applications/dev.lapce.lapce.desktop
 /usr/share/metainfo/dev.lapce.lapce.metainfo.xml
 /usr/share/pixmaps/dev.lapce.lapce.png

--- a/lapce.spec
+++ b/lapce.spec
@@ -1,4 +1,4 @@
-Name:           lapce
+Name:           lapce-git
 Version:        0.1.3.{{{ git_dir_version }}}
 Release:        1
 Summary:        Lightning-fast and Powerful Code Editor written in Rust

--- a/lapce.spec
+++ b/lapce.spec
@@ -4,8 +4,7 @@ Release:        1
 Summary:        Lightning-fast and Powerful Code Editor written in Rust
 License:        Apache-2.0
 URL:            https://github.com/lapce/lapce
-VCS:            {{{ git_dir_vcs }}}
-Source:        	{{{ git_dir_pack }}}
+Source:        	https://github.com/lapce/lapce.git
 BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel gcc g++ perl-lib perl-File-Compare
 
 %description

--- a/lapce.spec
+++ b/lapce.spec
@@ -37,4 +37,5 @@ install -Dm766 extra/images/logo.png %{buildroot}/usr/share/pixmaps/dev.lapce.la
 /usr/share/pixmaps/dev.lapce.lapce.png
 
 %changelog
-{{{ git_dir_changelog }}}
+* Sat Jul 16 2022 Simon Garding <titaniumtown@gmail.com> - test
+- test


### PR DESCRIPTION
Addresses #121 (in relation to Fedora)

Adds a `.spec` file that can be used to compile the latest git version of Lapce for Fedora in copr. 

I need to do some testing and add possibly it to my [copr repository](https://copr.fedorainfracloud.org/coprs/titaniumtown/lapce) which I mentioned in #121

Corresponding package for master builds can be found here: <https://copr.fedorainfracloud.org/coprs/titaniumtown/lapce/package/lapce-git/>