### PR TITLE
Fix prev_boundary function

### DIFF
--- a/lapce-core/src/word.rs
+++ b/lapce-core/src/word.rs
@@ -50,7 +50,7 @@ impl<'a> WordCursor<'a> {
             let mut candidate = self.inner.pos();
             while let Some(prev) = self.inner.prev_codepoint() {
                 let prop_prev = get_word_property(prev);
-                if classify_boundary(prop_prev, prop).is_start() {
+                if classify_boundary(prop_prev, prop).is_boundary() {
                     break;
                 }
                 prop = prop_prev;
@@ -302,7 +302,7 @@ fn classify_boundary(prev: WordProperty, next: WordProperty) -> WordBoundary {
     use self::WordProperty::*;
     match (prev, next) {
         (Lf, Lf) => Start,
-        (Lf, Space) => Interior,
+        (Lf, Space) => Start,
         (Cr, Lf) => Interior,
         (Space, Lf) => Interior,
         (Space, Cr) => Interior,


### PR DESCRIPTION
Resolve #778. It appeared that ``prev_boundary()`` was not working as expected. It makes sense to check also for the ``WordProperty::End``, which can be done using ``is_boundary()``.  I also had to change ``classify_boundary()`` since (Lf, Space) is more likely to be the Start.
This is the first OpenSource contribution in my life! Please review and let me know what you think, thank you!