### PR TITLE
Use utf8 offsets instead of lsp_types Position

### DIFF
--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -25,6 +25,7 @@ use xi_rope::{spans::Spans, Rope};
 use crate::alert::AlertContentData;
 use crate::data::LapceWorkspace;
 use crate::document::BufferContent;
+use crate::editor::EditorLspLocation;
 use crate::menu::MenuKind;
 use crate::rich_text::RichText;
 use crate::{
@@ -474,7 +475,7 @@ pub enum LapceUICommand {
     ShowKeybindings,
     FocusEditor,
     RunPalette(Option<PaletteType>),
-    RunPaletteReferences(Vec<EditorLocation>),
+    RunPaletteReferences(Vec<EditorLspLocation>),
     InitPaletteInput(String),
     UpdatePaletteInput(String),
     UpdatePaletteItems(String, Vec<PaletteItem>),
@@ -574,9 +575,20 @@ pub enum LapceUICommand {
     JumpToPosition(Option<WidgetId>, Position),
     JumpToLine(Option<WidgetId>, usize),
     JumpToLocation(Option<WidgetId>, EditorLocation),
+    JumpToLspLocation(Option<WidgetId>, EditorLspLocation),
+    JumpToLineColumnPath {
+        editor_view_id: Option<WidgetId>,
+        path: PathBuf,
+        line: usize,
+        column: usize,
+    },
     TerminalJumpToLine(i32),
     GoToLocationNew(WidgetId, EditorLocation),
-    GotoDefinition(WidgetId, usize, EditorLocation),
+    GotoDefinition {
+        editor_view_id: WidgetId,
+        offset: usize,
+        location: EditorLspLocation,
+    },
     PaletteReferences(usize, Vec<Location>),
     GotoLocation(Location),
     ActiveFileChanged {

--- a/lapce-data/src/db.rs
+++ b/lapce-data/src/db.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Result};
 use crossbeam_channel::{unbounded, Sender};
 use directories::ProjectDirs;
 use druid::{ExtEventSink, Point, Rect, Size, Vec2, WidgetId};
-use lsp_types::Position;
+
 use serde::{Deserialize, Serialize};
 use xi_rope::Rope;
 
@@ -247,7 +247,7 @@ pub struct EditorInfo {
     pub content: BufferContent,
     pub unsaved: Option<String>,
     pub scroll_offset: (f64, f64),
-    pub position: Option<Position>,
+    pub position: Option<usize>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use crate::command::CommandKind;
 use crate::data::{LapceWorkspace, LapceWorkspaceType};
 use crate::document::BufferContent;
-use crate::editor::EditorLocation;
+use crate::editor::EditorLspLocation;
 use crate::panel::PanelKind;
 use crate::proxy::path_from_url;
 use crate::{
@@ -134,9 +134,9 @@ pub enum PaletteItemContent {
         kind: SymbolKind,
         name: String,
         container_name: Option<String>,
-        location: EditorLocation,
+        location: EditorLspLocation,
     },
-    ReferenceLocation(PathBuf, EditorLocation),
+    ReferenceLocation(PathBuf, EditorLspLocation),
     Workspace(LapceWorkspace),
     SshHost(String, String),
     Command(LapceCommand),
@@ -181,7 +181,7 @@ impl PaletteItemContent {
                 };
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::JumpToLocation(editor_id, location.clone()),
+                    LapceUICommand::JumpToLspLocation(editor_id, location.clone()),
                     Target::Auto,
                 ));
             }
@@ -205,7 +205,7 @@ impl PaletteItemContent {
                 };
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::JumpToLocation(editor_id, location.clone()),
+                    LapceUICommand::JumpToLspLocation(editor_id, location.clone()),
                     Target::Auto,
                 ));
             }
@@ -529,7 +529,7 @@ impl PaletteViewData {
     pub fn run_references(
         &mut self,
         ctx: &mut EventCtx,
-        locations: &[EditorLocation],
+        locations: &[EditorLspLocation],
     ) {
         self.run(ctx, Some(PaletteType::Reference), None);
         let items: Vec<PaletteItem> = locations
@@ -1104,7 +1104,7 @@ impl PaletteViewData {
                                             PaletteItemContent::WorkspaceSymbol {
                                                 kind: s.kind,
                                                 name: s.name.clone(),
-                                                location: EditorLocation {
+                                                location: EditorLspLocation {
                                                     path: path_from_url(
                                                         &s.location.uri,
                                                     ),

--- a/lapce-ui/src/problem.rs
+++ b/lapce-ui/src/problem.rs
@@ -10,7 +10,7 @@ use lapce_data::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     config::LapceTheme,
     data::LapceTabData,
-    editor::EditorLocation,
+    editor::EditorLspLocation,
     panel::PanelKind,
     problem::ProblemData,
     proxy::path_from_url,
@@ -102,9 +102,9 @@ impl ProblemContent {
                 if ctx.is_hot() && i < n && n < i + 1 + msg_lines {
                     ctx.submit_command(Command::new(
                         LAPCE_UI_COMMAND,
-                        LapceUICommand::JumpToLocation(
+                        LapceUICommand::JumpToLspLocation(
                             None,
-                            EditorLocation {
+                            EditorLspLocation {
                                 path: path.clone(),
                                 position: Some(d.diagnostic.range.start),
                                 scroll_offset: None,
@@ -127,9 +127,9 @@ impl ProblemContent {
                     if i <= n && n <= i + lines {
                         ctx.submit_command(Command::new(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::JumpToLocation(
+                            LapceUICommand::JumpToLspLocation(
                                 None,
-                                EditorLocation {
+                                EditorLspLocation {
                                     path: related
                                         .location
                                         .uri

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -10,7 +10,6 @@ use lapce_data::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     config::LapceTheme,
     data::LapceTabData,
-    editor::EditorLocation,
     panel::PanelKind,
 };
 
@@ -89,18 +88,12 @@ impl SearchContent {
                 if i == n {
                     ctx.submit_command(Command::new(
                         LAPCE_UI_COMMAND,
-                        LapceUICommand::JumpToLocation(
-                            None,
-                            EditorLocation {
-                                path: path.clone(),
-                                position: Some(lsp_types::Position {
-                                    line: *line_number as u32 - 1,
-                                    character: *start as u32,
-                                }),
-                                scroll_offset: None,
-                                history: None,
-                            },
-                        ),
+                        LapceUICommand::JumpToLineColumnPath {
+                            editor_view_id: None,
+                            path: path.clone(),
+                            line: line_number.saturating_sub(1),
+                            column: *start,
+                        },
                         Target::Widget(data.id),
                     ));
                     return;

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -27,7 +27,7 @@ use lapce_data::{
         LapceWorkspace, LapceWorkspaceType, WorkProgress,
     },
     document::{BufferContent, LocalBufferKind},
-    editor::EditorLocation,
+    editor::{EditorLocation, EditorLspLocation},
     hover::HoverStatus,
     keypress::{DefaultKeyPressHandler, KeyPressData},
     menu::MenuKind,
@@ -1215,6 +1215,31 @@ impl LapceTab {
                         );
                         ctx.set_handled();
                     }
+                    LapceUICommand::JumpToLspLocation(editor_view_id, location) => {
+                        data.main_split.jump_to_lsp_location(
+                            ctx,
+                            *editor_view_id,
+                            location.clone(),
+                            &data.config,
+                        );
+                        ctx.set_handled();
+                    }
+                    LapceUICommand::JumpToLineColumnPath {
+                        editor_view_id,
+                        path,
+                        line,
+                        column,
+                    } => {
+                        data.main_split.jump_to_line_column_path(
+                            ctx,
+                            *editor_view_id,
+                            path.clone(),
+                            *line,
+                            *column,
+                            &data.config,
+                        );
+                        ctx.set_handled();
+                    }
                     LapceUICommand::JumpToLine(editor_view_id, line) => {
                         data.main_split.jump_to_line(
                             ctx,
@@ -1244,16 +1269,16 @@ impl LapceTab {
                         // ));
                         ctx.set_handled();
                     }
-                    LapceUICommand::GotoDefinition(
+                    LapceUICommand::GotoDefinition {
                         editor_view_id,
                         offset,
                         location,
-                    ) => {
+                    } => {
                         if let Some(editor) = data.main_split.active_editor() {
                             if *editor_view_id == editor.view_id
                                 && *offset == editor.cursor.offset()
                             {
-                                data.main_split.jump_to_location(
+                                data.main_split.jump_to_lsp_location(
                                     ctx,
                                     None,
                                     location.clone(),
@@ -1284,7 +1309,7 @@ impl LapceTab {
                             if *offset == editor.cursor.offset() {
                                 let locations = locations
                                     .iter()
-                                    .map(|l| EditorLocation {
+                                    .map(|l| EditorLspLocation {
                                         path: path_from_url(&l.uri),
                                         position: Some(l.range.start),
                                         scroll_offset: None,


### PR DESCRIPTION
This switches much of the code over to using utf8 offsets rather than `lsp_types::Position` (line & column). This does not include the utf8 <-> utf16 changes, but will make them easier.   
There are a few places where I could changed `lsp_types::Position` (such as for the `next_error` code) but they're likely to be continuing to use the lsp `Position` for comparison purposes with stored `lsp_types::Position` and so it is better to leave them as they are.  
I introduced a `EditorLspLocation` and `JumpToLspLocation` which use `Position`. This will make so code that has `Position` types doesn't have to translate them itself, making it a bit easier to just use them. (and in some places, you might want to jump but you don't have access to data, and so this makes so you don't have to create a command to call that will then translate yourself)  
I unfortunately had to introduce a command to jump to a line column and path for only the search results, since those report their in terms of the line column and path. (Previously we were using the `lsp_types::Position`, but since that is UTF16 we don't want to have the UTF8 offsets of search using that)