### PR TITLE
Fix: don't show the loading message when the plugin list is empty

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -193,6 +193,13 @@ impl LapceData {
                 )),
                 Target::Auto,
             );
+            let _ = event_sink.submit_command(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::UpdateUninstalledPluginDescriptions(Some(vec![
+                    PluginDescription::dummy_loading_plugin(),
+                ])),
+                Target::Auto,
+            );
             if let Ok(fetched_plugins) = LapceData::load_plugin_descriptions() {
                 let (installed, uninstalled) =
                     fetched_plugins.into_iter().partition(|p| {

--- a/lapce-rpc/src/plugin.rs
+++ b/lapce-rpc/src/plugin.rs
@@ -101,4 +101,19 @@ impl PluginDescription {
             .map(|(k, v)| (k.into(), v.into()))
             .collect::<Vec<(String, String)>>())
     }
+
+    pub fn dummy_loading_plugin() -> Self {
+        Self {
+            name: String::from("loading"),
+            version: String::from("loading"),
+            display_name: String::from("loading"),
+            author: String::from("loading"),
+            description: String::from("loading"),
+            repository: String::from("loading"),
+            wasm: None,
+            themes: None,
+            dir: None,
+            configuration: None,
+        }
+    }
 }

--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -220,7 +220,31 @@ impl Widget<LapceTabData> for Plugin {
                     .unwrap();
                 ctx.draw_text(&layout, Point::new(x, y));
             } else if let Some(ref plugins) = **fetched_plugins {
-                if !plugins.is_empty() {
+                let first = plugins.get(0);
+                if let Some(plugin) = first {
+                    if plugin.name == *"loading" && plugin.author == *"loading" {
+                        let y = self.line_height;
+                        let x = self.line_height;
+                        let layout = ctx
+                            .text()
+                            .new_text_layout("Loading plugin information...")
+                            .font(
+                                data.config.ui.font_family(),
+                                data.config.ui.font_size() as f64,
+                            )
+                            .default_attribute(TextAttribute::Weight(
+                                FontWeight::SEMI_BOLD,
+                            ))
+                            .text_color(
+                                data.config
+                                    .get_color_unchecked(LapceTheme::LAPCE_WARN)
+                                    .clone(),
+                            )
+                            .build()
+                            .unwrap();
+                        ctx.draw_text(&layout, Point::new(x, y));
+                        return;
+                    }
                     for (i, plugin) in plugins.iter().enumerate() {
                         let y = 3.0 * self.line_height * i as f64;
                         let x = 3.0 * self.line_height;
@@ -410,27 +434,6 @@ impl Widget<LapceTabData> for Plugin {
                             ),
                         );
                     }
-                } else {
-                    let y = self.line_height;
-                    let x = self.line_height;
-                    let layout = ctx
-                        .text()
-                        .new_text_layout("Loading plugin information...")
-                        .font(
-                            data.config.ui.font_family(),
-                            data.config.ui.font_size() as f64,
-                        )
-                        .default_attribute(TextAttribute::Weight(
-                            FontWeight::SEMI_BOLD,
-                        ))
-                        .text_color(
-                            data.config
-                                .get_color_unchecked(LapceTheme::LAPCE_WARN)
-                                .clone(),
-                        )
-                        .build()
-                        .unwrap();
-                    ctx.draw_text(&layout, Point::new(x, y));
                 }
             }
         });


### PR DESCRIPTION
This is a temporary fix for loading message showing up when the plugin list is loaded but is empty. This patch adds a dummy plugin when the plugin list is loading. This is not a perfect fix but I think for now it's ok.