### PR TITLE
Add JS/TS ESM and CJS extensions

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -211,7 +211,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         comment: "//",
         indent: "  ",
         code_lens: (&["source_file", "program"], &["source_file"]),
-        extensions: &["js"],
+        extensions: &["js", "cjs", "mjs"],
     },
     #[cfg(feature = "lang-javascript")]
     SyntaxProperties {
@@ -231,7 +231,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         comment: "//",
         indent: "    ",
         code_lens: (&["source_file", "program"], &["source_file"]),
-        extensions: &["ts"],
+        extensions: &["ts", "cts", "mts"],
     },
     #[cfg(feature = "lang-typescript")]
     SyntaxProperties {


### PR DESCRIPTION
.cjs and .mjs extensions are not recognized as JS/TS files.

More info: https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions