### PR TITLE
feat: add LapceUICommand::OpenURI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,6 +2587,7 @@ dependencies = [
  "log 0.4.17",
  "lsp-types",
  "notify",
+ "open",
  "parking_lot 0.11.2",
  "rayon",
  "regex",
@@ -3196,6 +3197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23a407004a1033f53e93f9b45580d14de23928faad187384f891507c9b0c045"
+dependencies = [
+ "pathdiff",
+ "windows-sys",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3351,12 @@ name = "paste"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pathfinder_geometry"

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -465,6 +465,7 @@ pub enum LapceUICommand {
     SetWorkspace(LapceWorkspace),
     SetTheme(String, bool),
     UpdateKeymap(KeyMap, Vec<KeyPress>),
+    OpenURI(String),
     OpenFile(PathBuf),
     OpenFileDiff(PathBuf, String),
     CancelCompletion(usize),

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -40,9 +40,12 @@ xi-rope = { git = "https://github.com/lapce/xi-editor", features = ["serde"] }
 xi-unicode = "0.3.0"
 fuzzy-matcher = "0.3.7"
 lsp-types = { version = "0.93", features = ["proposed"] }
+toml_edit = { version = "0.14.4", features = ["easy"] }
+open = { version = "3.0.2", features = [] }
+
+# lapce deps
 druid = { git = "https://github.com/lapce/druid", branch = "shell_opengl", features = [ "svg", "im", "serde", ] }
 # druid = { path = "../../druid/druid", features = ["svg", "im" , "serde"] }
-toml_edit = { version = "0.14.4", features = ["easy"] }
 structdesc = { git = "https://github.com/lapce/structdesc" }
 lapce-core = { path = "../lapce-core" }
 lapce-data = { path = "../lapce-data" }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1223,6 +1223,20 @@ impl LapceTab {
                     LapceUICommand::UpdateKeymap(keymap, keys) => {
                         KeyPressData::update_file(keymap, keys);
                     }
+                    LapceUICommand::OpenURI(uri) => {
+                        ctx.set_handled();
+                        if !uri.is_empty() {
+                            log::debug!(target: "lapce_ui::tab::handle_event::open_uri", "uri: {uri}");
+                            match open::that(uri) {
+                                Ok(_) => {
+                                    log::debug!(target: "lapce_ui::tab::handle_event::open_uri", "successfully opened URI: {uri}")
+                                }
+                                Err(e) => {
+                                    log::error!(target: "lapce_ui::tab::handle_event::open_uri", "{e}")
+                                }
+                            }
+                        }
+                    }
                     LapceUICommand::OpenFile(path) => {
                         data.main_split.jump_to_location(
                             ctx,


### PR DESCRIPTION
This is base for multiple other commands we can have in future like `Open Setting location`, `Reveal this file/folder in File Explorer` etc. and URLs in terminal/editor/UI

This was originally part of icon theme PR but I'm trying to decouple it into more smaller PRs so they can get merged already 