### PR TITLE
Open editors when applying text edits via code actions

### DIFF
--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -46,7 +46,7 @@ use xi_rope::{
 };
 
 use crate::{
-    command::{LapceUICommand, LAPCE_UI_COMMAND},
+    command::{InitBufferContentCb, LapceUICommand, LAPCE_UI_COMMAND},
     config::{Config, LapceTheme},
     data::{EditorDiagnostic, EditorView},
     editor::{EditorLocation, EditorPosition},
@@ -563,6 +563,7 @@ impl Document {
         &mut self,
         locations: Vec<(WidgetId, EditorLocation<P>)>,
         unsaved_buffer: Option<Rope>,
+        cb: Option<InitBufferContentCb>,
     ) {
         if self.loaded || *self.load_started.borrow() {
             return;
@@ -585,6 +586,7 @@ impl Document {
                                 Rope::from(resp.content),
                                 locations,
                                 unsaved_buffer,
+                                cb,
                             ),
                             Target::Widget(tab_id),
                         );

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -20,7 +20,9 @@ use crate::palette::PaletteData;
 use crate::proxy::path_from_url;
 use crate::proxy::RequestError;
 use crate::{
-    command::{EnsureVisiblePosition, LapceUICommand, LAPCE_UI_COMMAND},
+    command::{
+        EnsureVisiblePosition, InitBufferContent, LapceUICommand, LAPCE_UI_COMMAND,
+    },
     split::SplitMoveDirection,
 };
 use crate::{find::Find, split::SplitDirection};
@@ -103,12 +105,12 @@ impl EditorPosition for usize {
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         unsaved_buffers: Option<Rope>,
     ) -> LapceUICommand {
-        LapceUICommand::InitBufferContent {
+        LapceUICommand::InitBufferContent(InitBufferContent {
             path,
             content,
             locations,
             edits: unsaved_buffers,
-        }
+        })
     }
 }
 
@@ -127,12 +129,12 @@ impl EditorPosition for Line {
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         edits: Option<Rope>,
     ) -> LapceUICommand {
-        LapceUICommand::InitBufferContentLine {
+        LapceUICommand::InitBufferContentLine(InitBufferContent {
             path,
             content,
             locations,
             edits,
-        }
+        })
     }
 }
 
@@ -153,12 +155,12 @@ impl EditorPosition for LineCol {
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         edits: Option<Rope>,
     ) -> LapceUICommand {
-        LapceUICommand::InitBufferContentLineCol {
+        LapceUICommand::InitBufferContentLineCol(InitBufferContent {
             path,
             content,
             locations,
             edits,
-        }
+        })
     }
 }
 
@@ -173,12 +175,12 @@ impl EditorPosition for Position {
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         edits: Option<Rope>,
     ) -> LapceUICommand {
-        LapceUICommand::InitBufferContentLsp {
+        LapceUICommand::InitBufferContentLsp(InitBufferContent {
             path,
             content,
             locations,
             edits,
-        }
+        })
     }
 }
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1,3 +1,4 @@
+use crate::command::InitBufferContentCb;
 use crate::command::LapceCommand;
 use crate::command::LAPCE_COMMAND;
 use crate::command::LAPCE_SAVE_FILE_AS;
@@ -90,6 +91,7 @@ pub trait EditorPosition: Sized {
         content: Rope,
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         edits: Option<Rope>,
+        cb: Option<InitBufferContentCb>,
     ) -> LapceUICommand;
 }
 
@@ -104,12 +106,14 @@ impl EditorPosition for usize {
         content: Rope,
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         unsaved_buffers: Option<Rope>,
+        cb: Option<InitBufferContentCb>,
     ) -> LapceUICommand {
         LapceUICommand::InitBufferContent(InitBufferContent {
             path,
             content,
             locations,
             edits: unsaved_buffers,
+            cb,
         })
     }
 }
@@ -128,12 +132,14 @@ impl EditorPosition for Line {
         content: Rope,
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         edits: Option<Rope>,
+        cb: Option<InitBufferContentCb>,
     ) -> LapceUICommand {
         LapceUICommand::InitBufferContentLine(InitBufferContent {
             path,
             content,
             locations,
             edits,
+            cb,
         })
     }
 }
@@ -154,12 +160,14 @@ impl EditorPosition for LineCol {
         content: Rope,
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         edits: Option<Rope>,
+        cb: Option<InitBufferContentCb>,
     ) -> LapceUICommand {
         LapceUICommand::InitBufferContentLineCol(InitBufferContent {
             path,
             content,
             locations,
             edits,
+            cb,
         })
     }
 }
@@ -174,12 +182,14 @@ impl EditorPosition for Position {
         content: Rope,
         locations: Vec<(WidgetId, EditorLocation<Self>)>,
         edits: Option<Rope>,
+        cb: Option<InitBufferContentCb>,
     ) -> LapceUICommand {
         LapceUICommand::InitBufferContentLsp(InitBufferContent {
             path,
             content,
             locations,
             edits,
+            cb,
         })
     }
 }
@@ -338,7 +348,11 @@ impl LapceEditorBufferData {
         self.hover.status != HoverStatus::Inactive && !self.hover.is_empty()
     }
 
-    pub fn run_code_action(&mut self, action: &CodeActionOrCommand) {
+    pub fn run_code_action(
+        &mut self,
+        ctx: &mut EventCtx,
+        action: &CodeActionOrCommand,
+    ) {
         if let BufferContent::File(path) = &self.editor.content {
             match action {
                 CodeActionOrCommand::Command(_cmd) => {}
@@ -346,49 +360,57 @@ impl LapceEditorBufferData {
                     if let Some(edit) = action.edit.as_ref() {
                         if let Some(edits) = workspace_edits(edit) {
                             for (url, edits) in edits {
-                                // TODO: Neither of these methods work for paths
-                                // on different filesystems (i.e. windows and linux),
-                                // as pathbuf is meant to represent a path on the host
-                                let mut matches = false;
-                                // This handles windows drive letters, which rust-url doesn't do.
-                                if let Ok(url_path) = url.to_file_path() {
-                                    matches |= &url_path == path;
-                                }
-                                // This is the previous check, to ensure this isn't a regression
-                                if let Ok(path_url) = Url::from_file_path(path) {
-                                    matches |= path_url == url;
-                                }
-                                if matches {
+                                if url_matches_path(path, &url) {
                                     let path = path.clone();
                                     let doc = self
                                         .main_split
                                         .open_docs
-                                        .get_mut(&path)
-                                        .unwrap();
-                                    let edits = edits
-                                        .iter()
-                                        .map(|edit| {
-                                            let selection =
-                                            lapce_core::selection::Selection::region(
-                                                doc.buffer().offset_of_position(
-                                                    &edit.range.start,
-                                                )?,
-                                                doc.buffer().offset_of_position(
-                                                    &edit.range.end,
-                                                )?,
-                                            );
-                                            Some((selection, edit.new_text.as_str()))
-                                        })
-                                        .collect::<Option<Vec<_>>>();
-                                    if let Some(edits) = edits {
-                                        self.main_split.edit(
-                                            &path,
-                                            &edits,
-                                            lapce_core::editor::EditType::Other,
-                                        );
-                                    } else {
-                                        log::error!("Failed to convert code action edit Position to offset");
-                                    }
+                                        .get(&path)
+                                        .unwrap()
+                                        .clone();
+                                    apply_code_action(
+                                        &doc,
+                                        &mut self.main_split,
+                                        &path,
+                                        &edits,
+                                    );
+                                } else if let Ok(url_path) = url.to_file_path() {
+                                    // If it is not for the file we have open then we assume that
+                                    // we may have to load it
+                                    // So we jump to the location that the edits were at.
+                                    // TODO: url_matches_path checks if the url path 'goes back' to the original url
+                                    // Should we do that here?
+
+                                    // We choose to just jump to the start of the first edit. The edit function will jump
+                                    // appropriately when we actually apply the edits.
+                                    let position =
+                                        edits.get(0).map(|edit| edit.range.start);
+                                    self.main_split.jump_to_location_cb(
+                                        ctx,
+                                        None,
+                                        EditorLocation {
+                                            path: url_path.clone(),
+                                            position,
+                                            scroll_offset: None,
+                                            history: None,
+                                        },
+                                        &self.config,
+                                        // Note: For some reason Rust is unsure about what type the arguments are if we don't specify them
+                                        // Perhaps this could be fixed by being very explicit about the lifetimes in the jump_to_location_cb fn?
+                                        Some(move |_: &mut EventCtx, main_split: &mut LapceMainSplitData| {
+                                            // The file has been loaded, so we want to apply the edits now.
+                                            let doc = if let Some(doc) = main_split.open_docs.get(&url_path) {
+                                                doc.clone()
+                                            } else {
+                                                log::warn!("Failed to load URL-path {url_path:?} properly. It was loaded but was not able to be found, which might indicate cross platform path confusion issues.");
+                                                return;
+                                            };
+
+                                            apply_code_action(&doc, main_split, &url_path, &edits);
+                                        }),
+                                    );
+                                } else {
+                                    log::warn!("Text edits failed to apply to URL {url:?} because it was not found");
                                 }
                             }
                         }
@@ -2302,4 +2324,46 @@ fn workspace_edits(edit: &WorkspaceEdit) -> Option<HashMap<Url, Vec<TextEdit>>> 
             .collect::<HashMap<Url, Vec<TextEdit>>>(),
     };
     Some(edits)
+}
+
+/// Check if a [`Url`] matches the path
+fn url_matches_path(path: &Path, url: &Url) -> bool {
+    // TODO: Neither of these methods work for paths
+    // on different filesystems (i.e. windows and linux),
+    // as pathbuf is meant to represent a path on the host
+    let mut matches = false;
+    // This handles windows drive letters, which rust-url doesn't do.
+    if let Ok(url_path) = url.to_file_path() {
+        matches |= url_path == path;
+    }
+    // This is the previous check, to ensure this isn't a regression
+    if let Ok(path_url) = Url::from_file_path(path) {
+        matches |= &path_url == url;
+    }
+
+    matches
+}
+
+fn apply_code_action(
+    doc: &Document,
+    main_split: &mut LapceMainSplitData,
+    path: &Path,
+    edits: &[TextEdit],
+) {
+    let edits = edits
+        .iter()
+        .map(|edit| {
+            let selection = lapce_core::selection::Selection::region(
+                doc.buffer().offset_of_position(&edit.range.start)?,
+                doc.buffer().offset_of_position(&edit.range.end)?,
+            );
+            Some((selection, edit.new_text.as_str()))
+        })
+        .collect::<Option<Vec<_>>>();
+
+    if let Some(edits) = edits {
+        main_split.edit(path, &edits, lapce_core::editor::EditType::Other);
+    } else {
+        log::error!("Failed to convert code action edit Position to offset");
+    }
 }

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -189,7 +189,7 @@ impl LapceEditorView {
     ) {
         match cmd {
             LapceUICommand::RunCodeAction(action) => {
-                data.run_code_action(action);
+                data.run_code_action(ctx, action);
             }
             LapceUICommand::EnsureCursorVisible(position) => {
                 self.ensure_cursor_visible(ctx, data, panel, position.as_ref(), env);

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use druid::{
     kurbo::Line,
@@ -27,7 +27,7 @@ use lapce_data::{
         LapceWorkspace, LapceWorkspaceType, WorkProgress,
     },
     document::{BufferContent, LocalBufferKind},
-    editor::{EditorLocation, EditorPosition},
+    editor::EditorLocation,
     hover::HoverStatus,
     keypress::{DefaultKeyPressHandler, KeyPressData},
     menu::MenuKind,
@@ -733,50 +733,17 @@ impl LapceTab {
                         }
                         ctx.show_context_menu::<LapceData>(menu, *point);
                     }
-                    LapceUICommand::InitBufferContent {
-                        path,
-                        content,
-                        locations,
-                        edits,
-                    } => {
-                        init_buffer_content(
-                            ctx,
-                            data,
-                            path,
-                            content,
-                            locations,
-                            edits.as_ref(),
-                        );
+                    LapceUICommand::InitBufferContent(init) => {
+                        init.execute(ctx, data)
                     }
-                    LapceUICommand::InitBufferContentLsp {
-                        path,
-                        content,
-                        locations,
-                        edits,
-                    } => {
-                        init_buffer_content(
-                            ctx,
-                            data,
-                            path,
-                            content,
-                            locations,
-                            edits.as_ref(),
-                        );
+                    LapceUICommand::InitBufferContentLine(init) => {
+                        init.execute(ctx, data)
                     }
-                    LapceUICommand::InitBufferContentLineCol {
-                        path,
-                        content,
-                        locations,
-                        edits,
-                    } => {
-                        init_buffer_content(
-                            ctx,
-                            data,
-                            path,
-                            content,
-                            locations,
-                            edits.as_ref(),
-                        );
+                    LapceUICommand::InitBufferContentLineCol(init) => {
+                        init.execute(ctx, data)
+                    }
+                    LapceUICommand::InitBufferContentLsp(init) => {
+                        init.execute(ctx, data)
                     }
                     LapceUICommand::InitPaletteInput(pattern) => {
                         let doc = data
@@ -2318,36 +2285,4 @@ impl Widget<LapceTabData> for LapceTabHeader {
             );
         }
     }
-}
-
-fn init_buffer_content<P: EditorPosition + Clone + Send + 'static>(
-    ctx: &mut EventCtx,
-    data: &mut LapceTabData,
-    path: &Path,
-    content: &Rope,
-    locations: &[(WidgetId, EditorLocation<P>)],
-    edits: Option<&Rope>,
-) {
-    let doc = data.main_split.open_docs.get_mut(path).unwrap();
-    let doc = Arc::make_mut(doc);
-    doc.init_content(content.to_owned());
-
-    if let Some(rope) = edits {
-        doc.reload(rope.clone(), false);
-    }
-    if let BufferContent::File(path) = doc.content() {
-        if let Some(d) = data.main_split.diagnostics.get(path) {
-            doc.set_diagnostics(d);
-        }
-    }
-
-    for (view_id, location) in locations {
-        data.main_split.go_to_location(
-            ctx,
-            Some(*view_id),
-            location.clone(),
-            &data.config,
-        );
-    }
-    ctx.set_handled();
 }


### PR DESCRIPTION
This makes so when applying edits via code actions it will open files that it references.  
Previously, we would just ignore edits that reference other files, which was incorrect.  
One example where this occurs is:
- Create a new file in a rust project
- `Ctrl+.` inside that new file gives code actions to add `mod filename;` to the `lib.rs`/`main.rs` file so that it is recognized as part of the rust project.  
- Previously this would simply do nothing. With the PR, it will open the file if it isn't already open (because we need the file to apply the edit!) and apply the edit, letting the user save with the edits if they wish.  
  
The first commit switches to using a structure for `InitBufferContent`, since they were sharing literally all fields (and I was going to be adding yet another). It also moves the behavior function onto the structure, since it is obviously related to it.  
  
The second commit adds a callback parameter which is executed when the buffer is finally loaded. It is called immediately if the file is already open, otherwise given to the `InitBufferContent` structure and called when it finished. This then lets us just wait until the buffer is loaded and editor is opened, and then applies the edits.