### PR TITLE
Use UTF16 encoding for LSPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,6 +2312,7 @@ dependencies = [
  "hotwatch",
  "ignore",
  "jsonrpc-lite",
+ "lapce-core",
  "lapce-rpc",
  "locale_config",
  "log",

--- a/lapce-core/src/encoding.rs
+++ b/lapce-core/src/encoding.rs
@@ -127,6 +127,10 @@ mod tests {
         assert_eq!(offset_utf8_to_utf16_str("×", 0), Some(0));
         assert_eq!(offset_utf8_to_utf16_str("×", 1), None);
         assert_eq!(offset_utf8_to_utf16_str("×", 2), Some(1));
+        assert_eq!(offset_utf8_to_utf16_str("a×", 0), Some(0));
+        assert_eq!(offset_utf8_to_utf16_str("a×", 1), Some(1));
+        assert_eq!(offset_utf8_to_utf16_str("a×", 2), None);
+        assert_eq!(offset_utf8_to_utf16_str("a×", 3), Some(2));
     }
 
     #[test]

--- a/lapce-core/src/encoding.rs
+++ b/lapce-core/src/encoding.rs
@@ -1,0 +1,161 @@
+/// Convert a utf8 offset into a utf16 offset, if possible  
+/// `text` is what the offsets are into
+pub fn offset_utf8_to_utf16(
+    char_indices: impl Iterator<Item = (usize, char)>,
+    offset: usize,
+) -> Option<usize> {
+    if offset == 0 {
+        return Some(0);
+    }
+
+    let mut utf16_offset = 0;
+    let mut last_ich = None;
+    for (utf8_offset, ch) in char_indices {
+        last_ich = Some((utf8_offset, ch));
+
+        match utf8_offset.cmp(&offset) {
+            std::cmp::Ordering::Less => {}
+            // We found the right offset
+            std::cmp::Ordering::Equal => {
+                return Some(utf16_offset);
+            }
+            // Implies that the offset was inside of a character
+            std::cmp::Ordering::Greater => return None,
+        }
+
+        utf16_offset += ch.len_utf16();
+    }
+
+    // TODO: We could use TrustedLen when that is stabilized and it is impl'd on
+    // the iterators we use
+
+    // We did not find the offset. This means that it is either at the end
+    // or past the end.
+    let text_len = last_ich.map(|(i, c)| i + c.len_utf8());
+    if text_len == Some(offset) {
+        // Since the utf16 offset was being incremented each time, by now it is equivalent to the length
+        // but in utf16 characters
+        return Some(utf16_offset);
+    }
+
+    None
+}
+
+pub fn offset_utf8_to_utf16_str(text: &str, offset: usize) -> Option<usize> {
+    offset_utf8_to_utf16(text.char_indices(), offset)
+}
+
+/// Convert a utf16 offset into a utf8 offset, if possible  
+/// `char_indices` is an iterator over utf8 offsets and the characters
+/// It is cloneable so that it can be iterated multiple times. Though it should be cheaply cloneable.
+pub fn offset_utf16_to_utf8(
+    char_indices: impl Iterator<Item = (usize, char)>,
+    offset: usize,
+) -> Option<usize> {
+    if offset == 0 {
+        return Some(0);
+    }
+
+    // We accumulate the utf16 char lens until we find the utf8 offset that matches it
+    // or, we find out that it went into the middle of sometext
+    // We also keep track of the last offset and char in order to calculate the length of the text
+    // if we the index was at the end of the string
+    let mut utf16_offset = 0;
+    let mut last_ich = None;
+    for (utf8_offset, ch) in char_indices {
+        last_ich = Some((utf8_offset, ch));
+
+        let ch_utf16_len = ch.len_utf16();
+
+        match utf16_offset.cmp(&offset) {
+            std::cmp::Ordering::Less => {}
+            // We found the right offset
+            std::cmp::Ordering::Equal => {
+                return Some(utf8_offset);
+            }
+            // This implies that the offset was in the middle of a character as we skipped over it
+            std::cmp::Ordering::Greater => return None,
+        }
+
+        utf16_offset += ch_utf16_len;
+    }
+
+    // We did not find the offset, this means that it was either at the end
+    // or past the end
+    // Since we've iterated over all the char indices, the utf16_offset is now the
+    // utf16 length
+    if offset == utf16_offset {
+        let (last_utf8_offset, last_ch) = last_ich.unwrap();
+        let utf8_len = last_utf8_offset + last_ch.len_utf8();
+        return Some(utf8_len);
+    }
+
+    None
+}
+
+pub fn offset_utf16_to_utf8_str(text: &str, offset: usize) -> Option<usize> {
+    offset_utf16_to_utf8(text.char_indices(), offset)
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: more tests with unicode characters
+
+    use crate::encoding::{offset_utf16_to_utf8_str, offset_utf8_to_utf16_str};
+
+    #[test]
+    fn utf8_to_utf16() {
+        let text = "hello world";
+
+        assert_eq!(offset_utf8_to_utf16_str(text, 0), Some(0));
+        assert_eq!(offset_utf8_to_utf16_str("", 0), Some(0));
+
+        assert_eq!(offset_utf8_to_utf16_str("", 1), None);
+
+        assert_eq!(offset_utf8_to_utf16_str("h", 0), Some(0));
+        assert_eq!(offset_utf8_to_utf16_str("h", 1), Some(1));
+
+        assert_eq!(offset_utf8_to_utf16_str(text, text.len()), Some(text.len()));
+
+        assert_eq!(
+            offset_utf8_to_utf16_str(text, text.len() - 1),
+            Some(text.len() - 1)
+        );
+
+        assert_eq!(offset_utf8_to_utf16_str(text, text.len() + 1), None);
+
+        assert_eq!(offset_utf8_to_utf16_str("×", 0), Some(0));
+        assert_eq!(offset_utf8_to_utf16_str("×", 1), None);
+        assert_eq!(offset_utf8_to_utf16_str("×", 2), Some(1));
+    }
+
+    #[test]
+    fn utf16_to_utf8() {
+        let text = "hello world";
+
+        assert_eq!(offset_utf16_to_utf8_str(text, 0), Some(0));
+        assert_eq!(offset_utf16_to_utf8_str("", 0), Some(0));
+
+        assert_eq!(offset_utf16_to_utf8_str("", 1), None);
+
+        assert_eq!(offset_utf16_to_utf8_str("h", 0), Some(0));
+        assert_eq!(offset_utf16_to_utf8_str("h", 1), Some(1));
+
+        assert_eq!(offset_utf16_to_utf8_str(text, text.len()), Some(text.len()));
+
+        assert_eq!(
+            offset_utf16_to_utf8_str(text, text.len() - 1),
+            Some(text.len() - 1)
+        );
+
+        assert_eq!(offset_utf16_to_utf8_str(text, text.len() + 1), None);
+
+        assert_eq!(offset_utf16_to_utf8_str("×", 0), Some(0));
+        assert_eq!(offset_utf16_to_utf8_str("×", 1), Some(2));
+        assert_eq!(offset_utf16_to_utf8_str("a×", 0), Some(0));
+        assert_eq!(offset_utf16_to_utf8_str("a×", 1), Some(1));
+        assert_eq!(offset_utf16_to_utf8_str("a×", 2), Some(3));
+        assert_eq!(offset_utf16_to_utf8_str("×a", 1), Some(2));
+        assert_eq!(offset_utf16_to_utf8_str("×a", 2), Some(3));
+    }
+}

--- a/lapce-core/src/lib.rs
+++ b/lapce-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod chars;
 pub mod command;
 pub mod cursor;
 pub mod editor;
+pub mod encoding;
 pub mod indent;
 pub mod language;
 pub mod lens;

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -491,13 +491,18 @@ impl Document {
         self.diagnostics = Some(Arc::new(
             diagnostics
                 .iter()
-                .map(|d| EditorDiagnostic {
-                    range: (
-                        self.buffer.offset_of_position(&d.diagnostic.range.start),
-                        self.buffer.offset_of_position(&d.diagnostic.range.end),
-                    ),
-                    lines: d.lines,
-                    diagnostic: d.diagnostic.clone(),
+                // We discard diagnostics that have bad positions
+                .filter_map(|d| {
+                    Some(EditorDiagnostic {
+                        range: (
+                            self.buffer
+                                .offset_of_position(&d.diagnostic.range.start)?,
+                            self.buffer
+                                .offset_of_position(&d.diagnostic.range.end)?,
+                        ),
+                        lines: d.lines,
+                        diagnostic: d.diagnostic.clone(),
+                    })
                 })
                 .collect(),
         ));
@@ -512,11 +517,30 @@ impl Document {
                     transformer.transform(start, false),
                     transformer.transform(end, true),
                 );
+
+                let new_start_pos = if let Some(pos) =
+                    self.buffer().offset_to_position(new_start)
+                {
+                    pos
+                } else {
+                    // If we failed to transform the offset then we leave the diagnostic in the old position
+                    log::error!("Failed to transform diagnostic start offset {new_start} to Position");
+                    continue;
+                };
+
+                let new_end_pos = if let Some(pos) =
+                    self.buffer().offset_to_position(new_end)
+                {
+                    pos
+                } else {
+                    log::error!("Failed to transform diagnostic end offset {new_end} to Position");
+                    continue;
+                };
+
                 diagnostic.range = (new_start, new_end);
-                diagnostic.diagnostic.range.start =
-                    self.buffer().offset_to_position(new_start);
-                diagnostic.diagnostic.range.end =
-                    self.buffer().offset_to_position(new_end);
+
+                diagnostic.diagnostic.range.start = new_start_pos;
+                diagnostic.diagnostic.range.end = new_end_pos;
             }
             self.diagnostics = Some(diagnostics);
         }
@@ -782,12 +806,15 @@ impl Document {
 
                     let mut hints_span = SpansBuilder::new(len);
                     for hint in resp {
-                        let offset =
-                            buffer.offset_of_position(&hint.position).min(len);
-                        hints_span.add_span(
-                            Interval::new(offset, (offset + 1).min(len)),
-                            hint.clone(),
-                        );
+                        if let Some(offset) =
+                            buffer.offset_of_position(&hint.position)
+                        {
+                            let offset = offset.min(len);
+                            hints_span.add_span(
+                                Interval::new(offset, (offset + 1).min(len)),
+                                hint.clone(),
+                            );
+                        }
                     }
                     let hints = hints_span.build();
                     let _ = event_sink.submit_command(

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -81,7 +81,7 @@ pub enum EditorOperator {
 
 pub trait EditorPosition: Sized {
     /// Convert the position to a utf8 offset
-    fn to_utf8_offset(&self, buffer: &Buffer) -> usize;
+    fn to_utf8_offset(&self, buffer: &Buffer) -> Option<usize>;
 
     fn init_buffer_content_cmd(
         path: PathBuf,
@@ -92,8 +92,8 @@ pub trait EditorPosition: Sized {
 
 // Usize is always a utf8 offset
 impl EditorPosition for usize {
-    fn to_utf8_offset(&self, _buffer: &Buffer) -> usize {
-        *self
+    fn to_utf8_offset(&self, _buffer: &Buffer) -> Option<usize> {
+        Some(*self)
     }
 
     fn init_buffer_content_cmd(
@@ -109,7 +109,7 @@ impl EditorPosition for usize {
     }
 }
 impl EditorPosition for Position {
-    fn to_utf8_offset(&self, buffer: &Buffer) -> usize {
+    fn to_utf8_offset(&self, buffer: &Buffer) -> Option<usize> {
         buffer.offset_of_position(self)
     }
 
@@ -137,7 +137,7 @@ impl<P: EditorPosition> EditorLocation<P> {
     pub fn into_utf8_location(self, buffer: &Buffer) -> EditorLocation<usize> {
         EditorLocation {
             path: self.path,
-            position: self.position.map(|p| p.to_utf8_offset(buffer)),
+            position: self.position.and_then(|p| p.to_utf8_offset(buffer)),
             scroll_offset: self.scroll_offset,
             history: self.history,
         }
@@ -227,7 +227,14 @@ impl LapceEditorBufferData {
             let prev_offset = self.doc.buffer().prev_code_boundary(offset);
             if self.doc.code_actions.get(&prev_offset).is_none() {
                 let buffer_id = self.doc.id();
-                let position = self.doc.buffer().offset_to_position(prev_offset);
+                let position = if let Some(position) =
+                    self.doc.buffer().offset_to_position(prev_offset)
+                {
+                    position
+                } else {
+                    log::error!("Failed to convert prev_offset: {prev_offset} to Position when getting code actions");
+                    return;
+                };
                 let rev = self.doc.rev();
                 let event_sink = ctx.get_external_handle();
                 self.proxy
@@ -300,29 +307,30 @@ impl LapceEditorBufferData {
                                         .open_docs
                                         .get_mut(&path)
                                         .unwrap();
-                                    let edits: Vec<(
-                                        lapce_core::selection::Selection,
-                                        &str,
-                                    )> = edits
+                                    let edits = edits
                                         .iter()
                                         .map(|edit| {
                                             let selection =
                                             lapce_core::selection::Selection::region(
                                                 doc.buffer().offset_of_position(
                                                     &edit.range.start,
-                                                ),
+                                                )?,
                                                 doc.buffer().offset_of_position(
                                                     &edit.range.end,
-                                                ),
+                                                )?,
                                             );
-                                            (selection, edit.new_text.as_str())
+                                            Some((selection, edit.new_text.as_str()))
                                         })
-                                        .collect();
-                                    self.main_split.edit(
-                                        &path,
-                                        &edits,
-                                        lapce_core::editor::EditType::Other,
-                                    );
+                                        .collect::<Option<Vec<_>>>();
+                                    if let Some(edits) = edits {
+                                        self.main_split.edit(
+                                            &path,
+                                            &edits,
+                                            lapce_core::editor::EditType::Other,
+                                        );
+                                    } else {
+                                        log::error!("Failed to convert code action edit Position to offset");
+                                    }
                                 }
                             }
                         }
@@ -333,19 +341,32 @@ impl LapceEditorBufferData {
     }
 
     pub fn apply_completion_item(&mut self, item: &CompletionItem) -> Result<()> {
-        let additional_edit: Option<Vec<_>> =
+        let additional_edit: Option<Option<Vec<_>>> =
             item.additional_text_edits.as_ref().map(|edits| {
                 edits
                     .iter()
                     .map(|edit| {
                         let selection = lapce_core::selection::Selection::region(
-                            self.doc.buffer().offset_of_position(&edit.range.start),
-                            self.doc.buffer().offset_of_position(&edit.range.end),
+                            self.doc.buffer().offset_of_position(&edit.range.start)?,
+                            self.doc.buffer().offset_of_position(&edit.range.end)?,
                         );
-                        (selection, edit.new_text.as_str())
+                        Some((selection, edit.new_text.as_str()))
                     })
-                    .collect::<Vec<(lapce_core::selection::Selection, &str)>>()
+                    .collect::<Option<Vec<(lapce_core::selection::Selection, &str)>>>()
             });
+
+        // If the inner option is empty
+        if additional_edit
+            .as_ref()
+            .map(Option::is_none)
+            .unwrap_or(false)
+        {
+            log::error!("Failed to convert completion item's additional edit Positions to offsets");
+            return Err(anyhow!("Bad additional edit position"));
+        }
+
+        let additional_edit = additional_edit.flatten();
+
         let additional_edit: Vec<_> = additional_edit
             .as_ref()
             .map(|edits| {
@@ -362,10 +383,23 @@ impl LapceEditorBufferData {
                     let offset = self.editor.cursor.offset();
                     let start_offset = self.doc.buffer().prev_code_boundary(offset);
                     let end_offset = self.doc.buffer().next_code_boundary(offset);
-                    let edit_start =
-                        self.doc.buffer().offset_of_position(&edit.range.start);
-                    let edit_end =
-                        self.doc.buffer().offset_of_position(&edit.range.end);
+                    let edit_start = if let Some(edit_start) =
+                        self.doc.buffer().offset_of_position(&edit.range.start)
+                    {
+                        edit_start
+                    } else {
+                        log::error!("Failed to convert completion edit start Position {:?} to offset", edit.range.start);
+                        return Err(anyhow!("bad edit start position"));
+                    };
+                    let edit_end = if let Some(edit_end) =
+                        self.doc.buffer().offset_of_position(&edit.range.end)
+                    {
+                        edit_end
+                    } else {
+                        log::error!("Failed to convert completion edit end Position {:?} to offset", edit.range.end);
+                        return Err(anyhow!("bad edit end position"));
+                    };
+
                     let selection = lapce_core::selection::Selection::region(
                         start_offset.min(edit_start),
                         end_offset.max(edit_end),
@@ -526,29 +560,40 @@ impl LapceEditorBufferData {
             completion.update_input(input.clone());
 
             if !completion.input_items.contains_key("") {
-                let event_sink = ctx.get_external_handle();
-                completion.request(
-                    self.proxy.clone(),
-                    completion.request_id,
-                    self.doc.id(),
-                    "".to_string(),
-                    self.doc.buffer().offset_to_position(start_offset),
-                    completion.id,
-                    event_sink,
-                );
+                if let Some(start_pos) =
+                    self.doc.buffer().offset_to_position(start_offset)
+                {
+                    let event_sink = ctx.get_external_handle();
+                    completion.request(
+                        self.proxy.clone(),
+                        completion.request_id,
+                        self.doc.id(),
+                        "".to_string(),
+                        start_pos,
+                        completion.id,
+                        event_sink,
+                    );
+                } else {
+                    log::error!("Failed to convert start offset: {start_offset} to Position when making completion request");
+                }
             }
 
             if !completion.input_items.contains_key(&input) {
                 let event_sink = ctx.get_external_handle();
-                completion.request(
-                    self.proxy.clone(),
-                    completion.request_id,
-                    self.doc.id(),
-                    input,
-                    self.doc.buffer().offset_to_position(offset),
-                    completion.id,
-                    event_sink,
-                );
+                if let Some(position) = self.doc.buffer().offset_to_position(offset)
+                {
+                    completion.request(
+                        self.proxy.clone(),
+                        completion.request_id,
+                        self.doc.id(),
+                        input,
+                        position,
+                        completion.id,
+                        event_sink,
+                    );
+                } else {
+                    log::error!("Failed to convert offset: {offset} to Position when making completion request");
+                }
             }
 
             return;
@@ -561,25 +606,29 @@ impl LapceEditorBufferData {
         completion.input_items.clear();
         completion.request_id += 1;
         let event_sink = ctx.get_external_handle();
-        completion.request(
-            self.proxy.clone(),
-            completion.request_id,
-            self.doc.id(),
-            "".to_string(),
-            self.doc.buffer().offset_to_position(start_offset),
-            completion.id,
-            event_sink.clone(),
-        );
-        if !input.is_empty() {
+        if let Some(start_pos) = self.doc.buffer().offset_to_position(start_offset) {
             completion.request(
                 self.proxy.clone(),
                 completion.request_id,
                 self.doc.id(),
-                input,
-                self.doc.buffer().offset_to_position(offset),
+                "".to_string(),
+                start_pos,
                 completion.id,
-                event_sink,
+                event_sink.clone(),
             );
+        }
+        if !input.is_empty() {
+            if let Some(position) = self.doc.buffer().offset_to_position(offset) {
+                completion.request(
+                    self.proxy.clone(),
+                    completion.request_id,
+                    self.doc.id(),
+                    input,
+                    position,
+                    completion.id,
+                    event_sink,
+                );
+            }
         }
     }
 
@@ -648,16 +697,22 @@ impl LapceEditorBufferData {
         hover.request_id += 1;
 
         let event_sink = ctx.get_external_handle();
-        hover.request(
-            self.proxy.clone(),
-            hover.request_id,
-            self.doc.clone(),
-            diagnostics,
-            self.doc.buffer().offset_to_position(start_offset),
-            hover.id,
-            event_sink,
-            self.config.clone(),
-        );
+        if let Some(start_pos) = self.doc.buffer().offset_to_position(start_offset) {
+            hover.request(
+                self.proxy.clone(),
+                hover.request_id,
+                self.doc.clone(),
+                diagnostics,
+                start_pos,
+                hover.id,
+                event_sink,
+                self.config.clone(),
+            );
+        } else {
+            log::error!(
+                "Failed to convert offset {start_offset} to position for hover"
+            );
+        }
     }
 
     fn update_snippet_offset(&mut self, delta: &RopeDelta) {
@@ -769,20 +824,26 @@ impl LapceEditorBufferData {
             file_diagnostics.sort_by(|a, b| a.0.cmp(b.0));
 
             let offset = self.editor.cursor.offset();
-            let position = self.doc.buffer().offset_to_position(offset);
-            let (path, position) =
-                next_in_file_errors_offset(position, buffer_path, &file_diagnostics);
-            let location = EditorLocation {
-                path,
-                position: Some(position),
-                scroll_offset: None,
-                history: None,
-            };
-            ctx.submit_command(Command::new(
-                LAPCE_UI_COMMAND,
-                LapceUICommand::JumpToLspLocation(None, location),
-                Target::Auto,
-            ));
+            if let Some(position) = self.doc.buffer().offset_to_position(offset) {
+                let (path, position) = next_in_file_errors_offset(
+                    position,
+                    buffer_path,
+                    &file_diagnostics,
+                );
+                let location = EditorLocation {
+                    path,
+                    position: Some(position),
+                    scroll_offset: None,
+                    history: None,
+                };
+                ctx.submit_command(Command::new(
+                    LAPCE_UI_COMMAND,
+                    LapceUICommand::JumpToLspLocation(None, location),
+                    Target::Auto,
+                ));
+            } else {
+                log::error!("Failed to convert cursor offset to position when getting next error");
+            }
         }
     }
 
@@ -1635,11 +1696,24 @@ impl LapceEditorBufferData {
             GotoDefinition => {
                 let offset = self.editor.cursor.offset();
                 let start_offset = self.doc.buffer().prev_code_boundary(offset);
-                let start_position =
-                    self.doc.buffer().offset_to_position(start_offset);
+                let start_position = if let Some(start_position) =
+                    self.doc.buffer().offset_to_position(start_offset)
+                {
+                    start_position
+                } else {
+                    log::error!("Failed to convert offset {start_offset} to position in GotoDefinition");
+                    return CommandExecuted::Yes;
+                };
                 let event_sink = ctx.get_external_handle();
                 let buffer_id = self.doc.id();
-                let position = self.doc.buffer().offset_to_position(offset);
+                let position = if let Some(position) =
+                    self.doc.buffer().offset_to_position(offset)
+                {
+                    position
+                } else {
+                    log::error!("Failed to convert offset {offset} to position in GotoDefinition");
+                    return CommandExecuted::Yes;
+                };
                 let proxy = self.proxy.clone();
                 let editor_view_id = self.editor.view_id;
                 self.proxy.get_definition(
@@ -1698,7 +1772,14 @@ impl LapceEditorBufferData {
                 let offset = self.editor.cursor.offset();
                 let event_sink = ctx.get_external_handle();
                 let buffer_id = self.doc.id();
-                let position = self.doc.buffer().offset_to_position(offset);
+                let position = if let Some(position) =
+                    self.doc.buffer().offset_to_position(offset)
+                {
+                    position
+                } else {
+                    log::error!("Failed to convert offset {offset} to position in GotoTypeDefinition");
+                    return CommandExecuted::Yes;
+                };
                 let editor_view_id = self.editor.view_id;
                 self.proxy.get_type_definition(
                     offset,

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1.0.32"
 home = "0.5.3"
 toml = "0.5.6"
 git2 = { version = "0.14.4", features = ["vendored-openssl"] }
+lapce-core = { path = "../lapce-core" }
 lapce-rpc = { path = "../lapce-rpc" }
 trash = "2.1"
 log = "0.4.17"

--- a/lapce-proxy/src/lsp.rs
+++ b/lapce-proxy/src/lsp.rs
@@ -613,7 +613,7 @@ impl LspCatalog {
             // Range over the entire buffer
             let range = Range {
                 start: Position::new(0, 0),
-                end: buffer.offset_to_position(buffer.len()),
+                end: buffer.offset_to_position(buffer.len()).unwrap(),
             };
             client.request_inlay_hints(uri, range, move |lsp_client, result| {
                 let mut resp = json!({ "id": id });
@@ -1717,6 +1717,7 @@ fn format_semantic_styles(
             start += utf8_delta_start;
         } else {
             // Bad semantic token offsets
+            log::error!("Bad semantic token starty {semantic_token:?}");
             break;
         };
 
@@ -1726,6 +1727,7 @@ fn format_semantic_styles(
         {
             start + utf8_length
         } else {
+            log::error!("Bad semantic token end {semantic_token:?}");
             break;
         };
 


### PR DESCRIPTION
This PR adds an `encoding.rs` file for switching between UTF16 and UTF8 offsets given just an iterator over the char indices (which lets us work with both `&str` and a `Rope` without allocating).   
- Query: I put the `encoding.rs` in `lapce-core` so that it could be accessed by `lapce-core/src/buffer.rs` and `lapce-proxy/src/buffer.rs`, but that required making `lapce-proxy` depend on `lapce-core`. I could add a separate crate `lapce-encoding` (or `lapce-util` if we want it to be more general), so that we don't make it as tightly interlinked?  
  
This removes the `offset_encoding` field on the lsp capabilities, because supporting the UTF8 extension for LSP clients would be challenging. It is easier and less complex for the code to just use UTF16 offsets.  
This PR became much easier after doing the split between UTF16 `lsp_types::Position` and UTF8 `usize`s.