### PR TITLE
lapce-proxy: fix flatpak host detection

### DIFF
--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -380,6 +380,12 @@ fn flatpak_should_use_host_terminal() -> bool {
 
     const FLATPAK_INFO_PATH: &str = "/.flatpak-info";
 
+    // The de-facto way of checking whether one is inside of a Flatpak container is by checking for
+    // the presence of /.flatpak-info in the filesystem
+    if !Path::new(FLATPAK_INFO_PATH).exists() {
+        return false;
+    }
+
     // Ensure flatpak-spawn --host can execute a basic command
     let host_available = Command::new("flatpak-spawn")
         .arg("--host")
@@ -387,7 +393,5 @@ fn flatpak_should_use_host_terminal() -> bool {
         .status()
         .unwrap();
 
-    // The de-facto way of checking whether one is inside of a Flatpak container is by checking for
-    // the presence of /.flatpak-info in the filesystem
-    Path::new(FLATPAK_INFO_PATH).exists() && host_available.success()
+    host_available.success()
 }

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -387,7 +387,7 @@ fn flatpak_should_use_host_terminal() -> bool {
         .status()
         .unwrap();
 
-    /* The de-facto way of checking whether one is inside of a Flatpak container is by checking for
-    the presence of /.flatpak-info in the filesystem */
+    // The de-facto way of checking whether one is inside of a Flatpak container is by checking for
+    // the presence of /.flatpak-info in the filesystem
     Path::new(FLATPAK_INFO_PATH).exists() && host_available.success()
 }

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -387,11 +387,10 @@ fn flatpak_should_use_host_terminal() -> bool {
     }
 
     // Ensure flatpak-spawn --host can execute a basic command
-    let host_available = Command::new("flatpak-spawn")
+    Command::new("flatpak-spawn")
         .arg("--host")
         .arg("true")
         .status()
-        .unwrap();
-
-    host_available.success()
+        .map(|status| status.success())
+        .unwrap_or(false)
 }


### PR DESCRIPTION
Supersedes #1157 and #1151

This PR
 - cleans up a block comment (a bit of style consistency)
 - only executes the flatpak command if the info file exists
 - does not crash on error