### PR TITLE
Specify the workspace folder of the root uri if available

### DIFF
--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -1311,11 +1311,16 @@ impl LspClient {
         #[allow(deprecated)]
         let init_params = InitializeParams {
             process_id: Some(process::id()),
-            root_uri,
+            root_uri: root_uri.clone(),
             initialization_options: self.options.clone(),
             capabilities: client_capabilities,
             trace: Some(TraceValue::Verbose),
-            workspace_folders: None,
+            workspace_folders: root_uri.map(|uri| {
+                vec![WorkspaceFolder {
+                    name: uri.as_str().to_string(),
+                    uri,
+                }]
+            }),
             client_info: None,
             root_path: None,
             locale: None,


### PR DESCRIPTION
`root_uri` is deprecated, and so we should specify workspace folder as well (if we can). I don't think there's any LSPs that actually require it currently, but it might be useful in the future.
Note: I was a bit uncertain about the name of the workspace passed to the LSP. At a glance I didn't nice function on `Url` to get the basename, and I'm not sure it matters much beyond the case of if an LSP decides to use it in an error message?