### PR TITLE
Request utf8 from LSP if possible

### DIFF
--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -1270,6 +1270,17 @@ impl LspClient {
                 configuration: Some(true),
                 ..Default::default()
             }),
+
+            // TODO: GeneralClientCapabilities is getting a position encoding option
+            // as the standardized version of this, but it is not yet in lsp-types
+            // (and probably not as supported due to how new it is?)
+
+            // Inform the LSP that we would prefer utf8 encoding if possible
+            // Though, of course, we have to support utf16
+            // We could also inform that we support utf32 (there's technically some perf on the table there if
+            //   we do utf32 -> utf8 rather than utf32 -> utf16 -> utf8) but that is uncommon and is not even
+            // an option in the upcoming standardized version of this field.
+            offset_encoding: Some(vec!["utf-8".to_string(), "utf-16".to_string()]),
             experimental: Some(json!({
                 "serverStatusNotification": true,
             })),


### PR DESCRIPTION
This is a basic patch which fixed utf16 offsets being wrong when interpreted as utf8, by just requesting utf8 from language servers that support this extension. (Ex: Rust Analyzer and Clangd)  
This of course does not fix the actual underlying issue, but this should serve to at least lessen the amount of problems from that until I implement the full fix.