### PR TITLE
Add next/previous tab commands and keybindings

### DIFF
--- a/defaults/keymaps-macos.toml
+++ b/defaults/keymaps-macos.toml
@@ -178,6 +178,10 @@ command = "close_folder"
 key = "meta+\\"
 command = "split_vertical"
 
+[[keymaps]]
+key = "meta+tab"
+command = "next_editor_tab"
+
 # --------------------------------- Rich Language Editing ----------------------------
 
 [[keymaps]]

--- a/defaults/keymaps-nonmacos.toml
+++ b/defaults/keymaps-nonmacos.toml
@@ -173,6 +173,10 @@ command = "split_close"
 key = "ctrl+\\"
 command = "split_vertical"
 
+[[keymaps]]
+key = "ctrl+tab"
+command = "next_editor_tab"
+
 # --------------------------------- Rich Language Editing ----------------------------
 
 [[keymaps]]

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -198,10 +198,6 @@ pub enum FocusCommand {
     SplitUp,
     #[strum(serialize = "split_down")]
     SplitDown,
-    #[strum(serialize = "editor_tab_previous")]
-    EditorTabPrvious,
-    #[strum(serialize = "editor_tab_next")]
-    EditorTabNext,
     #[strum(serialize = "search_whole_word_forward")]
     SearchWholeWordForward,
     #[strum(serialize = "search_forward")]

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -388,6 +388,14 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "change_file_language")]
     #[strum(message = "Change current file language")]
     ChangeFileLanguage,
+
+    #[strum(serialize = "next_editor_tab")]
+    #[strum(message = "Next editor tab")]
+    NextEditorTab,
+
+    #[strum(serialize = "previous_editor_tab")]
+    #[strum(message = "Previous editor tab")]
+    PreviousEditorTab,
 }
 
 #[derive(Debug)]
@@ -492,6 +500,8 @@ pub enum LapceUICommand {
     NewTab,
     NextTab,
     PreviousTab,
+    NextEditorTab,
+    PreviousEditorTab,
     FilterItems,
     NewWindow(WindowId),
     ReloadWindow,

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1355,6 +1355,24 @@ impl LapceTabData {
                     Target::Auto,
                 ))
             }
+            LapceWorkbenchCommand::NextEditorTab => {
+                if let Some(active) = *self.main_split.active_tab {
+                    ctx.submit_command(Command::new(
+                        LAPCE_UI_COMMAND,
+                        LapceUICommand::NextEditorTab,
+                        Target::Widget(active),
+                    ));
+                }
+            }
+            LapceWorkbenchCommand::PreviousEditorTab => {
+                if let Some(active) = *self.main_split.active_tab {
+                    ctx.submit_command(Command::new(
+                        LAPCE_UI_COMMAND,
+                        LapceUICommand::NextEditorTab,
+                        Target::Widget(active),
+                    ));
+                }
+            }
         }
     }
 

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -314,69 +314,20 @@ impl Widget<LapceTabData> for LapceEditorTab {
             Event::Command(cmd) if cmd.is(LAPCE_COMMAND) => {
                 ctx.set_handled();
                 let cmd = cmd.get_unchecked(LAPCE_COMMAND);
-                match cmd.kind {
-                    CommandKind::Focus(FocusCommand::SplitVertical) => {
-                        let editor_tab = data
-                            .main_split
-                            .editor_tabs
-                            .get_mut(&self.widget_id)
-                            .unwrap();
-                        ctx.submit_command(Command::new(
-                            LAPCE_COMMAND,
-                            LapceCommand {
-                                kind: CommandKind::Focus(
-                                    FocusCommand::SplitVertical,
-                                ),
-                                data: None,
-                            },
-                            Target::Widget(editor_tab.active_child().widget_id()),
-                        ));
-                    }
-                    CommandKind::Focus(FocusCommand::EditorTabNext) => {
-                        let editor_tab = data
-                            .main_split
-                            .editor_tabs
-                            .get(&self.widget_id)
-                            .unwrap();
-                        if !editor_tab.children.is_empty() {
-                            let index = if editor_tab.active
-                                == editor_tab.children.len() - 1
-                            {
-                                0
-                            } else {
-                                editor_tab.active + 1
-                            };
-                            ctx.submit_command(Command::new(
-                                LAPCE_UI_COMMAND,
-                                LapceUICommand::Focus,
-                                Target::Widget(
-                                    editor_tab.children[index].widget_id(),
-                                ),
-                            ));
-                        }
-                    }
-                    CommandKind::Focus(FocusCommand::EditorTabPrvious) => {
-                        let editor_tab = data
-                            .main_split
-                            .editor_tabs
-                            .get(&self.widget_id)
-                            .unwrap();
-                        if !editor_tab.children.is_empty() {
-                            let index = if editor_tab.active == 0 {
-                                editor_tab.children.len() - 1
-                            } else {
-                                editor_tab.active - 1
-                            };
-                            ctx.submit_command(Command::new(
-                                LAPCE_UI_COMMAND,
-                                LapceUICommand::Focus,
-                                Target::Widget(
-                                    editor_tab.children[index].widget_id(),
-                                ),
-                            ));
-                        }
-                    }
-                    _ => (),
+                if let CommandKind::Focus(FocusCommand::SplitVertical) = cmd.kind {
+                    let editor_tab = data
+                        .main_split
+                        .editor_tabs
+                        .get_mut(&self.widget_id)
+                        .unwrap();
+                    ctx.submit_command(Command::new(
+                        LAPCE_COMMAND,
+                        LapceCommand {
+                            kind: CommandKind::Focus(FocusCommand::SplitVertical),
+                            data: None,
+                        },
+                        Target::Widget(editor_tab.active_child().widget_id()),
+                    ));
                 }
             }
             Event::Command(cmd) if cmd.is(LAPCE_UI_COMMAND) => {
@@ -461,6 +412,52 @@ impl Widget<LapceTabData> for LapceEditorTab {
                                 EditorTabChildInfo::Settings => {}
                             }
                             return;
+                        }
+                    }
+                    LapceUICommand::NextEditorTab => {
+                        let editor_tab = data
+                            .main_split
+                            .editor_tabs
+                            .get(&self.widget_id)
+                            .unwrap();
+                        if !editor_tab.children.is_empty() {
+                            let new_index = if editor_tab.active
+                                == editor_tab.children.len() - 1
+                            {
+                                0
+                            } else {
+                                editor_tab.active + 1
+                            };
+
+                            ctx.submit_command(Command::new(
+                                LAPCE_UI_COMMAND,
+                                LapceUICommand::Focus,
+                                Target::Widget(
+                                    editor_tab.children[new_index].widget_id(),
+                                ),
+                            ));
+                        }
+                    }
+                    LapceUICommand::PreviousEditorTab => {
+                        let editor_tab = data
+                            .main_split
+                            .editor_tabs
+                            .get(&self.widget_id)
+                            .unwrap();
+                        if !editor_tab.children.is_empty() {
+                            let new_index = if editor_tab.active == 0 {
+                                editor_tab.children.len() - 1
+                            } else {
+                                editor_tab.active - 1
+                            };
+
+                            ctx.submit_command(Command::new(
+                                LAPCE_UI_COMMAND,
+                                LapceUICommand::Focus,
+                                Target::Widget(
+                                    editor_tab.children[new_index].widget_id(),
+                                ),
+                            ));
                         }
                     }
                     _ => (),

--- a/lapce-ui/src/editor/tab_header.rs
+++ b/lapce-ui/src/editor/tab_header.rs
@@ -300,11 +300,8 @@ impl Widget<LapceTabData> for LapceEditorTabHeader {
                         .to_rect()
                         .with_origin(Point::new(x, gap)),
                     command: Command::new(
-                        LAPCE_COMMAND,
-                        LapceCommand {
-                            kind: CommandKind::Focus(FocusCommand::EditorTabNext),
-                            data: None,
-                        },
+                        LAPCE_UI_COMMAND,
+                        LapceUICommand::NextEditorTab,
                         Target::Widget(self.widget_id),
                     ),
                 };
@@ -318,11 +315,8 @@ impl Widget<LapceTabData> for LapceEditorTabHeader {
                         .to_rect()
                         .with_origin(Point::new(x, gap)),
                     command: Command::new(
-                        LAPCE_COMMAND,
-                        LapceCommand {
-                            kind: CommandKind::Focus(FocusCommand::EditorTabPrvious),
-                            data: None,
-                        },
+                        LAPCE_UI_COMMAND,
+                        LapceUICommand::PreviousEditorTab,
                         Target::Widget(self.widget_id),
                     ),
                 };


### PR DESCRIPTION
This adds commands for going to the next/previous editor tab using ctrl+tab.  
It would be good to have the more typical form of the feature where the editor keeps track of the previously focused tabs (on each split too?), but this is the simple form that is easier to implement.