### PR TITLE
dep: replace tree-sitter-json crate with git repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5100,9 +5100,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-json"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b04c4e1a92139535eb9fca4ec8fa9666cc96b618005d3ae35f3c957fa92f92"
+version = "0.20.0"
+source = "git+https://github.com/tree-sitter/tree-sitter-json.git?rev=11e2cc12d9b267766fb11a06e52952792fd8e3f0#11e2cc12d9b267766fb11a06e52952792fd8e3f0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -32,7 +32,9 @@ tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", 
 tree-sitter-ruby = { git = "https://github.com/Liberatys/tree-sitter-ruby.git", branch = "chore/allow-range-of-tree-sitter", optional = true  }
 tree-sitter-c = { version = "0.20.1", optional = true }
 tree-sitter-cpp = { version = "0.20.0", optional = true }
-tree-sitter-json = { version = "0.19.0", optional = true }
+# new version cannot be published on crates.io - https://github.com/tree-sitter/tree-sitter-json/issues/21
+# tree-sitter-json = { version = "0.19.0", optional = true }
+tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json.git", rev = "11e2cc12d9b267766fb11a06e52952792fd8e3f0", optional = true }
 tree-sitter-md = { git = "https://github.com/MDeiml/tree-sitter-markdown.git", branch = "split_parser", optional = true }
 tree-sitter-html = { version = "0.19.0", optional = true }
 tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git", version = "0.20.0", optional = true  }


### PR DESCRIPTION
Replacing crate with git repo because maintainers have no permission to publish new crate versions