### PR TITLE
Specify a field so that LSPs to avoid minor lsp-types bug

### DIFF
--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -1268,6 +1268,9 @@ impl LspClient {
                     ..Default::default()
                 }),
                 type_definition: Some(GotoCapability {
+                    // Note: This is explicitly specified rather than left to the Default because
+                    // of a bug in lsp-types https://github.com/gluon-lang/lsp-types/pull/244
+                    link_support: Some(false),
                     ..Default::default()
                 }),
                 ..Default::default()


### PR DESCRIPTION
This specifies a field to avoid a bug in lsp-types where it serializes the field even if it is `None`. RA has a less strict deserialization than the Julia LSP and so it was not noticed. I've opened a PR on lsp-types, so we should probably be able to remove the minor fix soon.