### PR TITLE
fix: replace toml-rs with toml_edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "config"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,7 +2295,7 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.2",
  "thiserror",
- "toml",
+ "toml_edit",
  "unicode-segmentation",
  "unicode-width",
  "uuid",
@@ -2323,7 +2333,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.140",
  "serde_json",
- "toml",
+ "toml_edit",
  "trash",
  "wasmer",
  "wasmer-wasi",
@@ -2389,7 +2399,7 @@ dependencies = [
  "structdesc",
  "strum 0.24.1",
  "strum_macros 0.24.2",
- "toml",
+ "toml_edit",
  "unicode-segmentation",
  "unicode-width",
  "winres",
@@ -4454,7 +4464,18 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
+ "serde 1.0.140",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
  "indexmap",
+ "itertools",
  "serde 1.0.140",
 ]
 

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -48,7 +48,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 lsp-types = { version = "0.93", features = ["proposed"] }
 druid = { git = "https://github.com/lapce/druid", branch = "shell_opengl", features = [ "svg", "im", "serde", ] }
 # druid = { path = "../../druid/druid", features = ["svg", "im" , "serde"] }
-toml = { version = "0.5.8", features = ["preserve_order"] }
+toml_edit = { version = "0.14.4", features = ["easy"] }
 structdesc = { git = "https://github.com/lapce/structdesc" }
 #structdesc = { path = "../../structdesc" }
 lapce-core = { path = "../lapce-core" }

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use structdesc::FieldNames;
 use thiserror::Error;
+use toml_edit::easy as toml;
 
 use crate::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -41,6 +41,7 @@ use lsp_types::{Diagnostic, DiagnosticSeverity, Position, ProgressToken, TextEdi
 use notify::Watcher;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use toml_edit::easy as toml;
 use xi_rope::{Rope, RopeDelta};
 
 use crate::{

--- a/lapce-data/src/keypress/loader.rs
+++ b/lapce-data/src/keypress/loader.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use indexmap::IndexMap;
 use lapce_core::mode::Modes;
+use toml_edit::easy as toml;
 
 use crate::keypress::{get_modes, keypress::KeyPress, KeyMap};
 

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -15,7 +15,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use lapce_core::mode::{Mode, Modes};
-use toml;
+use toml_edit::easy as toml;
 
 mod keypress;
 mod loader;

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -31,7 +31,7 @@ jsonrpc-lite = "0.5.0"
 serde_json = "1.0.59"
 anyhow = "1.0.32"
 home = "0.5.3"
-toml = "0.5.6"
+toml_edit = { version = "0.14.4", features = ["easy"] }
 git2 = { version = "0.14.4", features = ["vendored-openssl"] }
 lapce-core = { path = "../lapce-core" }
 lapce-rpc = { path = "../lapce-rpc" }

--- a/lapce-proxy/src/plugin.rs
+++ b/lapce-proxy/src/plugin.rs
@@ -15,7 +15,7 @@ use std::sync::mpsc;
 use std::sync::mpsc::Sender;
 use std::thread;
 use std::time::Duration;
-use toml;
+use toml_edit::easy as toml;
 use wasmer::ChainableNamedResolver;
 use wasmer::ImportObject;
 use wasmer::Store;

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -45,7 +45,7 @@ fuzzy-matcher = "0.3.7"
 lsp-types = { version = "0.93", features = ["proposed"] }
 druid = { git = "https://github.com/lapce/druid", branch = "shell_opengl", features = [ "svg", "im", "serde", ] }
 # druid = { path = "../../druid/druid", features = ["svg", "im" , "serde"] }
-toml = { version = "0.5.8", features = ["preserve_order"] }
+toml_edit = { version = "0.14.4", features = ["easy"] }
 structdesc = { git = "https://github.com/lapce/structdesc" }
 lapce-core = { path = "../lapce-core" }
 lapce-data = { path = "../lapce-data" }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -41,6 +41,7 @@ use lapce_data::{
 use lapce_rpc::plugin::PluginDescription;
 use lsp_types::DiagnosticSeverity;
 use serde::Deserialize;
+use toml_edit::easy as toml;
 use xi_rope::Rope;
 
 use crate::{


### PR DESCRIPTION
toml-rs is abandoned and not fixed anymore, it also has a bug
that in certain cases might prevent plugins getting installed
because of struct serialization, where `Value` is seralized
in alphabetical order and certain keys end after table which
is incorrect in Toml

this is also the reason why `cargo` switched to `toml_edit`
and I think it would be good to follow same dependencies as
cargo