### PR TITLE
Tone down inlay hint background color in lapce dark theme

### DIFF
--- a/defaults/dark-theme.toml
+++ b/defaults/dark-theme.toml
@@ -79,7 +79,7 @@ magenta = "#C678DD"
 "editor.link" = "$cyan"
 
 "inlay_hint.foreground" = "$white"
-"inlay_hint.background" = "#528bFF88"
+"inlay_hint.background" = "#528abF37"
 
 "error_lens.error.foreground" = "$red"
 "error_lens.error.background" = "#E06C7520"


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/977627/190010784-645445ee-4f72-429b-8431-2970f8bccbc7.png)

After:
![image](https://user-images.githubusercontent.com/977627/190010752-ac768505-37e1-43ba-a27c-6b3d932e985e.png)

I didn't touch the light theme as I think it's less obnoxious there. Disclaimer: I'm not a designer, so let's put this up to a vote.