### PR TITLE
fix: align settings button size to window controls

### DIFF
--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -380,7 +380,7 @@ impl Title {
         let settings_svg = get_svg("settings.svg").unwrap();
         self.svgs.push((
             settings_svg,
-            settings_rect.inflate(-10.5, -10.5),
+            settings_rect.inflate(-10.0, -10.0),
             Some(
                 data.config
                     .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/50457605/187314951-e27bf535-cfe8-4dd6-933c-ea663b0f2753.png)
after:
![image](https://user-images.githubusercontent.com/50457605/187315121-509be945-114e-44d9-8478-d37bb80d974d.png)

other:
![image](https://user-images.githubusercontent.com/50457605/187315000-e89409af-84f0-4ce1-8df1-06cf4a5b8ce3.png)
![image](https://user-images.githubusercontent.com/50457605/187315281-bb44aa16-e08e-439a-b00c-38f686c87981.png)

