### PR TITLE
Window Tab improvements

### DIFF
--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -352,7 +352,7 @@ impl AppDelegate<LapceData> for LapceAppDelegate {
                             WidgetPod::new(tab_header)
                         })
                         .collect(),
-                    dragable_area: Region::EMPTY,
+                    draggable_area: Region::EMPTY,
                     tab_header_cmds: Vec::new(),
                     mouse_down_cmd: None,
                     #[cfg(not(target_os = "macos"))]

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -2467,6 +2467,7 @@ impl Widget<LapceTabData> for LapceTabHeader {
                     self.holding_click_rect = None;
                     ctx.set_active(false);
                     self.drag_start = None;
+                    ctx.request_layout();
                 }
             }
             _ => {}

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -2518,7 +2518,7 @@ impl Widget<LapceTabData> for LapceTabHeader {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, _env: &Env) {
         let tab_rect = ctx.size().to_rect();
 
-        if ctx.is_hot() {
+        if ctx.is_hot() || self.drag_start.is_some() {
             // Currenlty, we only paint background for the hot tab to prevent showing
             // overlapped content on drag. In the future, we might want to:
             // - introduce a tab background color
@@ -2588,7 +2588,7 @@ impl Widget<LapceTabData> for LapceTabHeader {
         let y = text_layout.y_offset(size.height);
         ctx.draw_text(&text_layout, Point::new(x, y));
 
-        if ctx.is_hot() {
+        if ctx.is_hot() || self.drag_start.is_some() {
             let svg = get_svg("close.svg").unwrap();
             ctx.draw_svg(
                 &svg,

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -2515,6 +2515,19 @@ impl Widget<LapceTabData> for LapceTabHeader {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, _env: &Env) {
+        if ctx.is_hot() {
+            // Currenlty, we only paint background for the hot tab to prevent showing
+            // overlapped content on drag. In the future, we might want to:
+            // - introduce a tab background color
+            // - introduce a hover color
+            let tab_rect = ctx.size().to_rect();
+            ctx.fill(
+                tab_rect,
+                data.config
+                    .get_color_unchecked(LapceTheme::PANEL_BACKGROUND),
+            );
+        }
+
         let dir = data
             .workspace
             .path

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -2515,18 +2515,39 @@ impl Widget<LapceTabData> for LapceTabHeader {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, _env: &Env) {
+        let tab_rect = ctx.size().to_rect();
+
         if ctx.is_hot() {
             // Currenlty, we only paint background for the hot tab to prevent showing
             // overlapped content on drag. In the future, we might want to:
             // - introduce a tab background color
             // - introduce a hover color
-            let tab_rect = ctx.size().to_rect();
             ctx.fill(
                 tab_rect,
                 data.config
                     .get_color_unchecked(LapceTheme::PANEL_BACKGROUND),
             );
         }
+
+        const BORDER_PADDING: f64 = 8.0;
+
+        ctx.stroke(
+            Line::new(
+                Point::new(tab_rect.x0, tab_rect.y0 + BORDER_PADDING),
+                Point::new(tab_rect.x0, tab_rect.y1 - BORDER_PADDING),
+            ),
+            data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
+            1.0,
+        );
+
+        ctx.stroke(
+            Line::new(
+                Point::new(tab_rect.x1, tab_rect.y0 + BORDER_PADDING),
+                Point::new(tab_rect.x1, tab_rect.y1 - BORDER_PADDING),
+            ),
+            data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
+            1.0,
+        );
 
         let dir = data
             .workspace

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -558,11 +558,6 @@ impl Widget<LapceWindowData> for LapceWindow {
     ) -> Size {
         let self_size = bc.max();
 
-        const TAB_HEADER_HEIGHT: f64 = 36.0;
-        const TAB_HEADER_PADDING: f64 = 0.0;
-        const RIGHT_PADDING: f64 = 100.0;
-        const WINDOW_CONTROL_BUTTON_WIDTH: f64 = 36.0;
-
         let (tab_size, tab_origin) = if self.tabs.len() > 1 {
             let tab_size = Size::new(
                 self_size.width,
@@ -672,10 +667,9 @@ impl Widget<LapceWindowData> for LapceWindow {
 
         // let title_height = self.title.layout_rect().height();
 
-        let tab_height = 36.0;
         let size = ctx.size();
         if self.tabs.len() > 1 {
-            let rect = Size::new(size.width, tab_height).to_rect();
+            let rect = Size::new(size.width, TAB_HEADER_HEIGHT).to_rect();
             ctx.fill(
                 rect,
                 data.config
@@ -735,8 +729,8 @@ impl Widget<LapceWindowData> for LapceWindow {
                 let (cmds, svgs) = window_controls(
                     data.window_id,
                     &ctx.window().get_window_state(),
-                    size.width - 36.0 * 3.0,
-                    36.0,
+                    size.width - WINDOW_CONTROL_BUTTON_WIDTH * 3.0,
+                    WINDOW_CONTROL_BUTTON_WIDTH,
                     &data.config,
                 );
                 self.tab_header_cmds = cmds;
@@ -894,3 +888,9 @@ pub fn window_controls(
 
     (commands, svgs)
 }
+
+// TODO(dbuga): find a better place for these
+const TAB_HEADER_HEIGHT: f64 = 36.0;
+const TAB_HEADER_PADDING: f64 = 0.0;
+const RIGHT_PADDING: f64 = 100.0;
+const WINDOW_CONTROL_BUTTON_WIDTH: f64 = 36.0;

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -611,7 +611,6 @@ impl Widget<LapceWindowData> for LapceWindow {
                 tab_header.set_origin(ctx, data, env, origin);
                 x += size.width;
             }
-            x += TAB_HEADER_HEIGHT;
 
             // Area right of tabs, but left of the window control buttons
             self.dragable_area = Region::from(

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -682,42 +682,6 @@ impl Widget<LapceWindowData> for LapceWindow {
                     .get_color_unchecked(LapceTheme::PANEL_BACKGROUND),
             );
 
-            fn draw_tab_header<W: Widget<LapceWindowData>>(
-                tab_header: &mut WidgetPod<LapceWindowData, W>,
-                ctx: &mut PaintCtx,
-                data: &LapceWindowData,
-                env: &Env,
-                left_border: bool,
-                right_border: bool,
-            ) {
-                const BORDER_PADDING: f64 = 8.0;
-
-                tab_header.paint(ctx, data, env);
-                let rect = tab_header.layout_rect();
-
-                if left_border {
-                    ctx.stroke(
-                        Line::new(
-                            Point::new(rect.x0, rect.y0 + BORDER_PADDING),
-                            Point::new(rect.x0, rect.y1 - BORDER_PADDING),
-                        ),
-                        data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
-                        1.0,
-                    );
-                }
-
-                if right_border {
-                    ctx.stroke(
-                        Line::new(
-                            Point::new(rect.x1, rect.y0 + BORDER_PADDING),
-                            Point::new(rect.x1, rect.y1 - BORDER_PADDING),
-                        ),
-                        data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
-                        1.0,
-                    );
-                }
-            }
-
             let mut dragged = None;
             for (i, tab_header) in self.tab_headers.iter_mut().enumerate() {
                 // Store index and skip if tab is being dragged.
@@ -726,28 +690,14 @@ impl Widget<LapceWindowData> for LapceWindow {
                     continue;
                 }
 
-                draw_tab_header(
-                    tab_header,
-                    ctx,
-                    data,
-                    env,
-                    i > 0 && dragged == Some(i - 1),
-                    true,
-                );
+                tab_header.paint(ctx, data, env);
             }
 
             // Draw the dragged tab last, above the others
             if let Some(dragged_tab_idx) = dragged {
                 let tab_header = &mut self.tab_headers[dragged_tab_idx];
 
-                // Prevent overlapped tab contents showing
-                ctx.fill(
-                    tab_header.layout_rect(),
-                    data.config
-                        .get_color_unchecked(LapceTheme::PANEL_BACKGROUND),
-                );
-
-                draw_tab_header(tab_header, ctx, data, env, true, true);
+                tab_header.paint(ctx, data, env);
             }
 
             let shadow_width = data.config.ui.drop_shadow_width() as f64;

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -620,7 +620,7 @@ impl Widget<LapceWindowData> for LapceWindow {
 
                 // Area left of the tabs
                 draggable_area.add_rect(
-                    Size::new(left_padding, 36.0)
+                    Size::new(left_padding, TAB_HEADER_HEIGHT)
                         .to_rect()
                         .with_origin(Point::ZERO),
                 );

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -681,28 +681,75 @@ impl Widget<LapceWindowData> for LapceWindow {
                 data.config
                     .get_color_unchecked(LapceTheme::PANEL_BACKGROUND),
             );
-            for (i, tab_header) in self.tab_headers.iter_mut().enumerate() {
+
+            fn draw_tab_header<W: Widget<LapceWindowData>>(
+                tab_header: &mut WidgetPod<LapceWindowData, W>,
+                ctx: &mut PaintCtx,
+                data: &LapceWindowData,
+                env: &Env,
+                left_border: bool,
+                right_border: bool,
+            ) {
+                const BORDER_PADDING: f64 = 8.0;
+
                 tab_header.paint(ctx, data, env);
                 let rect = tab_header.layout_rect();
-                if i == 0 {
+
+                if left_border {
                     ctx.stroke(
                         Line::new(
-                            Point::new(rect.x0, rect.y0 + 8.0),
-                            Point::new(rect.x0, rect.y1 - 8.0),
+                            Point::new(rect.x0, rect.y0 + BORDER_PADDING),
+                            Point::new(rect.x0, rect.y1 - BORDER_PADDING),
                         ),
                         data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
                         1.0,
                     );
                 }
-                ctx.stroke(
-                    Line::new(
-                        Point::new(rect.x1, rect.y0 + 8.0),
-                        Point::new(rect.x1, rect.y1 - 8.0),
-                    ),
-                    data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
-                    1.0,
+
+                if right_border {
+                    ctx.stroke(
+                        Line::new(
+                            Point::new(rect.x1, rect.y0 + BORDER_PADDING),
+                            Point::new(rect.x1, rect.y1 - BORDER_PADDING),
+                        ),
+                        data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
+                        1.0,
+                    );
+                }
+            }
+
+            let mut dragged = None;
+            for (i, tab_header) in self.tab_headers.iter_mut().enumerate() {
+                // Store index and skip if tab is being dragged.
+                if tab_header.widget().child().origin().is_some() {
+                    dragged = Some(i);
+                    continue;
+                }
+
+                draw_tab_header(
+                    tab_header,
+                    ctx,
+                    data,
+                    env,
+                    i > 0 && dragged == Some(i - 1),
+                    true,
                 );
             }
+
+            // Draw the dragged tab last, above the others
+            if let Some(dragged_tab_idx) = dragged {
+                let tab_header = &mut self.tab_headers[dragged_tab_idx];
+
+                // Prevent overlapped tab contents showing
+                ctx.fill(
+                    tab_header.layout_rect(),
+                    data.config
+                        .get_color_unchecked(LapceTheme::PANEL_BACKGROUND),
+                );
+
+                draw_tab_header(tab_header, ctx, data, env, true, true);
+            }
+
             let shadow_width = data.config.ui.drop_shadow_width() as f64;
             if shadow_width > 0.0 {
                 ctx.blurred_rect(


### PR DESCRIPTION
 - Prevent window tabs "sticking" when released
 - Fix undraggable area right of tabs
 - Turn magic numbers into constants
 - Prevent dragged tab overdrawing others
 - Swap tabs if dragged tab's center gets inside another tab (instead of mouse). This might be a controversial change.

Window tab code is a bit confusing as it's not obvious at all, what handles tab drags, for example. There are a number of small bugs around this area, this PR (when finished) attempts fixing those I found.