### PR TITLE
Check lsp capabilities before sending commands

### DIFF
--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -151,6 +151,7 @@ fn language_id_from_path(path: &Path) -> Option<&str> {
         "rs" => "rust",
         "go" => "go",
         "py" => "python",
+        "jl" => "julia",
         "cpp" | "hpp" | "cxx" | "hxx" | "c++" | "h++" | "cc" | "hh" | "C" | "H" => {
             "cpp"
         }


### PR DESCRIPTION
This makes  so we check the `server_capabilities` fields before actually sending anything. RA supports all of the requests we have implemented right now, but not all LSPs do, and some don't handle unknown requests gracefully (such as crashing). This also makes so they aren't sent until the LSP has told us it has initialized, which is what the LSP docs say we are supposed to do.  
Includes a fix for `window/workDoneProgress/create` which is supposed to send back nothing, not an empty object. (or at least the Julia LSP seems to want it to be empty?)  
Also adds Julia language id.