### PR TITLE
Fix hotkey for redo

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -65,7 +65,7 @@ command = "scroll_down"
 # ------------------------------------ Multi cursor -------------------------------------
 
 [[keymaps]]
-key = "alt+I"
+key = "alt+shift+i"
 command = "insert_cursor_end_of_line"
 mode = "i"
 
@@ -263,7 +263,7 @@ mode = "niv"
 when = "!search_focus && !modal_focus"
 
 [[keymaps]]
-key="Ctrl+c"
+key="ctrl+c"
 command = "normal_mode"
 mode = "niv"
 when = "!search_focus && !modal_focus"

--- a/defaults/keymaps-macos.toml
+++ b/defaults/keymaps-macos.toml
@@ -5,7 +5,7 @@ key = "meta+p"
 command = "palette"
 
 [[keymaps]]
-key = "meta+P"
+key = "meta+shift+p"
 command = "palette.command"
 
 [[keymaps]]
@@ -28,7 +28,7 @@ key = "meta+z"
 command = "undo"
 
 [[keymaps]]
-key = "meta+Z"
+key = "meta+shift+z"
 command = "redo"
 
 [[keymaps]]
@@ -131,7 +131,7 @@ command = "select_current_line"
 mode = "i"
 
 [[keymaps]]
-key = "meta+L"
+key = "meta+shift+l"
 command = "select_all_current"
 mode = "i"
 
@@ -197,19 +197,19 @@ command = "show_code_actions"
 # --------------------------------- Display -------------------------------------------
 
 [[keymaps]]
-key = "meta+E"
+key = "meta+shift+e"
 command = "toggle_file_explorer_focus"
 
 [[keymaps]]
-key = "meta+F"
+key = "meta+shift+f"
 command = "toggle_search_focus"
 
 [[keymaps]]
-key = "meta+X"
+key = "meta+shift+x"
 command = "toggle_plugin_focus"
 
 [[keymaps]]
-key = "meta+M"
+key = "meta+shift+m"
 command = "toggle_problem_focus"
 
 # ------------------------------------ Navigation -------------------------------------
@@ -223,7 +223,7 @@ key = "meta+down"
 command = "document_end"
 
 [[keymaps]]
-key = "meta+O"
+key = "meta+shift+o"
 command = "palette.symbol"
 
 [[keymaps]]

--- a/defaults/keymaps-nonmacos.toml
+++ b/defaults/keymaps-nonmacos.toml
@@ -5,7 +5,7 @@ key = "ctrl+p"
 command = "palette"
 
 [[keymaps]]
-key = "Ctrl+P"
+key = "ctrl+shift+p"
 command = "palette.command"
 
 [[keymaps]]
@@ -29,7 +29,7 @@ command = "undo"
 mode = "i"
 
 [[keymaps]]
-key = "ctrl+Z"
+key = "ctrl+shift+z"
 command = "redo"
 mode = "i"
 
@@ -192,19 +192,19 @@ command = "show_code_actions"
 # --------------------------------- Display -------------------------------------------
 
 [[keymaps]]
-key = "ctrl+E"
+key = "ctrl+shift+e"
 command = "toggle_file_explorer_focus"
 
 [[keymaps]]
-key = "ctrl+F"
+key = "ctrl+shift+f"
 command = "toggle_search_focus"
 
 [[keymaps]]
-key = "ctrl+X"
+key = "ctrl+shift+x"
 command = "toggle_plugin_focus"
 
 [[keymaps]]
-key = "ctrl+M"
+key = "ctrl+shift+m"
 command = "toggle_problem_focus"
 
 # ------------------------------------ Navigation -------------------------------------
@@ -218,7 +218,7 @@ key = "Ctrl+End"
 command = "document_end"
 
 [[keymaps]]
-key = "ctrl+O"
+key = "ctrl+shift+o"
 command = "palette.symbol"
 
 [[keymaps]]

--- a/lapce-data/src/keypress/keypress.rs
+++ b/lapce-data/src/keypress/keypress.rs
@@ -46,6 +46,17 @@ impl KeyPress {
         false
     }
 
+    pub fn to_lowercase(&self) -> Self {
+        let key = match &self.key {
+            druid::KbKey::Character(c) => druid::KbKey::Character(c.to_lowercase()),
+            _ => self.key.clone(),
+        };
+        Self {
+            key,
+            mods: self.mods,
+        }
+    }
+
     pub fn paint(
         &self,
         ctx: &mut PaintCtx,

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -279,17 +279,8 @@ impl KeyPressData {
 
     fn get_key_modifiers(key_event: &KeyEvent) -> Modifiers {
         // We only care about some modifiers
-        let mut mods = (Modifiers::ALT
-            | Modifiers::CONTROL
-            | Modifiers::SHIFT
-            | Modifiers::META)
-            & key_event.mods;
-
-        if matches!(key_event.key, KbKey::Shift | KbKey::Character(_)) {
-            mods.set(Modifiers::SHIFT, false);
-        }
-
-        mods
+        (Modifiers::ALT | Modifiers::CONTROL | Modifiers::SHIFT | Modifiers::META)
+            & key_event.mods
     }
 
     pub fn keypress(key_event: &KeyEvent) -> Option<KeyPress> {
@@ -402,9 +393,11 @@ impl KeyPressData {
         keypresses: &[KeyPress],
         check: &T,
     ) -> KeymapMatch {
+        let keypresses: Vec<KeyPress> =
+            keypresses.iter().map(KeyPress::to_lowercase).collect();
         let matches = self
             .keymaps
-            .get(keypresses)
+            .get(&keypresses)
             .map(|keymaps| {
                 keymaps
                     .iter()


### PR DESCRIPTION
On Mac when a character is pressed along with shift and
command, the character returned is not the upper case
variant.  This code allows recognition of "Redo", command-
shift-z, to work.