### PR TITLE
Use theme color for install plugin button

### DIFF
--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -1,9 +1,9 @@
 use crate::{panel::PanelSizing, scroll::LapceScroll};
 use druid::{
     piet::{Text, TextAttribute, TextLayout as PietTextLayout, TextLayoutBuilder},
-    BoxConstraints, Color, Command, Cursor, Env, Event, EventCtx, FontWeight,
-    LayoutCtx, LifeCycle, LifeCycleCtx, MouseEvent, PaintCtx, Point, Rect,
-    RenderContext, Size, Target, UpdateCtx, Widget, WidgetExt, WidgetId,
+    BoxConstraints, Command, Cursor, Env, Event, EventCtx, FontWeight, LayoutCtx,
+    LifeCycle, LifeCycleCtx, MouseEvent, PaintCtx, Point, Rect, RenderContext, Size,
+    Target, UpdateCtx, Widget, WidgetExt, WidgetId,
 };
 use lapce_data::{
     command::{LapceUICommand, LAPCE_UI_COMMAND},
@@ -59,6 +59,7 @@ impl Plugin {
     fn paint_plugin(
         &mut self,
         ctx: &mut PaintCtx,
+        data: &LapceTabData,
         i: usize,
         display_name: &str,
         description: &str,
@@ -182,7 +183,10 @@ impl Plugin {
                 .to_rect()
                 .with_origin(Point::new(x, y));
 
-        ctx.fill(rect, &Color::rgb8(80, 161, 79));
+        ctx.fill(
+            rect,
+            data.config.get_color_unchecked(LapceTheme::EDITOR_CARET),
+        );
         ctx.draw_text(
             &text_layout,
             Point::new(
@@ -199,6 +203,7 @@ impl Plugin {
             let status = data.plugin.plugin_status(id);
             let rect = self.paint_plugin(
                 ctx,
+                data,
                 i,
                 &volt.display_name,
                 &volt.description,
@@ -263,6 +268,7 @@ impl Plugin {
                     let status = data.plugin.plugin_status(id);
                     let rect = self.paint_plugin(
                         ctx,
+                        data,
                         i,
                         &volt.display_name,
                         &volt.description,

--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -155,14 +155,14 @@ impl Plugin {
         let size = ctx.size();
         let padding = 10.0;
 
-        let text = if status == PluginStatus::Install {
+        let button_text = if status == PluginStatus::Install {
             status.to_string()
         } else {
             format!("{} ▼", status)
         };
         let text_layout = ctx
             .text()
-            .new_text_layout(text)
+            .new_text_layout(button_text)
             .font(config.ui.font_family(), config.ui.font_size() as f64)
             .text_color(
                 config
@@ -171,18 +171,24 @@ impl Plugin {
             )
             .build()
             .unwrap();
+
+        let button_padding = 8.0;
         let text_size = text_layout.size();
-        let text_padding = 5.0;
-        let x = size.width - text_size.width - text_padding * 2.0 - padding;
+
+        let x = size.width - text_size.width - button_padding * 2.0 - padding;
         let y = y + self.line_height * 2.0;
-        let color = Color::rgb8(80, 161, 79);
-        let rect = Size::new(text_size.width + text_padding * 2.0, self.line_height)
-            .to_rect()
-            .with_origin(Point::new(x, y));
-        ctx.fill(rect, &color);
+        let rect =
+            Size::new(text_size.width + button_padding * 2.0, self.line_height)
+                .to_rect()
+                .with_origin(Point::new(x, y));
+
+        ctx.fill(rect, &Color::rgb8(80, 161, 79));
         ctx.draw_text(
             &text_layout,
-            Point::new(x + text_padding, y + text_layout.y_offset(self.line_height)),
+            Point::new(
+                x + button_padding,
+                y + text_layout.y_offset(self.line_height),
+            ),
         );
         rect
     }


### PR DESCRIPTION
The backgound color for the install plugin buttons is currently hard-coded to `rgb(80, 161, 79)` but it should probably use a theme color.
| before | after |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/64036709/190273747-76a77205-0259-45e0-ac0e-f4839e35260c.png) | ![image](https://user-images.githubusercontent.com/64036709/190274204-887f03c2-42e5-423c-9f25-b947a1a2641d.png) |

I just used the `editor caret` color for now but it would probably make sense to add some sort of `primary button` theme color.
