### PR TITLE
Use generic parameter instead of separate structures

### DIFF
--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -25,7 +25,6 @@ use xi_rope::{spans::Spans, Rope};
 use crate::alert::AlertContentData;
 use crate::data::LapceWorkspace;
 use crate::document::BufferContent;
-use crate::editor::EditorLspLocation;
 use crate::menu::MenuKind;
 use crate::rich_text::RichText;
 use crate::{
@@ -421,6 +420,12 @@ pub enum LapceUICommand {
         content: Rope,
         locations: Vec<(WidgetId, EditorLocation)>,
     },
+    /// Init buffer content but using lsp positions instead
+    InitBufferContentLsp {
+        path: PathBuf,
+        content: Rope,
+        locations: Vec<(WidgetId, EditorLocation<Position>)>,
+    },
     OpenFileChanged {
         path: PathBuf,
         content: Rope,
@@ -475,7 +480,7 @@ pub enum LapceUICommand {
     ShowKeybindings,
     FocusEditor,
     RunPalette(Option<PaletteType>),
-    RunPaletteReferences(Vec<EditorLspLocation>),
+    RunPaletteReferences(Vec<EditorLocation<Position>>),
     InitPaletteInput(String),
     UpdatePaletteInput(String),
     UpdatePaletteItems(String, Vec<PaletteItem>),
@@ -575,7 +580,7 @@ pub enum LapceUICommand {
     JumpToPosition(Option<WidgetId>, Position),
     JumpToLine(Option<WidgetId>, usize),
     JumpToLocation(Option<WidgetId>, EditorLocation),
-    JumpToLspLocation(Option<WidgetId>, EditorLspLocation),
+    JumpToLspLocation(Option<WidgetId>, EditorLocation<Position>),
     JumpToLineColumnPath {
         editor_view_id: Option<WidgetId>,
         path: PathBuf,
@@ -587,7 +592,7 @@ pub enum LapceUICommand {
     GotoDefinition {
         editor_view_id: WidgetId,
         offset: usize,
-        location: EditorLspLocation,
+        location: EditorLocation<Position>,
     },
     PaletteReferences(usize, Vec<Location>),
     GotoLocation(Location),

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -49,7 +49,7 @@ use crate::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     config::{Config, LapceTheme},
     data::{EditorDiagnostic, EditorView},
-    editor::EditorLocation,
+    editor::{EditorLocation, EditorPosition},
     find::{Find, FindProgress},
     history::DocumentHistory,
     proxy::LapceProxy,
@@ -535,7 +535,10 @@ impl Document {
         }
     }
 
-    pub fn retrieve_file(&mut self, locations: Vec<(WidgetId, EditorLocation)>) {
+    pub fn retrieve_file<P: EditorPosition + Send + 'static>(
+        &mut self,
+        locations: Vec<(WidgetId, EditorLocation<P>)>,
+    ) {
         if self.loaded || *self.load_started.borrow() {
             return;
         }
@@ -552,11 +555,11 @@ impl Document {
                     if let Ok(resp) = result {
                         let _ = event_sink.submit_command(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::InitBufferContent {
+                            P::init_buffer_content_cmd(
                                 path,
-                                content: Rope::from(resp.content),
+                                Rope::from(resp.content),
                                 locations,
-                            },
+                            ),
                             Target::Widget(tab_id),
                         );
                     };

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -10,7 +10,7 @@ use lapce_core::command::{EditCommand, FocusCommand};
 use lapce_core::language::LapceLanguage;
 use lapce_core::mode::Mode;
 use lapce_core::movement::Movement;
-use lsp_types::{DocumentSymbolResponse, Range, SymbolKind};
+use lsp_types::{DocumentSymbolResponse, Position, Range, SymbolKind};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use crate::command::CommandKind;
 use crate::data::{LapceWorkspace, LapceWorkspaceType};
 use crate::document::BufferContent;
-use crate::editor::EditorLspLocation;
+use crate::editor::EditorLocation;
 use crate::panel::PanelKind;
 use crate::proxy::path_from_url;
 use crate::{
@@ -134,9 +134,9 @@ pub enum PaletteItemContent {
         kind: SymbolKind,
         name: String,
         container_name: Option<String>,
-        location: EditorLspLocation,
+        location: EditorLocation<Position>,
     },
-    ReferenceLocation(PathBuf, EditorLspLocation),
+    ReferenceLocation(PathBuf, EditorLocation<Position>),
     Workspace(LapceWorkspace),
     SshHost(String, String),
     Command(LapceCommand),
@@ -529,7 +529,7 @@ impl PaletteViewData {
     pub fn run_references(
         &mut self,
         ctx: &mut EventCtx,
-        locations: &[EditorLspLocation],
+        locations: &[EditorLocation<Position>],
     ) {
         self.run(ctx, Some(PaletteType::Reference), None);
         let items: Vec<PaletteItem> = locations
@@ -1104,7 +1104,7 @@ impl PaletteViewData {
                                             PaletteItemContent::WorkspaceSymbol {
                                                 kind: s.kind,
                                                 name: s.name.clone(),
-                                                location: EditorLspLocation {
+                                                location: EditorLocation {
                                                     path: path_from_url(
                                                         &s.location.uri,
                                                     ),

--- a/lapce-ui/src/problem.rs
+++ b/lapce-ui/src/problem.rs
@@ -10,7 +10,7 @@ use lapce_data::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     config::LapceTheme,
     data::LapceTabData,
-    editor::EditorLspLocation,
+    editor::EditorLocation,
     panel::PanelKind,
     problem::ProblemData,
     proxy::path_from_url,
@@ -104,7 +104,7 @@ impl ProblemContent {
                         LAPCE_UI_COMMAND,
                         LapceUICommand::JumpToLspLocation(
                             None,
-                            EditorLspLocation {
+                            EditorLocation {
                                 path: path.clone(),
                                 position: Some(d.diagnostic.range.start),
                                 scroll_offset: None,
@@ -129,7 +129,7 @@ impl ProblemContent {
                             LAPCE_UI_COMMAND,
                             LapceUICommand::JumpToLspLocation(
                                 None,
-                                EditorLspLocation {
+                                EditorLocation {
                                     path: related
                                         .location
                                         .uri


### PR DESCRIPTION
In my PR to split the positions, I hadn't realized that the buffer wasn't loaded immediately. (That I was able to get the document made me think it was fine, oops)  
I incorrectly translated the lsp Position to an offset when we first get the buffer, which would just produce an offset of `0` for files that weren't already open. This broke goto definition / workspace references / etcetera.  
Fixing it proved a bit rough, since I realized I had to wait until the file was requested and gotten. I didn't want to duplicate the whole function `go_to_location`, and so I made `EditorLocation` generic over the type of position. This made so that rather than having `EditorLocation` and `EditorLspLocation` we had `EditorLocation<usize>` and `EditorLocation<Position>`. This helps avoiding duplication of code.  
Though there is still some duplication with the `InitBufferContent`/`InitBufferContentLsp` commands.