### PR TITLE
fix: create directory tree before plugin download

### DIFF
--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -806,6 +806,11 @@ pub fn download_volt(volt: VoltInfo, wasm: bool) -> Result<VoltMetadata> {
         let url = url.join(wasm)?;
         {
             let mut resp = reqwest::blocking::get(url)?;
+            if let Some(path) = path.join(&wasm).parent() {
+                if !path.exists() {
+                    fs::DirBuilder::new().recursive(true).create(path)?;
+                }
+            }
             let mut file = fs::OpenOptions::new()
                 .create(true)
                 .truncate(true)


### PR DESCRIPTION
Fixes plugin installation when `wasm` specifies any kind of directory tree