### PR TITLE
Fix goto ref on single references

### DIFF
--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -574,7 +574,6 @@ pub enum LapceUICommand {
     JumpToLocation(Option<WidgetId>, EditorLocation),
     TerminalJumpToLine(i32),
     GoToLocationNew(WidgetId, EditorLocation),
-    GotoReference(WidgetId, usize, EditorLocation),
     GotoDefinition(WidgetId, usize, EditorLocation),
     PaletteReferences(usize, Vec<Location>),
     GotoLocation(Location),

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1633,10 +1633,7 @@ impl LapceEditorBufferData {
                                             position,
                                             Box::new(move |result| {
                                                 let _ = process_get_references(
-                                                    editor_view_id,
-                                                    offset,
-                                                    result,
-                                                    event_sink,
+                                                    offset, result, event_sink,
                                                 );
                                             }),
                                         );
@@ -2075,7 +2072,6 @@ fn next_in_file_errors_offset(
 }
 
 fn process_get_references(
-    editor_view_id: WidgetId,
     offset: usize,
     result: Result<Value, Value>,
     event_sink: ExtEventSink,
@@ -2086,12 +2082,12 @@ fn process_get_references(
         return Ok(());
     }
     if locations.len() == 1 {
+        // If there's only a single location then just jump directly to it
         let location = &locations[0];
         let _ = event_sink.submit_command(
             LAPCE_UI_COMMAND,
-            LapceUICommand::GotoReference(
-                editor_view_id,
-                offset,
+            LapceUICommand::JumpToLocation(
+                None,
                 EditorLocation {
                     path: path_from_url(&location.uri),
                     position: Some(location.range.start),
@@ -2101,12 +2097,13 @@ fn process_get_references(
             ),
             Target::Auto,
         );
+    } else {
+        let _ = event_sink.submit_command(
+            LAPCE_UI_COMMAND,
+            LapceUICommand::PaletteReferences(offset, locations),
+            Target::Auto,
+        );
     }
-    let _ = event_sink.submit_command(
-        LAPCE_UI_COMMAND,
-        LapceUICommand::PaletteReferences(offset, locations),
-        Target::Auto,
-    );
     Ok(())
 }
 

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1237,25 +1237,6 @@ impl LapceTab {
                         }
                         ctx.set_handled();
                     }
-                    LapceUICommand::GotoReference(
-                        editor_view_id,
-                        offset,
-                        location,
-                    ) => {
-                        if let Some(editor) = data.main_split.active_editor() {
-                            if *editor_view_id == editor.view_id
-                                && *offset == editor.cursor.offset()
-                            {
-                                data.main_split.jump_to_location(
-                                    ctx,
-                                    Some(*editor_view_id),
-                                    location.clone(),
-                                    &data.config,
-                                );
-                            }
-                        }
-                        ctx.set_handled();
-                    }
                     LapceUICommand::UpdateInlayHints { path, rev, hints } => {
                         if let Some(doc) = data.main_split.open_docs.get_mut(path) {
                             if doc.rev() == *rev {


### PR DESCRIPTION
Fixes where goto reference would show the palette when there was only a single entry to jump to. (it would jump and then show palette for a single entry)
Also fixes a bug where it would swap out the current editor for the destination file when there was a single entry. This just makes so it uses the same command that the palette would use.