### PR TITLE
lapce-proxy: fix flatpak host detection

### DIFF
--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -381,13 +381,15 @@ fn flatpak_should_use_host_terminal() -> bool {
     const FLATPAK_INFO_PATH: &str = "/.flatpak-info";
 
     // Ensure flatpak-spawn --host can execute a basic command
-    let host_available = Command::new("flatpak-spawn")
+    let host_available = match Command::new("flatpak-spawn")
         .arg("--host")
         .arg("true")
-        .status()
-        .unwrap();
+        .status() {
+            Ok(status) => status.success(),
+            Err(_) => false
+        };
 
     /* The de-facto way of checking whether one is inside of a Flatpak container is by checking for
     the presence of /.flatpak-info in the filesystem */
-    Path::new(FLATPAK_INFO_PATH).exists() && host_available.success()
+    Path::new(FLATPAK_INFO_PATH).exists() && host_available
 }


### PR DESCRIPTION
Fix an issue with @Newbytee's flatpak host detection, where if the editor was launched outside a flatpak container, the terminal would fail to open with the following error:

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', lapce-proxy/src/terminal.rs:388:10
```