### PR TITLE
Add keybindings for `Shift-Del`, `Shift-Ins`, `Ctrl-Ins`

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -22,11 +22,6 @@ command = "delete_forward"
 mode = "i"
 
 [[keymaps]]
-key = "shift+Delete"
-command = "delete_forward"
-mode = "i"
-
-[[keymaps]]
 key = "backspace"
 command = "delete_backward"
 mode = "i"

--- a/defaults/keymaps-nonmacos.toml
+++ b/defaults/keymaps-nonmacos.toml
@@ -45,12 +45,27 @@ command = "clipboard_cut"
 mode = "i"
 
 [[keymaps]]
+key = "shift+Delete"
+command = "clipboard_cut"
+mode = "i"
+
+[[keymaps]]
 key = "ctrl+c"
 command = "clipboard_copy"
 mode = "i"
 
 [[keymaps]]
+key = "ctrl+insert"
+command = "clipboard_copy"
+mode = "i"
+
+[[keymaps]]
 key = "ctrl+v"
+command = "clipboard_paste"
+mode = "i"
+
+[[keymaps]]
+key = "shift+insert"
 command = "clipboard_paste"
 mode = "i"
 


### PR DESCRIPTION
These are probably less known, but AFAIK they work in Gtk apps, VS, VS Code and even older IDEs like Delphi and Turbo/Borland Pascal. Probably inherited from WordStar.

I _think_ I've seen `Shift-Del` working like Backspace once, but never as Del.

CC @MinusGix from https://github.com/lapce/lapce/issues/662