### PR TITLE
temporary patch for slow start

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -195,7 +195,14 @@ impl LapceData {
             );
             let _ = event_sink.submit_command(
                 LAPCE_UI_COMMAND,
-                LapceUICommand::UpdateDisabledPlugins(catalog.disabled.clone()),
+                LapceUICommand::UpdateUninstalledPluginDescriptions(
+                    PluginLoadingStatus::Loading,
+                ),
+                Target::Auto,
+            );
+            let _ = event_sink.submit_command(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::UpdateInstalledPlugins(catalog.items.clone()),
                 Target::Auto,
             );
             if let Ok(fetched_plugins) = LapceData::load_plugin_descriptions() {

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -76,11 +76,12 @@ impl Dispatcher {
         };
         *dispatcher.file_watcher.lock() = Some(FileWatcher::new(dispatcher.clone()));
         dispatcher.lsp.lock().dispatcher = Some(dispatcher.clone());
-
         let local_dispatcher = dispatcher.clone();
         thread::spawn(move || {
             local_dispatcher.plugins.lock().reload();
             let plugins = { local_dispatcher.plugins.lock().items.clone() };
+            let delay = std::time::Duration::from_millis(50);
+            std::thread::sleep(delay);
             local_dispatcher.send_notification(
                 "installed_plugins",
                 json!({
@@ -92,7 +93,6 @@ impl Dispatcher {
                 .lock()
                 .start_all(local_dispatcher.clone());
         });
-
         let local_dispatcher = dispatcher.clone();
         thread::spawn(move || {
             if let Some(path) = BaseDirs::new().map(|d| PathBuf::from(d.home_dir()))

--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -211,7 +211,6 @@ impl Widget<LapceTabData> for Plugin {
                     if let Some((plugin, status)) =
                         self.hit_test(ctx, data, mouse_event)
                     {
-                        println!("{:?}", status.to_string());
                         if status == PluginStatus::Install
                             || status == PluginStatus::Upgrade
                         {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -943,31 +943,42 @@ impl LapceTab {
                         data.disabled_plugins = Arc::new(plugins.to_owned());
                     }
                     LapceUICommand::UpdatePluginInstallationChange(plugins) => {
-                        let local_plugins = plugins.clone();
-                        let handle = std::thread::spawn(move || {
-                            if let Ok(fetched_plugins) =
-                                LapceData::load_plugin_descriptions()
-                            {
-                                let (installed, uninstalled): (
-                                    Vec<PluginDescription>,
-                                    Vec<PluginDescription>,
-                                ) = fetched_plugins.into_iter().partition(|p| {
-                                    local_plugins
-                                        .iter()
-                                        .find(|(_, ip)| ip.name == p.name)
-                                        .ok_or(())
-                                        .is_ok()
+                        if let PluginLoadingStatus::Ok(ref installed_plugins_desc) =
+                            *data.installed_plugins_desc
+                        {
+                            if installed_plugins_desc.len() != plugins.len() {
+                                let local_plugins = plugins.clone();
+                                let handle = std::thread::spawn(move || {
+                                    if let Ok(fetched_plugins) =
+                                        LapceData::load_plugin_descriptions()
+                                    {
+                                        let (installed, uninstalled): (
+                                            Vec<PluginDescription>,
+                                            Vec<PluginDescription>,
+                                        ) = fetched_plugins.into_iter().partition(
+                                            |p| {
+                                                local_plugins
+                                                    .iter()
+                                                    .find(|(_, ip)| {
+                                                        ip.name == p.name
+                                                    })
+                                                    .ok_or(())
+                                                    .is_ok()
+                                            },
+                                        );
+                                        return Ok((installed, uninstalled));
+                                    }
+                                    Err(())
                                 });
-                                return Ok((installed, uninstalled));
+                                let fetch_result = handle.join().unwrap_or(Err(()));
+                                if let Ok((installed, uninstalled)) = fetch_result {
+                                    data.installed_plugins_desc =
+                                        Arc::new(PluginLoadingStatus::Ok(installed));
+                                    data.uninstalled_plugins_desc = Arc::new(
+                                        PluginLoadingStatus::Ok(uninstalled),
+                                    );
+                                }
                             }
-                            Err(())
-                        });
-                        let fetch_result = handle.join().unwrap_or(Err(()));
-                        if let Ok((installed, uninstalled)) = fetch_result {
-                            data.installed_plugins_desc =
-                                Arc::new(PluginLoadingStatus::Ok(installed));
-                            data.uninstalled_plugins_desc =
-                                Arc::new(PluginLoadingStatus::Ok(uninstalled));
                         }
                     }
                     LapceUICommand::DisablePlugin(plugin) => {


### PR DESCRIPTION
Temporarily fix #900 by preventing the initial call to update the plugin list in the dispatcher when lapce starts. The editor will still freeze for a while when installing/removing plugins. When the proxy refactor is done I'll move the code from the UI thread to the proxy to prevent blocking the UI thread.

Edit: the previous patch will cause the plugin panel to be blank when opening a new folder. Instead, I introduce a small delay in the dispatcher to allow the plugin loading thread in lapce-data to load the plugin in the background first so the editor will still be responsive when starts for the first time. The editor will still freeze when opening new folders, and installing and removing plugins.