### PR TITLE
fix: hover on empty split links

### DIFF
--- a/lapce-ui/src/split.rs
+++ b/lapce-ui/src/split.rs
@@ -1070,21 +1070,6 @@ impl Widget<LapceTabData> for LapceSplit {
     ) {
         match event {
             Event::MouseMove(mouse_event) => {
-                if self.children.is_empty() {
-                    let mut on_command = false;
-                    for (_, _, rect, _) in &self.commands {
-                        if rect.contains(mouse_event.pos) {
-                            on_command = true;
-                            break;
-                        }
-                    }
-                    if on_command {
-                        ctx.set_cursor(&druid::Cursor::Pointer);
-                    } else {
-                        ctx.clear_cursor();
-                    }
-                }
-
                 if ctx.is_active() {
                     // If we're active then we're probably being dragged
                     self.update_resize_point(mouse_event.pos);
@@ -1115,6 +1100,16 @@ impl Widget<LapceTabData> for LapceSplit {
                         ctx.clear_cursor();
                     }
                 }
+
+                if self.children.is_empty() {
+                    for (_, _, rect, _) in &self.commands {
+                        if rect.contains(mouse_event.pos) {
+                            ctx.set_cursor(&druid::Cursor::Pointer);
+                            break;
+                        }
+                    }
+                }
+                ctx.request_paint();
             }
             Event::MouseDown(mouse_event) => {
                 if mouse_event.button.is_left() {


### PR DESCRIPTION
Current implementation doesn't work, presumably because paint is not requested and it gets reset to default cursor in drag logic later.