### PR TITLE
Use recv when receiving messages and stop checking when the channel closes

### DIFF
--- a/lapce-proxy/src/plugin.rs
+++ b/lapce-proxy/src/plugin.rs
@@ -248,7 +248,7 @@ impl PluginCatalog {
         let (tx, rx) = mpsc::channel();
 
         thread::spawn(move || loop {
-            match rx.try_recv() {
+            match rx.recv() {
                 Ok(PluginTransmissionMessage::Initialize) => {
                     let initialize = local_plugin
                         .instance
@@ -283,7 +283,9 @@ impl PluginCatalog {
                     }
                     break;
                 }
-                _ => {}
+                // There was an error when receiving, which means that the other end was closed.
+                // So we simply shutdown this thread by breaking out of the loop
+                Err(_) => break,
             }
         });
         tx.send(PluginTransmissionMessage::Initialize)?;


### PR DESCRIPTION
The channel receiving code for the plugins (introduced to allow enabling/disabling them) was using `try_recv` (which would unnecessarily execute nothing when there was no messages, and it is on a separate thread so `recv` is the better choice since we just want to wait for a message). As well, it would ignore the error of the channel closing on the other end, which would cause it to do nothing forever in an infinite loop. This would cause 100% CPU usage for that thread.