### PR TITLE
CI: disable MacOS release in forked repos.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
           retention-days: 1
 
   macos:
+    if: github.repository == 'lapce/lapce'
     runs-on: macos-11
     needs: tagname
     env:


### PR DESCRIPTION
I'd like to point out that everyone who forks the repo will get an email every night for a failing MacOS release build. That's because a certificate needs to be configured for it to work. Here is the failing step:

```
Import Certificate 0s
1 > Run apple-actions/import-codesign-certs@v1
11 Error: At least one of p12-filepath or p12-file-base64 must be provided
```

I'm posting the quick fix to disable it in forked repos. More elaborate solution is to add a job that checks whether a certificate is provided and to only run the `macos` job depending on that. Like here for example: https://github.com/vector-im/element-ios/pull/5496/files

Besides, perhaps it's worth reconsidering running the cron job every night? It seems a bit wasteful to have that run in every single forked repository as well, especially since it takes over 30 to 40 minutes to build one release for each system. Should I open a new issue?