### PR TITLE
Change color of subtext on plugin menu

### DIFF
--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -224,7 +224,7 @@ impl Widget<LapceTabData> for Plugin {
                     )
                     .text_color(
                         data.config
-                            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+                            .get_color_unchecked(LapceTheme::EDITOR_DIM)
                             .clone(),
                     )
                     .build()
@@ -253,7 +253,7 @@ impl Widget<LapceTabData> for Plugin {
                         )
                         .text_color(
                             data.config
-                                .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+                                .get_color_unchecked(LapceTheme::EDITOR_DIM)
                                 .clone(),
                         )
                         .build()
@@ -288,7 +288,7 @@ impl Widget<LapceTabData> for Plugin {
                     )
                     .text_color(
                         data.config
-                            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+                            .get_color_unchecked(LapceTheme::EDITOR_DIM)
                             .clone(),
                     )
                     .build()


### PR DESCRIPTION
This switches the subtext of the plugin menu to use the `editor.dim` color instead of `editor.foreground`.  It currently is works for the default themes, because the foreground colors aren't very bright, but for themes with brighter foreground colors, it's hard to differentiate between the plugin names, descriptions and authors visually.  