### PR TITLE
Don't clone strings when looking up font family

### DIFF
--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -307,7 +307,7 @@ impl UIConfig {
         if self.font_family.is_empty() {
             FontFamily::SYSTEM_UI
         } else {
-            FontFamily::new_unchecked(self.font_family.clone())
+            FontFamily::new_unchecked(self.font_family.as_str())
         }
     }
 
@@ -345,7 +345,7 @@ impl UIConfig {
         if self.hover_font_family.is_empty() {
             self.font_family()
         } else {
-            FontFamily::new_unchecked(self.hover_font_family.clone())
+            FontFamily::new_unchecked(self.hover_font_family.as_str())
         }
     }
 


### PR DESCRIPTION
The strings are immediately converted into an `Arc<str>` so this should save an allocation on each call.