### PR TITLE
fix: rework titlebar

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -2,6 +2,7 @@
 modal = false
 color-theme = "Lapce Dark"
 icon-theme = ""
+custom-titlebar = true
 
 [editor]
 font-family = "Cascadia Code"
@@ -39,7 +40,6 @@ tab-min-width = 100
 scroll-width = 10
 drop-shadow-width = 0
 preview-editor-width = 0
-custom-titlebar = false
 hover-font-family = ""
 hover-font-size = 0
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -150,6 +150,10 @@ pub struct LapceConfig {
     pub modal: bool,
     #[field_names(desc = "Set the color theme of Lapce")]
     pub color_theme: String,
+    #[field_names(
+        desc = "Enable customised titlebar and disable OS native one (Linux, BSD, Windows)"
+    )]
+    pub custom_titlebar: bool,
 }
 
 #[derive(FieldNames, Debug, Clone, Deserialize, Serialize, Default)]

--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -121,17 +121,22 @@ fn new_window_desc<W, T: druid::Data>(
     size: Size,
     pos: Point,
     maximised: bool,
-    _config: &Arc<Config>,
+    config: &Arc<Config>,
 ) -> WindowDesc<T>
 where
     W: Widget<T> + 'static,
 {
     let mut desc = WindowDesc::new_with_id(window_id, root)
-        .show_titlebar(false)
         .title(LocalizedString::new("Lapce").with_placeholder("Lapce"))
         .with_min_size(Size::new(384.0, 384.0))
         .window_size(size)
         .set_position(pos);
+
+    if cfg!(not(target_os = "macos")) {
+        desc = desc.show_titlebar(!config.lapce.custom_titlebar);
+    } else {
+        desc = desc.show_titlebar(false);
+    }
 
     if maximised {
         desc = desc.set_window_state(WindowState::Maximized);

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -650,7 +650,9 @@ impl Widget<LapceTabData> for Title {
                 }
             }
             Event::MouseDown(mouse_event) => {
-                self.mouse_down(ctx, mouse_event);
+                if mouse_event.button.is_left() {
+                    self.mouse_down(ctx, mouse_event);
+                }
             }
             Event::MouseUp(mouse_event) => {
                 if !data.multiple_tab


### PR DESCRIPTION
- moved `custom-titlebar` into `lapce` otherwise theme plugins will modify that setting
- adjusted other icons sizes in titlebar to match with minimise/maximise/close
- added hover effect for window controls, with close button having distinct red background color
- replaced font based icons on Windows with SVGs
- activate buttons on left click **only**

fixes #997 