### PR TITLE
fix: Utilize active/inactive tab colors from theme

### DIFF
--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -635,9 +635,11 @@ impl TabRectRenderer for TabRect {
             let color = if data.focus_area == FocusArea::Editor
                 && Some(widget_id) == *data.main_split.active_tab
             {
-                data.config.get_color_unchecked(LapceTheme::EDITOR_CARET)
+                data.config
+                    .get_color_unchecked(LapceTheme::LAPCE_ACTIVE_TAB)
             } else {
-                data.config.get_color_unchecked(LapceTheme::EDITOR_DIM)
+                data.config
+                    .get_color_unchecked(LapceTheme::LAPCE_INACTIVE_TAB)
             };
             ctx.stroke(
                 Line::new(


### PR DESCRIPTION
Currently, neither `LapceTheme::LAPCE_ACTIVE_TAB` nor `LapceTheme::LAPCE_INACTIVE_TAB` are utilized in the [Lapce codebase](https://github.com/lapce/lapce/search?q=LAPCE_ACTIVE_TAB).

Though it would probably be more feasible to give theme color keys a well-thought rework, this quick patch would at least allow the two unused theme colors to be recognized by Lapce.
