### PR TITLE
don't paint tiny tab drags

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -527,7 +527,7 @@ pub struct LapceTabData {
     pub focus_area: FocusArea,
     pub db: Arc<LapceDb>,
     pub progresses: im::Vector<WorkProgress>,
-    pub drag: Arc<Option<(Vec2, DragContent)>>,
+    pub drag: Arc<Option<(Vec2, Vec2, DragContent)>>,
 }
 
 impl Data for LapceTabData {
@@ -815,7 +815,7 @@ impl LapceTabData {
     }
 
     pub fn is_drag_editor(&self) -> bool {
-        matches!(&*self.drag, Some((_, DragContent::EditorTab(..))))
+        matches!(&*self.drag, Some((_, _, DragContent::EditorTab(..))))
     }
 
     pub fn update_from_editor_buffer_data(

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -139,7 +139,7 @@ impl LapceEditorTab {
         data: &mut LapceTabData,
         mouse_event: &MouseEvent,
     ) {
-        if let Some((_, drag_content)) = data.drag.clone().as_ref() {
+        if let Some((_, _, drag_content)) = data.drag.clone().as_ref() {
             match drag_content {
                 DragContent::EditorTab(from_id, from_index, child, _) => {
                     let size = ctx.size();

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -153,6 +153,7 @@ impl LapceEditorTabHeaderContent {
                     mouse_event.pos.to_vec2() - tab_rect.rect.origin().to_vec2();
                 *Arc::make_mut(&mut data.drag) = Some((
                     offset,
+                    mouse_event.window_pos.to_vec2(),
                     DragContent::EditorTab(
                         editor_tab.widget_id,
                         target,
@@ -189,7 +190,7 @@ impl LapceEditorTabHeaderContent {
         ctx: &mut EventCtx,
         data: &mut LapceTabData,
     ) {
-        if let Some((_, DragContent::EditorTab(from_id, from_index, child, _))) =
+        if let Some((_, _, DragContent::EditorTab(from_id, from_index, child, _))) =
             Arc::make_mut(&mut data.drag).take()
         {
             let editor_tab = data

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -955,8 +955,11 @@ impl Widget<LapceTabData> for PanelSwitcher {
                         let (kind, icon) = &self.icons[i];
                         let offset =
                             mouse_event.pos.to_vec2() - icon.rect.origin().to_vec2();
-                        *Arc::make_mut(&mut data.drag) =
-                            Some((offset, DragContent::Panel(*kind, icon.rect)));
+                        *Arc::make_mut(&mut data.drag) = Some((
+                            offset,
+                            mouse_event.window_pos.to_vec2(),
+                            DragContent::Panel(*kind, icon.rect),
+                        ));
                     }
                 }
                 self.mouse_pos = mouse_event.pos;

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -485,15 +485,15 @@ impl LapceTab {
 
     fn paint_drag(&self, ctx: &mut PaintCtx, data: &LapceTabData) {
         if let Some((offset, start, drag_content)) = data.drag.as_ref() {
+            if (self.mouse_pos.x - start.x).abs() < 5.
+                && (self.mouse_pos.y - start.y).abs() < 5.
+            {
+                // debounce accidental drags
+                return;
+            }
             match drag_content {
                 DragContent::EditorTab(_, _, _, tab_rect) => {
                     let rect = tab_rect.rect.with_origin(self.mouse_pos - *offset);
-                    if (self.mouse_pos.x - start.x).abs() < 5.
-                        && (self.mouse_pos.y - start.y).abs() < 5.
-                    {
-                        // debounce accidental drags
-                        return;
-                    }
                     let size = rect.size();
                     let shadow_width = data.config.ui.drop_shadow_width() as f64;
                     if shadow_width > 0.0 {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -425,7 +425,7 @@ impl LapceTab {
     }
 
     fn handle_panel_drop(&mut self, _ctx: &mut EventCtx, data: &mut LapceTabData) {
-        if let Some((_, DragContent::Panel(kind, _))) = data.drag.as_ref() {
+        if let Some((_, _, DragContent::Panel(kind, _))) = data.drag.as_ref() {
             let rects = self.panel_rects();
             for (p, rect) in rects.iter() {
                 if rect.contains(self.mouse_pos) {
@@ -465,7 +465,7 @@ impl LapceTab {
     }
 
     fn paint_drag_on_panel(&self, ctx: &mut PaintCtx, data: &LapceTabData) {
-        if let Some((_, DragContent::Panel(_, _))) = data.drag.as_ref() {
+        if let Some((_, _, DragContent::Panel(_, _))) = data.drag.as_ref() {
             let rects = self.panel_rects();
             for (_, rect) in rects.iter() {
                 if rect.contains(self.mouse_pos) {
@@ -475,7 +475,7 @@ impl LapceTab {
                             .config
                             .get_color_unchecked(LapceTheme::EDITOR_CURRENT_LINE)
                             .clone()
-                            .with_alpha(0.8),
+                            .with_alpha(0.0), // 3
                     );
                     break;
                 }
@@ -484,10 +484,16 @@ impl LapceTab {
     }
 
     fn paint_drag(&self, ctx: &mut PaintCtx, data: &LapceTabData) {
-        if let Some((offset, drag_content)) = data.drag.as_ref() {
+        if let Some((offset, start, drag_content)) = data.drag.as_ref() {
             match drag_content {
                 DragContent::EditorTab(_, _, _, tab_rect) => {
                     let rect = tab_rect.rect.with_origin(self.mouse_pos - *offset);
+                    if (self.mouse_pos.x - start.x).abs() < 5.
+                        && (self.mouse_pos.y - start.y).abs() < 5.
+                    {
+                        // debounce accidental drags
+                        return;
+                    }
                     let size = rect.size();
                     let shadow_width = data.config.ui.drop_shadow_width() as f64;
                     if shadow_width > 0.0 {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -475,7 +475,7 @@ impl LapceTab {
                             .config
                             .get_color_unchecked(LapceTheme::EDITOR_CURRENT_LINE)
                             .clone()
-                            .with_alpha(0.0), // 3
+                            .with_alpha(0.8),
                     );
                     break;
                 }


### PR DESCRIPTION
This is my idea of how to fix #886. The drag data keeps track of the start position, and we don't paint the editor tab unless it's 5px away from the initial mouse down event.  It would need to be updated to include other draggable items, mainly the file picker tab. Right now it does still paint the stationary tab highlight, which isn't as jarring as seeing the entire tab move a tiny bit when you just meant to click on it. It should be cleaned up a bit.

It now handles the file picker tabs, but the rectangle indicating the drag target still flashes sometimes on small drags.