### PR TITLE
Don't show autocomplete after backspacing over whitespace

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1348,17 +1348,21 @@ impl LapceEditorBufferData {
         let show_completion = match cmd {
             EditCommand::DeleteBackward | EditCommand::DeleteForward => {
                 let start = match &deltas[0].0.els[0] {
-                    xi_rope::DeltaElement::Copy(_, end) => end,
-                    _ => &0,
+                    xi_rope::DeltaElement::Copy(_, end) => Some(end),
+                    _ => None,
                 };
         
                 let end = match &deltas[0].0.els[1] {
-                    xi_rope::DeltaElement::Copy(start, _) => start,
-                    _ => &0,
+                    xi_rope::DeltaElement::Copy(start, _) => Some(start),
+                    _ => None,
                 };
-        
-                let slice = &doc_old[*start..*end];
-                !slice.chars().all(|c| c.is_whitespace() || c.is_ascii_whitespace())
+
+                if start.is_some() && end.is_some() {
+                    let slice = &doc_old[*start.unwrap()..*end.unwrap()];
+                    !slice.chars().all(|c| c.is_whitespace() || c.is_ascii_whitespace())
+                } else {
+                    true
+                }
             },
             EditCommand::InsertNewLine
             | EditCommand::InsertTab

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1348,22 +1348,24 @@ impl LapceEditorBufferData {
         let show_completion = match cmd {
             EditCommand::DeleteBackward | EditCommand::DeleteForward => {
                 let start = match &deltas[0].0.els[0] {
-                    xi_rope::DeltaElement::Copy(_, end) => Some(end),
-                    _ => None,
-                };
-        
-                let end = match &deltas[0].0.els[1] {
-                    xi_rope::DeltaElement::Copy(start, _) => Some(start),
-                    _ => None,
+                    xi_rope::DeltaElement::Copy(_, start) => start,
+                    _ => &0,
                 };
 
-                if start.is_some() && end.is_some() {
-                    let slice = &doc_old[*start.unwrap()..*end.unwrap()];
-                    !slice.chars().all(|c| c.is_whitespace() || c.is_ascii_whitespace())
+                let end = match &deltas[0].0.els[1] {
+                    xi_rope::DeltaElement::Copy(end, _) => end,
+                    _ => &0,
+                };
+
+                if start > &0 && end > &0 && end > start {
+                    let slice = &doc_old[*start..*end];
+                    !slice
+                        .chars()
+                        .all(|c| c.is_whitespace() || c.is_ascii_whitespace())
                 } else {
                     true
                 }
-            },
+            }
             EditCommand::InsertNewLine
             | EditCommand::InsertTab
             | EditCommand::NewLineAbove
@@ -1372,7 +1374,7 @@ impl LapceEditorBufferData {
             | EditCommand::Redo => false,
             _ => true,
         };
-        
+
         if show_completion {
             self.update_completion(ctx, false);
         }


### PR DESCRIPTION
Fixes #743 
Added `EditCommand::DeleteBackward` and `EditCommand::DeleteForward` to the match statement that checks for whitespace commands. On receiving one of these commands the deleted string gets checked if it's all whitespace.

Added `EditCommand::Undo` and `EditCommand::Redo` to the check, because i think it's not necessary to show autocompletion after an undo or redo.

Maybe it would make sense to extract this into a function?