### PR TITLE
Check if flaptak-spawn --host works before attempting to use it

### DIFF
--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -334,6 +334,7 @@ fn set_locale_environment() {
     std::env::set_var("LC_ALL", locale + ".UTF-8");
 }
 
+#[inline]
 #[cfg(not(target_os = "linux"))]
 fn flatpak_get_default_host_shell() -> String {
     panic!(
@@ -342,6 +343,7 @@ fn flatpak_get_default_host_shell() -> String {
     );
 }
 
+#[inline]
 #[cfg(target_os = "linux")]
 fn flatpak_get_default_host_shell() -> String {
     let env_string = Command::new("flatpak-spawn")
@@ -365,11 +367,13 @@ fn flatpak_get_default_host_shell() -> String {
     "/bin/sh".to_string()
 }
 
+#[inline]
 #[cfg(not(target_os = "linux"))]
 fn flatpak_should_use_host_terminal() -> bool {
     false // Flatpak is only available on Linux
 }
 
+#[inline]
 #[cfg(target_os = "linux")]
 fn flatpak_should_use_host_terminal() -> bool {
     use std::path::Path;


### PR DESCRIPTION
Users may have manually removed the org.freedestkop.Flatpak session
bus talk name from permissions, in which case flatpak-spawn --host
won't work.

Closes https://github.com/lapce/lapce/issues/1133

---

This is not the cleanest solution to this problem, but without pulling in something like zbus I think this is the best we can do.