### PR TITLE
Add emptiness check for editor font family field

### DIFF
--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -221,7 +221,11 @@ pub struct EditorConfig {
 
 impl EditorConfig {
     pub fn font_family(&self) -> FontFamily {
-        FontFamily::new_unchecked(self.font_family.clone())
+        if self.font_family.is_empty() {
+            FontFamily::SYSTEM_UI
+        } else {
+            FontFamily::new_unchecked(self.font_family.clone())
+        }
     }
 
     pub fn inlay_hint_font_family(&self) -> FontFamily {


### PR DESCRIPTION
My first pull request!

Currently, there is an issue #918 where if you leave the font family field in the Editor Settings empty, Lapce keeps trying to open an empty font which doesn't exist, causing the editor to become unusable. The problem was that this font_family function didn't have a guard for the field being empty like the font_family function in the UI settings.