### PR TITLE
fix: add *bsd targets

### DIFF
--- a/lapce-data/src/update.rs
+++ b/lapce-data/src/update.rs
@@ -100,7 +100,7 @@ pub fn extract(src: &Path, process_path: &Path) -> Result<PathBuf> {
     Ok(dest.join("Lapce.app"))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 pub fn extract(src: &Path, process_path: &Path) -> Result<PathBuf> {
     let tar_gz = std::fs::File::open(src)?;
     let tar = flate2::read::GzDecoder::new(tar_gz);
@@ -134,7 +134,7 @@ pub fn restart(path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 pub fn restart(path: &Path) -> Result<()> {
     use std::os::unix::process::CommandExt;
     std::process::Command::new(path).exec();
@@ -185,7 +185,7 @@ pub fn update(_process_id: &str, src: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 pub fn update(_process_id: &str, src: &Path, dest: &Path) -> Result<()> {
     let tar_gz = std::fs::File::open(src)?;
     let tar = flate2::read::GzDecoder::new(tar_gz);

--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -17,7 +17,7 @@ use lapce_data::{
 use crate::logging::override_log_levels;
 use crate::window::LapceWindow;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 const LOGO_PNG: &[u8] = include_bytes!("../../extra/images/logo.png");
 #[cfg(target_os = "windows")]
 const LOGO_ICO: &[u8] = include_bytes!("../../extra/windows/lapce.ico");
@@ -154,7 +154,7 @@ fn window_icon() -> Option<druid::Icon> {
     None
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 fn window_icon() -> Option<druid::Icon> {
     let image = image::load_from_memory(LOGO_PNG)
         .expect("Invalid Icon")

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -749,7 +749,10 @@ pub fn window_controls(
     ));
 
     let mut svgs = Vec::new();
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux")
+        || cfg!(target_os = "freebsd")
+        || cfg!(target_os = "openbsd")
+    {
         let minimize_rect = Size::new(width, width)
             .to_rect()
             .with_origin(Point::new(x, 0.0))


### PR DESCRIPTION
`target_family = "unix"` includes all Unix-like systems, like *BSD, etc.