### PR TITLE
Check if line is at the max in line styles

### DIFF
--- a/lapce-core/src/style.rs
+++ b/lapce-core/src/style.rs
@@ -9,7 +9,7 @@ use tree_sitter::{
     Language, LossyUtf8, Node, Point, Query, QueryCaptures, QueryCursor, QueryError,
     QueryMatch, Range, Tree,
 };
-use xi_rope::{spans::Spans, Rope};
+use xi_rope::{spans::Spans, LinesMetric, Rope};
 
 const CANCELLATION_CHECK_INTERVAL: usize = 100;
 const BUFFER_HTML_RESERVE_CAPACITY: usize = 10 * 1024;
@@ -967,6 +967,12 @@ pub fn line_styles(
     line: usize,
     styles: &Spans<Style>,
 ) -> Vec<LineStyle> {
+    let max_line = text.measure::<LinesMetric>() + 1;
+
+    if line >= max_line {
+        return Vec::new();
+    }
+
     let start_offset = text.offset_of_line(line);
     let end_offset = text.offset_of_line(line + 1);
     let line_styles: Vec<LineStyle> = styles


### PR DESCRIPTION
This checks if the line is at the `max_line` (1 past the end of the file) or greater, and if it is then it doesn't return any styles. Previously it would panic if the LSP gave a diagnostic at one past the end of the document (so the `line + 1` would then be 2 lines past the end of the document, which crashes).  
