### PR TITLE
Properly jump to line-col for search; Make line jumping not rely on the buffer being immediately open

### DIFF
--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -25,6 +25,7 @@ use xi_rope::{spans::Spans, Rope};
 use crate::alert::AlertContentData;
 use crate::data::LapceWorkspace;
 use crate::document::BufferContent;
+use crate::editor::{Line, LineCol};
 use crate::menu::MenuKind;
 use crate::rich_text::RichText;
 use crate::{
@@ -428,6 +429,18 @@ pub enum LapceUICommand {
         locations: Vec<(WidgetId, EditorLocation)>,
         edits: Option<Rope>,
     },
+    InitBufferContentLine {
+        path: PathBuf,
+        content: Rope,
+        locations: Vec<(WidgetId, EditorLocation<Line>)>,
+        edits: Option<Rope>,
+    },
+    InitBufferContentLineCol {
+        path: PathBuf,
+        content: Rope,
+        locations: Vec<(WidgetId, EditorLocation<LineCol>)>,
+        edits: Option<Rope>,
+    },
     /// Init buffer content but using lsp positions instead
     InitBufferContentLsp {
         path: PathBuf,
@@ -594,12 +607,8 @@ pub enum LapceUICommand {
     JumpToLine(Option<WidgetId>, usize),
     JumpToLocation(Option<WidgetId>, EditorLocation),
     JumpToLspLocation(Option<WidgetId>, EditorLocation<Position>),
-    JumpToLineColumnPath {
-        editor_view_id: Option<WidgetId>,
-        path: PathBuf,
-        line: usize,
-        column: usize,
-    },
+    JumpToLineLocation(Option<WidgetId>, EditorLocation<Line>),
+    JumpToLineColLocation(Option<WidgetId>, EditorLocation<LineCol>),
     TerminalJumpToLine(i32),
     GoToLocationNew(WidgetId, EditorLocation),
     GotoDefinition {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -57,7 +57,7 @@ use crate::{
         SplitInfo, TabsInfo, WindowInfo, WorkspaceInfo,
     },
     document::{BufferContent, Document, LocalBufferKind},
-    editor::{EditorLocation, EditorPosition, LapceEditorBufferData, TabRect},
+    editor::{EditorLocation, EditorPosition, LapceEditorBufferData, Line, TabRect},
     explorer::FileExplorerData,
     find::Find,
     hover::HoverData,
@@ -2546,8 +2546,6 @@ impl LapceMainSplitData {
         }
     }
 
-    // TODO: This function assumes the buffer is already loaded, which is typically the case
-    // but is not always and we may want it to be able to properly jump to a specific line in a doc
     pub fn jump_to_line(
         &mut self,
         ctx: &mut EventCtx,
@@ -2562,53 +2560,18 @@ impl LapceMainSplitData {
         } else {
             None
         };
-        let view_id = editor.view_id;
 
-        let doc = self.editor_doc(view_id);
-        let offset = doc.buffer().first_non_blank_character_on_line(if line > 0 {
-            line - 1
-        } else {
-            0
-        });
+        let position = Line(line);
 
         if let Some(path) = path {
             let location = EditorLocation {
                 path,
-                position: Some(offset),
+                position: Some(position),
                 scroll_offset: None,
                 history: None,
             };
             self.jump_to_location(ctx, editor_view_id, location, config);
         }
-    }
-
-    pub fn jump_to_line_column_path(
-        &mut self,
-        ctx: &mut EventCtx,
-        editor_view_id: Option<WidgetId>,
-        path: PathBuf,
-        line: usize,
-        column: usize,
-        config: &Config,
-    ) {
-        let editor_view_id = self
-            .get_editor_or_new(
-                ctx,
-                editor_view_id,
-                Some(path.clone()),
-                false,
-                config,
-            )
-            .view_id;
-        let doc = self.editor_doc(editor_view_id);
-        let offset = doc.buffer().offset_of_line_col(line, column);
-        let location = EditorLocation {
-            path,
-            position: Some(offset),
-            scroll_offset: None,
-            history: None,
-        };
-        self.jump_to_location(ctx, Some(editor_view_id), location, config);
     }
 }
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -111,6 +111,57 @@ impl EditorPosition for usize {
         }
     }
 }
+
+/// Jump to first non blank character on a line
+/// (If you want to jump to the very first character then use `LineCol` with column set to 0)
+#[derive(Debug, Clone, Copy)]
+pub struct Line(pub usize);
+impl EditorPosition for Line {
+    fn to_utf8_offset(&self, buffer: &Buffer) -> Option<usize> {
+        Some(buffer.first_non_blank_character_on_line(self.0.saturating_sub(1)))
+    }
+
+    fn init_buffer_content_cmd(
+        path: PathBuf,
+        content: Rope,
+        locations: Vec<(WidgetId, EditorLocation<Self>)>,
+        edits: Option<Rope>,
+    ) -> LapceUICommand {
+        LapceUICommand::InitBufferContentLine {
+            path,
+            content,
+            locations,
+            edits,
+        }
+    }
+}
+
+/// UTF8 line and column-offset
+#[derive(Debug, Clone, Copy)]
+pub struct LineCol {
+    pub line: usize,
+    pub column: usize,
+}
+impl EditorPosition for LineCol {
+    fn to_utf8_offset(&self, buffer: &Buffer) -> Option<usize> {
+        Some(buffer.offset_of_line_col(self.line, self.column))
+    }
+
+    fn init_buffer_content_cmd(
+        path: PathBuf,
+        content: Rope,
+        locations: Vec<(WidgetId, EditorLocation<Self>)>,
+        edits: Option<Rope>,
+    ) -> LapceUICommand {
+        LapceUICommand::InitBufferContentLineCol {
+            path,
+            content,
+            locations,
+            edits,
+        }
+    }
+}
+
 impl EditorPosition for Position {
     fn to_utf8_offset(&self, buffer: &Buffer) -> Option<usize> {
         buffer.offset_of_position(self)

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -10,6 +10,7 @@ use lapce_data::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
     config::LapceTheme,
     data::LapceTabData,
+    editor::{EditorLocation, LineCol},
     panel::PanelKind,
 };
 
@@ -88,12 +89,18 @@ impl SearchContent {
                 if i == n {
                     ctx.submit_command(Command::new(
                         LAPCE_UI_COMMAND,
-                        LapceUICommand::JumpToLineColumnPath {
-                            editor_view_id: None,
-                            path: path.clone(),
-                            line: line_number.saturating_sub(1),
-                            column: *start,
-                        },
+                        LapceUICommand::JumpToLineColLocation(
+                            None,
+                            EditorLocation {
+                                path: path.clone(),
+                                position: Some(LineCol {
+                                    line: line_number.saturating_sub(1),
+                                    column: *start,
+                                }),
+                                scroll_offset: None,
+                                history: None,
+                            },
+                        ),
                         Target::Widget(data.id),
                     ));
                     return;


### PR DESCRIPTION
This fixes *another* issue I introduced in that move to offsets PR.  
Search would jump to a line column but it tried translating that before the buffer was guaranteed to be available, and so opening a search in a file that did not exist would just put you at the start.  
This fixes that, using the generics for `EditorPosition` (now I'm very glad I didn't duplicate the code, the generics make it easier).  
This also makes so the jump-to-line (or, rather, jump to first character on line) uses `EditorPosition` too. This doesn't help much at the moment, because Ctrl+G is always used on a file you already have open, but it will avoid that being a confusing bug later on if we allow syntax like Ctrl+P, `file.rs:42`.  
It also makes the `InitBufferContent` commands call a function, because they were all the same and just depended on the generic parameter.  