### PR TITLE
Add functionalities to enable, disable and remove plugins

### DIFF
--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -398,6 +398,13 @@ pub enum LapceWorkbenchCommand {
     PreviousEditorTab,
 }
 
+#[derive(Debug, Clone)]
+pub enum PluginLoadingStatus {
+    Loading,
+    Failed,
+    Ok(Vec<PluginDescription>),
+}
+
 #[derive(Debug)]
 pub enum EnsureVisiblePosition {
     // Move the view so the cursor line will be at the center of the window.  If
@@ -495,9 +502,13 @@ pub enum LapceUICommand {
     UpdateExplorerItems(PathBuf, HashMap<PathBuf, FileNodeItem>, bool),
     UpdateInstalledPlugins(HashMap<String, PluginDescription>),
     UpdatePluginDescriptions(Vec<PluginDescription>),
-    UpdateInstalledPluginDescriptions(Option<Vec<PluginDescription>>),
-    UpdateUninstalledPluginDescriptions(Option<Vec<PluginDescription>>),
-    DeleteUninstalledPluginDescriptions(Vec<PluginDescription>),
+    UpdateInstalledPluginDescriptions(PluginLoadingStatus),
+    UpdateUninstalledPluginDescriptions(PluginLoadingStatus),
+    UpdatePluginInstallationChange(HashMap<String, PluginDescription>),
+    UpdateDisabledPlugins(HashMap<String, PluginDescription>),
+    DisablePlugin(PluginDescription),
+    EnablePlugin(PluginDescription),
+    RemovePlugin(PluginDescription),
     RequestLayout,
     RequestPaint,
     ResetFade,

--- a/lapce-data/src/plugin.rs
+++ b/lapce-data/src/plugin.rs
@@ -28,4 +28,5 @@ pub enum PluginStatus {
     Installed,
     Install,
     Upgrade,
+    Disabled,
 }

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -125,23 +125,17 @@ impl Handler for LapceProxy {
                     LapceUICommand::UpdateInstalledPlugins(plugins.clone()),
                     Target::Widget(self.tab_id),
                 );
-                let plugins_desc = plugins
-                    .iter()
-                    .map(|(_, desc)| desc.to_owned())
-                    .collect::<Vec<PluginDescription>>();
                 let _ = self.event_sink.submit_command(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::UpdateInstalledPluginDescriptions(Some(
-                        plugins_desc.clone(),
-                    )),
+                    LapceUICommand::UpdatePluginInstallationChange(plugins),
                     Target::Widget(self.tab_id),
                 );
+            }
+            DisabledPlugins { plugins } => {
                 let _ = self.event_sink.submit_command(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::DeleteUninstalledPluginDescriptions(
-                        plugins_desc,
-                    ),
-                    Target::Widget(self.tab_id),
+                    LapceUICommand::UpdateDisabledPlugins(plugins),
+                    Target::Auto,
                 );
             }
             DiffInfo { diff } => {
@@ -435,6 +429,21 @@ impl LapceProxy {
     pub fn install_plugin(&self, plugin: &PluginDescription) {
         self.rpc
             .send_rpc_notification("install_plugin", &json!({ "plugin": plugin }));
+    }
+
+    pub fn disable_plugin(&self, plugin: &PluginDescription) {
+        self.rpc
+            .send_rpc_notification("disable_plugin", &json!({ "plugin": plugin }))
+    }
+
+    pub fn enable_plugin(&self, plugin: &PluginDescription) {
+        self.rpc
+            .send_rpc_notification("enable_plugin", &json!({ "plugin": plugin }))
+    }
+
+    pub fn remove_plugin(&self, plugin: &PluginDescription) {
+        self.rpc
+            .send_rpc_notification("remove_plugin", &json!({ "plugin": plugin }));
     }
 
     pub fn get_buffer_head(

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -114,6 +114,12 @@ impl LspCatalog {
         self.dispatcher.take();
     }
 
+    pub fn stop_language_lsp(&mut self, lang: &String) {
+        if let Some(lsp) = self.clients.get(lang) {
+            lsp.stop();
+        }
+    }
+
     pub fn start_server(
         &mut self,
         exec_path: &str,

--- a/lapce-rpc/src/core.rs
+++ b/lapce-rpc/src/core.rs
@@ -34,6 +34,9 @@ pub enum CoreNotification {
     InstalledPlugins {
         plugins: HashMap<String, PluginDescription>,
     },
+    DisabledPlugins {
+        plugins: HashMap<String, PluginDescription>,
+    },
     ListDir {
         items: Vec<FileNodeItem>,
     },

--- a/lapce-rpc/src/plugin.rs
+++ b/lapce-rpc/src/plugin.rs
@@ -16,6 +16,7 @@ pub struct PluginDescription {
     pub author: String,
     pub description: String,
     pub repository: String,
+    pub enabled: Option<bool>,
     pub wasm: Option<String>,
     pub themes: Option<Vec<String>>,
     pub dir: Option<PathBuf>,

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -30,6 +30,15 @@ pub enum ProxyNotification {
     InstallPlugin {
         plugin: PluginDescription,
     },
+    DisablePlugin {
+        plugin: PluginDescription,
+    },
+    EnablePlugin {
+        plugin: PluginDescription,
+    },
+    RemovePlugin {
+        plugin: PluginDescription,
+    },
     GitCommit {
         message: String,
         diffs: Vec<FileDiff>,

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -17,8 +17,8 @@ use lapce_core::{
 use lapce_data::{
     command::{
         CommandKind, LapceCommand, LapceUICommand, LapceWorkbenchCommand,
-        LAPCE_COMMAND, LAPCE_OPEN_FILE, LAPCE_OPEN_FOLDER, LAPCE_SAVE_FILE_AS,
-        LAPCE_UI_COMMAND,
+        PluginLoadingStatus, LAPCE_COMMAND, LAPCE_OPEN_FILE, LAPCE_OPEN_FOLDER,
+        LAPCE_SAVE_FILE_AS, LAPCE_UI_COMMAND,
     },
     completion::CompletionStatus,
     config::{Config, LapceTheme},
@@ -275,15 +275,15 @@ impl LapceTab {
                             .is_container_shown(&PanelContainerPosition::Bottom)
                         {
                             ctx.submit_command(Command::new(
-                            LAPCE_COMMAND,
-                            LapceCommand {
-                                kind: CommandKind::Workbench(
-                                    LapceWorkbenchCommand::TogglePanelBottomVisual,
-                                ),
-                                data: None,
-                            },
-                            Target::Widget(data.id),
-                        ));
+                                LAPCE_COMMAND,
+                                LapceCommand {
+                                    kind: CommandKind::Workbench(
+                                        LapceWorkbenchCommand::TogglePanelBottomVisual,
+                                    ),
+                                    data: None,
+                                },
+                                Target::Widget(data.id),
+                            ));
                         }
                     } else if !data
                         .panel
@@ -923,39 +923,45 @@ impl LapceTab {
                     LapceUICommand::UpdateUninstalledPluginDescriptions(plugins) => {
                         data.uninstalled_plugins_desc = Arc::new(plugins.to_owned());
                     }
-                    LapceUICommand::DeleteUninstalledPluginDescriptions(plugins) => {
-                        let new_installed_plugin = plugins
-                            .iter()
-                            .filter(|p| {
-                                if let Some(ref plugins) =
-                                    *data.uninstalled_plugins_desc
-                                {
-                                    plugins
+                    LapceUICommand::UpdateDisabledPlugins(plugins) => {
+                        data.disabled_plugins = Arc::new(plugins.to_owned());
+                    }
+                    LapceUICommand::UpdatePluginInstallationChange(plugins) => {
+                        let local_plugins = plugins.clone();
+                        let handle = std::thread::spawn(move || {
+                            if let Ok(fetched_plugins) =
+                                LapceData::load_plugin_descriptions()
+                            {
+                                let (installed, uninstalled): (
+                                    Vec<PluginDescription>,
+                                    Vec<PluginDescription>,
+                                ) = fetched_plugins.into_iter().partition(|p| {
+                                    local_plugins
                                         .iter()
-                                        .find(|up| up.name == p.name)
+                                        .find(|(_, ip)| ip.name == p.name)
                                         .ok_or(())
                                         .is_ok()
-                                } else {
-                                    false
-                                }
-                            })
-                            .collect::<Vec<&PluginDescription>>();
-                        if !new_installed_plugin.is_empty() {
-                            let plugin_desc =
-                                (*data.uninstalled_plugins_desc).clone().map(|pd| {
-                                    pd.iter()
-                                        .filter_map(|p| {
-                                            if p.name != new_installed_plugin[0].name
-                                            {
-                                                Some(p.to_owned())
-                                            } else {
-                                                None
-                                            }
-                                        })
-                                        .collect::<Vec<PluginDescription>>()
                                 });
-                            data.uninstalled_plugins_desc = Arc::new(plugin_desc);
+                                return Ok((installed, uninstalled));
+                            }
+                            Err(())
+                        });
+                        let fetch_result = handle.join().unwrap_or(Err(()));
+                        if let Ok((installed, uninstalled)) = fetch_result {
+                            data.installed_plugins_desc =
+                                Arc::new(PluginLoadingStatus::Ok(installed));
+                            data.uninstalled_plugins_desc =
+                                Arc::new(PluginLoadingStatus::Ok(uninstalled));
                         }
+                    }
+                    LapceUICommand::DisablePlugin(plugin) => {
+                        data.proxy.disable_plugin(plugin);
+                    }
+                    LapceUICommand::EnablePlugin(plugin) => {
+                        data.proxy.enable_plugin(plugin);
+                    }
+                    LapceUICommand::RemovePlugin(plugin) => {
+                        data.proxy.remove_plugin(plugin);
                     }
                     LapceUICommand::UpdateDiffInfo(diff) => {
                         let source_control = Arc::make_mut(&mut data.source_control);


### PR DESCRIPTION
This PR adds a basic functionality to make wasm plugins able to be enabled, disabled or removed. When disabling a plugin, if the wasm plugin provides a `stop` function, it will be called. Otherwise, the added code will try to find the LSP started by the plugin and stop it. The PR adds a context menu to the plugin panel to provide enable/disable and remove options. It also fixes the loading problem mentioned in #848 by adding a enum to keep track of the plugin loading status.
<img width="265" alt="Screen Shot 2022-07-27 at 2 53 59 AM" src="https://user-images.githubusercontent.com/10806961/181218828-600f5438-d89e-45c4-ad26-eb4fbcc404ed.png">
.