### PR TITLE
Add LSP Goto Type Definition support

### DIFF
--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -251,6 +251,9 @@ pub enum FocusCommand {
     #[strum(message = "Go to Definition")]
     #[strum(serialize = "goto_definition")]
     GotoDefinition,
+    #[strum(message = "Go to Type Definition")]
+    #[strum(serialize = "goto_type_definition")]
+    GotoTypeDefinition,
     #[strum(serialize = "jump_location_backward")]
     JumpLocationBackward,
     #[strum(serialize = "jump_location_forward")]

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -40,6 +40,7 @@ use lapce_core::command::{
 };
 use lapce_core::mode::{Mode, MotionMode};
 pub use lapce_core::syntax::Syntax;
+use lsp_types::request::GotoTypeDefinitionResponse;
 use lsp_types::CodeActionOrCommand;
 use lsp_types::CompletionTextEdit;
 use lsp_types::DocumentChangeOperation;
@@ -1659,6 +1660,61 @@ impl LapceEditorBufferData {
                                             Target::Auto,
                                         );
                                     }
+                                }
+                            }
+                        }
+                    }),
+                );
+            }
+            GotoTypeDefinition => {
+                let offset = self.editor.cursor.offset();
+                let event_sink = ctx.get_external_handle();
+                let buffer_id = self.doc.id();
+                let position = self.doc.buffer().offset_to_position(offset);
+                let editor_view_id = self.editor.view_id;
+                self.proxy.get_type_definition(
+                    offset,
+                    buffer_id,
+                    position,
+                    Box::new(move |result| {
+                        if let Ok(res) = result {
+                            if let Ok(resp) = serde_json::from_value::<
+                                GotoTypeDefinitionResponse,
+                            >(res)
+                            {
+                                match resp {
+                                    GotoTypeDefinitionResponse::Scalar(location) => {
+                                        let _ = event_sink.submit_command(
+                                            LAPCE_UI_COMMAND,
+                                            LapceUICommand::GotoDefinition(
+                                                editor_view_id,
+                                                offset,
+                                                EditorLocation {
+                                                    path: path_from_url(
+                                                        &location.uri,
+                                                    ),
+                                                    position: Some(
+                                                        location.range.start,
+                                                    ),
+                                                    scroll_offset: None,
+                                                    history: None,
+                                                },
+                                            ),
+                                            Target::Auto,
+                                        );
+                                    }
+                                    GotoTypeDefinitionResponse::Array(locations) => {
+                                        let _ = event_sink.submit_command(
+                                            LAPCE_UI_COMMAND,
+                                            LapceUICommand::PaletteReferences(
+                                                offset, locations,
+                                            ),
+                                            Target::Auto,
+                                        );
+                                    }
+                                    GotoTypeDefinitionResponse::Link(
+                                        _location_links,
+                                    ) => {}
                                 }
                             }
                         }

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -643,6 +643,24 @@ impl LapceProxy {
         );
     }
 
+    pub fn get_type_definition(
+        &self,
+        request_id: usize,
+        buffer_id: BufferId,
+        position: Position,
+        f: Box<dyn Callback>,
+    ) {
+        self.rpc.send_rpc_request_async(
+            "get_type_definition",
+            &json!({
+                "request_id": request_id,
+                "buffer_id": buffer_id,
+                "position": position,
+            }),
+            f,
+        );
+    }
+
     pub fn get_document_symbols(&self, buffer_id: BufferId, f: Box<dyn Callback>) {
         self.rpc.send_rpc_request_async(
             "get_document_symbols",

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -520,6 +520,17 @@ impl Dispatcher {
                     .lock()
                     .get_definition(id, request_id, buffer, position);
             }
+            GetTypeDefinition {
+                request_id,
+                buffer_id,
+                position,
+            } => {
+                let buffers = self.buffers.lock();
+                let buffer = buffers.get(&buffer_id).unwrap();
+                self.lsp
+                    .lock()
+                    .get_type_definition(id, request_id, buffer, position);
+            }
             GetInlayHints { buffer_id } => {
                 let buffers = self.buffers.lock();
                 let buffer = buffers.get(&buffer_id).unwrap();

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -101,6 +101,11 @@ pub enum ProxyRequest {
         buffer_id: BufferId,
         position: Position,
     },
+    GetTypeDefinition {
+        request_id: usize,
+        buffer_id: BufferId,
+        position: Position,
+    },
     GetInlayHints {
         buffer_id: BufferId,
     },


### PR DESCRIPTION
Closes #790   
This adds a command for going to the type definition variable if the LSP supports it.  
Ex:  
```rust
fn thing(text: String) {
    let a = text|.trim();
}
```
where `|` is the cursor
The command will then go to the file where `String` is defined. This is faster, especially in cases where the variable is a field that you'd have to jump to to then jump to the actual type that it is.  
This does not set a keybind for it as VSCode does not set one. (Personally, I think this should have a keybind, but I don't know what would be a good default)