### PR TITLE
Don't clone paths when collecting diag items

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2237,7 +2237,7 @@ impl LapceMainSplitData {
                     None
                 }
             })
-            .sorted_by_key(|(path, _)| (*path).clone())
+            .sorted_by_key(|(path, _)| *path)
             .collect()
     }
 


### PR DESCRIPTION
The usual papercut perf thingy :) 