### PR TITLE
ci: add index update before installing deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install cmake pkg-config libfontconfig-dev libgtk-3-dev
       - name: Update rust
         run: rustup update


### PR DESCRIPTION
apt indexes should always be updated
before installing packages to prevent
situations where packages have been
removed from mirror