### PR TITLE
Automatic line height

### DIFF
--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -166,9 +166,9 @@ pub struct EditorConfig {
     #[field_names(desc = "Set the font size in the code lens")]
     pub code_lens_font_size: usize,
     #[field_names(
-        desc = "Set the editor line height. If 0, line height will be calculated automatically"
+        desc = "Set the editor line height. If less than 5.0, line height will be a multiple of the font size."
     )]
-    line_height: usize,
+    line_height: f64,
     #[field_names(desc = "Set the tab width")]
     pub tab_width: usize,
     #[field_names(desc = "If opened editors are shown in a tab")]
@@ -229,12 +229,16 @@ pub struct EditorConfig {
 
 impl EditorConfig {
     pub fn line_height(&self) -> usize {
-        if self.line_height == 0 {
-            (self.font_size as f64 * 1.35).ceil() as usize
+        const SCALE_OR_SIZE_LIMIT: f64 = 5.0;
+
+        let line_height = if self.line_height < SCALE_OR_SIZE_LIMIT {
+            self.line_height * self.font_size as f64
         } else {
-            // Prevent overlapping lines
-            self.line_height.max(self.font_size)
-        }
+            self.line_height
+        };
+
+        // Prevent overlapping lines
+        (line_height.round() as usize).max(self.font_size)
     }
 
     pub fn font_family(&self) -> FontFamily {

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -166,7 +166,7 @@ pub struct EditorConfig {
     #[field_names(desc = "Set the font size in the code lens")]
     pub code_lens_font_size: usize,
     #[field_names(desc = "Set the editor line height")]
-    pub line_height: usize,
+    line_height: usize,
     #[field_names(desc = "Set the tab width")]
     pub tab_width: usize,
     #[field_names(desc = "If opened editors are shown in a tab")]
@@ -226,6 +226,10 @@ pub struct EditorConfig {
 }
 
 impl EditorConfig {
+    pub fn line_height(&self) -> usize {
+        self.line_height
+    }
+
     pub fn font_family(&self) -> FontFamily {
         if self.font_family.is_empty() {
             FontFamily::SYSTEM_UI

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -165,7 +165,9 @@ pub struct EditorConfig {
     pub font_size: usize,
     #[field_names(desc = "Set the font size in the code lens")]
     pub code_lens_font_size: usize,
-    #[field_names(desc = "Set the editor line height")]
+    #[field_names(
+        desc = "Set the editor line height. If 0, line height will be calculated automatically"
+    )]
     line_height: usize,
     #[field_names(desc = "Set the tab width")]
     pub tab_width: usize,
@@ -227,7 +229,11 @@ pub struct EditorConfig {
 
 impl EditorConfig {
     pub fn line_height(&self) -> usize {
-        self.line_height
+        if self.line_height == 0 {
+            (self.font_size as f64 * 1.35).ceil() as usize
+        } else {
+            self.line_height
+        }
     }
 
     pub fn font_family(&self) -> FontFamily {
@@ -1002,7 +1008,7 @@ impl Config {
         if self.terminal.line_height > 0 {
             self.terminal.line_height
         } else {
-            self.editor.line_height
+            self.editor.line_height()
         }
     }
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -232,7 +232,8 @@ impl EditorConfig {
         if self.line_height == 0 {
             (self.font_size as f64 * 1.35).ceil() as usize
         } else {
-            self.line_height
+            // Prevent overlapping lines
+            self.line_height.max(self.font_size)
         }
     }
 

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -960,7 +960,7 @@ impl LapceTabData {
         tab_size: Size,
         config: &Config,
     ) -> Point {
-        let line_height = self.config.editor.line_height as f64;
+        let line_height = self.config.editor.line_height() as f64;
 
         let editor = self.main_split.active_editor();
         let editor = match editor {
@@ -1064,7 +1064,7 @@ impl LapceTabData {
         tab_size: Size,
         config: &Config,
     ) -> Point {
-        let line_height = self.config.editor.line_height as f64;
+        let line_height = self.config.editor.line_height() as f64;
 
         let editor = self.main_split.editors.get(&self.hover.editor_view_id);
         let editor = match editor {

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1392,7 +1392,7 @@ impl Document {
         let (line, font_size) = match view {
             EditorView::Diff(version) => {
                 if let Some(history) = self.get_history(version) {
-                    let line_height = config.editor.line_height;
+                    let line_height = config.editor.line_height();
                     let mut line = 0;
                     let mut lines = 0;
                     for change in history.changes().iter() {
@@ -1435,7 +1435,7 @@ impl Document {
                     let line = lens.line_of_height(point.y.round() as usize);
                     let line_height =
                         lens.height_of_line(line + 1) - lens.height_of_line(line);
-                    let font_size = if line_height < config.editor.line_height {
+                    let font_size = if line_height < config.editor.line_height() {
                         config.editor.code_lens_font_size
                     } else {
                         config.editor.font_size
@@ -1443,14 +1443,14 @@ impl Document {
                     (line, font_size)
                 } else {
                     (
-                        (point.y / config.editor.line_height as f64).floor()
+                        (point.y / config.editor.line_height() as f64).floor()
                             as usize,
                         config.editor.font_size,
                     )
                 }
             }
             EditorView::Normal => (
-                (point.y / config.editor.line_height as f64).floor() as usize,
+                (point.y / config.editor.line_height() as f64).floor() as usize,
                 config.editor.font_size,
             ),
         };
@@ -1530,7 +1530,7 @@ impl Document {
         let (y, line_height, font_size) = match view {
             EditorView::Diff(version) => {
                 if let Some(history) = self.get_history(version) {
-                    let line_height = config.editor.line_height;
+                    let line_height = config.editor.line_height();
                     let mut current_line = 0;
                     let mut y = 0;
                     for change in history.changes().iter() {
@@ -1555,9 +1555,9 @@ impl Document {
                             }
                         }
                     }
-                    (y, config.editor.line_height, config.editor.font_size)
+                    (y, config.editor.line_height(), config.editor.font_size)
                 } else {
-                    (0, config.editor.line_height, config.editor.font_size)
+                    (0, config.editor.line_height(), config.editor.font_size)
                 }
             }
             EditorView::Lens => {
@@ -1566,7 +1566,7 @@ impl Document {
                     let height = lens.height_of_line(line);
                     let line_height =
                         lens.height_of_line(line + 1) - lens.height_of_line(line);
-                    let font_size = if line_height < config.editor.line_height {
+                    let font_size = if line_height < config.editor.line_height() {
                         config.editor.code_lens_font_size
                     } else {
                         config.editor.font_size
@@ -1574,15 +1574,15 @@ impl Document {
                     (height, line_height, font_size)
                 } else {
                     (
-                        config.editor.line_height * line,
-                        config.editor.line_height,
+                        config.editor.line_height() * line,
+                        config.editor.line_height(),
                         config.editor.font_size,
                     )
                 }
             }
             EditorView::Normal => (
-                config.editor.line_height * line,
-                config.editor.line_height,
+                config.editor.line_height() * line,
+                config.editor.line_height(),
                 config.editor.font_size,
             ),
         };
@@ -2147,7 +2147,7 @@ impl Document {
 
                                     let line_height = lens.height_of_line(line + 1)
                                         - lens.height_of_line(line);
-                                    if line_height == config.editor.line_height {
+                                    if line_height == config.editor.line_height() {
                                         break;
                                     }
                                     line -= 1;
@@ -2159,7 +2159,7 @@ impl Document {
                             let line_height = lens.height_of_line(line + 1)
                                 - lens.height_of_line(line);
                             let font_size =
-                                if line_height == config.editor.line_height {
+                                if line_height == config.editor.line_height() {
                                     config.editor.font_size
                                 } else {
                                     config.editor.code_lens_font_size
@@ -2220,7 +2220,7 @@ impl Document {
 
                                     let line_height = lens.height_of_line(line + 1)
                                         - lens.height_of_line(line);
-                                    if line_height == config.editor.line_height {
+                                    if line_height == config.editor.line_height() {
                                         break;
                                     }
                                     line += 1;
@@ -2232,7 +2232,7 @@ impl Document {
                             let line_height = lens.height_of_line(line + 1)
                                 - lens.height_of_line(line);
                             let font_size =
-                                if line_height == config.editor.line_height {
+                                if line_height == config.editor.line_height() {
                                     config.editor.font_size
                                 } else {
                                     config.editor.code_lens_font_size
@@ -2321,7 +2321,7 @@ impl Document {
                         let line_height = lens.height_of_line(line + 1)
                             - lens.height_of_line(line);
 
-                        if line_height == config.editor.line_height {
+                        if line_height == config.editor.line_height() {
                             config.editor.font_size
                         } else {
                             config.editor.code_lens_font_size
@@ -2448,7 +2448,7 @@ impl Document {
                 width = line_width;
             }
         }
-        let line_height = config.editor.line_height as f64;
+        let line_height = config.editor.line_height() as f64;
         Size::new(width, code_actions.len() as f64 * line_height)
     }
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1009,7 +1009,7 @@ impl LapceEditorBufferData {
     }
 
     fn page_move(&mut self, ctx: &mut EventCtx, down: bool, mods: Modifiers) {
-        let line_height = self.config.editor.line_height as f64;
+        let line_height = self.config.editor.line_height() as f64;
         let lines =
             (self.editor.size.borrow().height / line_height / 2.0).round() as usize;
         let distance = (lines as f64) * line_height;
@@ -1043,7 +1043,7 @@ impl LapceEditorBufferData {
         count: usize,
         mods: Modifiers,
     ) {
-        let line_height = self.config.editor.line_height as f64;
+        let line_height = self.config.editor.line_height() as f64;
         let diff = line_height * count as f64;
         let diff = if down { diff } else { -diff };
 
@@ -1115,7 +1115,7 @@ impl LapceEditorBufferData {
                 let line_height = syntax.lens.height_of_line(line + 1)
                     - syntax.lens.height_of_line(line);
 
-                let font_size = if line_height < config.editor.line_height {
+                let font_size = if line_height < config.editor.line_height() {
                     config.editor.code_lens_font_size
                 } else {
                     config.editor.font_size
@@ -1132,11 +1132,11 @@ impl LapceEditorBufferData {
 
             (line, config.char_width(text, font_size as f64))
         } else if let Some(compare) = self.editor.compare.as_ref() {
-            let line = (pos.y / config.editor.line_height as f64).floor() as usize;
+            let line = (pos.y / config.editor.line_height() as f64).floor() as usize;
             let line = self.doc.history_actual_line_from_visual(compare, line);
             (line, config.editor_char_width(text))
         } else {
-            let line = (pos.y / config.editor.line_height as f64).floor() as usize;
+            let line = (pos.y / config.editor.line_height() as f64).floor() as usize;
             (line, config.editor_char_width(text))
         };
 
@@ -1624,12 +1624,12 @@ impl LapceEditorBufferData {
             }
             SearchInView => {
                 let start_line = ((self.editor.scroll_offset.y
-                    / self.config.editor.line_height as f64)
+                    / self.config.editor.line_height() as f64)
                     .ceil() as usize)
                     .max(self.doc.buffer().last_line());
                 let end_line = ((self.editor.scroll_offset.y
                     + self.editor.size.borrow().height
-                        / self.config.editor.line_height as f64)
+                        / self.config.editor.line_height() as f64)
                     .ceil() as usize)
                     .max(self.doc.buffer().last_line());
                 let end_offset = self.doc.buffer().offset_of_line(end_line + 1);
@@ -1746,7 +1746,7 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.next_page(self.config.editor.line_height);
+                    completion.next_page(self.config.editor.line_height());
                 }
             }
             ListPrevious => {
@@ -1776,7 +1776,7 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.previous_page(self.config.editor.line_height);
+                    completion.previous_page(self.config.editor.line_height());
                 }
             }
             JumpToNextSnippetPlaceholder => {

--- a/lapce-data/src/settings.rs
+++ b/lapce-data/src/settings.rs
@@ -18,7 +18,8 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SettingsValueKind {
     String,
-    Number,
+    Integer,
+    Float,
     Bool,
 }
 

--- a/lapce-ui/src/completion.rs
+++ b/lapce-ui/src/completion.rs
@@ -220,7 +220,7 @@ impl CompletionContainer {
         env: &Env,
     ) {
         let width = ctx.size().width;
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let rect = Size::new(width, line_height)
             .to_rect()
             .with_origin(Point::new(
@@ -248,7 +248,7 @@ impl CompletionContainer {
         ctx: &mut EventCtx,
         data: &LapceTabData,
     ) {
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let point = Point::new(0.0, data.completion.index as f64 * line_height);
         if self.completion.widget_mut().inner_mut().scroll_to(point) {
             ctx.submit_command(Command::new(
@@ -503,7 +503,7 @@ impl Widget<LapceTabData> for Completion {
         data: &LapceTabData,
         _env: &Env,
     ) -> Size {
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let height = data.completion.len();
         let height = height as f64 * line_height;
         Size::new(bc.max().width, height)
@@ -513,7 +513,7 @@ impl Widget<LapceTabData> for Completion {
         if data.completion.status == CompletionStatus::Inactive {
             return;
         }
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let rect = ctx.region().bounding_box();
         let size = ctx.size();
 

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -108,7 +108,7 @@ impl LapceEditor {
             return false;
         }
 
-        let line_height = config.editor.line_height as f64;
+        let line_height = config.editor.line_height() as f64;
         let scroll_offset = editor_data.editor.scroll_offset;
         let size = *editor_data.editor.size.borrow();
 
@@ -354,7 +354,7 @@ impl LapceEditor {
         panel: &PanelData,
         env: &Env,
     ) -> Size {
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let width = data.config.editor_char_width(text);
         match &data.editor.content {
             BufferContent::File(_)
@@ -494,7 +494,7 @@ impl LapceEditor {
     ) -> ScreenLines {
         let empty_lens = Syntax::lens_from_normal_lines(
             data.doc.buffer().len(),
-            data.config.editor.line_height,
+            data.config.editor.line_height(),
             data.config.editor.code_lens_font_size,
             &[],
         );
@@ -512,7 +512,9 @@ impl LapceEditor {
         let start_line =
             lens.line_of_height(rect.y0.floor() as usize).min(last_line);
         let end_line = lens
-            .line_of_height(rect.y1.ceil() as usize + data.config.editor.line_height)
+            .line_of_height(
+                rect.y1.ceil() as usize + data.config.editor.line_height(),
+            )
             .min(last_line);
         let start_offset = data.doc.buffer().offset_of_line(start_line);
         let end_offset = data.doc.buffer().offset_of_line(end_line + 1);
@@ -524,7 +526,7 @@ impl LapceEditor {
         let mut info = HashMap::new();
         for (line, line_height) in lens.iter_chunks(start_line..end_line + 1) {
             if let Some(line_content) = lines_iter.next() {
-                let is_small = line_height < data.config.editor.line_height;
+                let is_small = line_height < data.config.editor.line_height();
                 let mut x = 0.0;
 
                 if is_small {
@@ -847,7 +849,8 @@ impl LapceEditor {
                     &text_layout,
                     Point::new(
                         0.0,
-                        text_layout.y_offset(data.config.editor.line_height as f64),
+                        text_layout
+                            .y_offset(data.config.editor.line_height() as f64),
                     ),
                 );
             }
@@ -1763,7 +1766,7 @@ impl LapceEditor {
         } else if data.editor.content.is_input() {
             env.get(LapceTheme::INPUT_LINE_HEIGHT)
         } else {
-            data.config.editor.line_height as f64
+            data.config.editor.line_height() as f64
         }
     }
 
@@ -1930,7 +1933,8 @@ impl Widget<LapceTabData> for LapceEditor {
                                         &editor_data.config,
                                     )
                                     .x;
-                                let y = editor_data.config.editor.line_height as f64
+                                let y = editor_data.config.editor.line_height()
+                                    as f64
                                     * (line + 1) as f64;
                                 ctx.to_window(Point::new(x, y))
                             });

--- a/lapce-ui/src/editor/bread_crumb.rs
+++ b/lapce-ui/src/editor/bread_crumb.rs
@@ -64,7 +64,7 @@ impl Widget<LapceTabData> for LapceEditorBreadCrumb {
         self.text_layouts.clear();
         self.svgs.clear();
 
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
 
         let font_size = data.config.ui.font_size() as f64;
 

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -49,7 +49,8 @@ impl Widget<LapceTabData> for LapceEditorGutter {
                         if rect.contains(self.mouse_down_pos)
                             && rect.contains(mouse_event.pos)
                         {
-                            let line_height = data.config.editor.line_height as f64;
+                            let line_height =
+                                data.config.editor.line_height() as f64;
                             let offset = data.editor.cursor.offset();
                             let (line, _) =
                                 data.doc.buffer().offset_to_line_col(offset);
@@ -153,7 +154,7 @@ impl LapceEditorGutter {
         let history = data.doc.get_history(version).unwrap();
         let self_size = ctx.size();
         let rect = self_size.to_rect();
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let scroll_offset = data.editor.scroll_offset;
         let start_line = (scroll_offset.y / line_height).floor() as usize;
         let end_line =
@@ -401,7 +402,7 @@ impl LapceEditorGutter {
         let scroll_offset = data.editor.scroll_offset;
         let empty_lens = Syntax::lens_from_normal_lines(
             data.doc.buffer().len(),
-            data.config.editor.line_height,
+            data.config.editor.line_height(),
             data.config.editor.code_lens_font_size,
             &[],
         );
@@ -421,7 +422,7 @@ impl LapceEditorGutter {
         let end_line = lens
             .line_of_height(
                 (scroll_offset.y + rect.height()).ceil() as usize
-                    + data.config.editor.line_height,
+                    + data.config.editor.line_height(),
             )
             .min(last_line);
         let char_width = data.config.editor_char_width(ctx.text());
@@ -440,7 +441,7 @@ impl LapceEditorGutter {
                 cursor_line - line
             };
             let content = content.to_string();
-            let is_small = line_height < data.config.editor.line_height;
+            let is_small = line_height < data.config.editor.line_height();
             let text_layout = ctx
                 .text()
                 .new_text_layout(content.clone())
@@ -484,7 +485,7 @@ impl LapceEditorGutter {
         text: &mut PietText,
         data: &LapceEditorBufferData,
     ) -> Rect {
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let offset = data.editor.cursor.offset();
         let (line, _) = data.doc.buffer().offset_to_line_col(offset);
 
@@ -527,7 +528,7 @@ impl LapceEditorGutter {
         }
 
         let size = ctx.size();
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
 
         let info = data.editor.sticky_header.borrow();
 
@@ -584,7 +585,7 @@ impl LapceEditorGutter {
                 self.paint_gutter_code_lens(data, ctx);
                 return;
             }
-            let line_height = data.config.editor.line_height as f64;
+            let line_height = data.config.editor.line_height() as f64;
             let scroll_offset = data.editor.scroll_offset;
             let start_line = (scroll_offset.y / line_height).floor() as usize;
             let num_lines = (ctx.size().height / line_height).floor() as usize;

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -607,8 +607,11 @@ impl Widget<LapceTabData> for LapceEditorView {
                         SettingsValueKind::String => {
                             Some(serde_json::json!(content))
                         }
-                        SettingsValueKind::Number => {
+                        SettingsValueKind::Integer => {
                             content.parse::<i64>().ok().map(|n| serde_json::json!(n))
+                        }
+                        SettingsValueKind::Float => {
+                            content.parse::<f64>().ok().map(|n| serde_json::json!(n))
                         }
                         SettingsValueKind::Bool => None,
                     };

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -238,7 +238,7 @@ impl LapceEditorView {
                         .scroll_by(Vec2::new(
                             0.0,
                             (new_line as f64 - line as f64)
-                                * data.config.editor.line_height as f64,
+                                * data.config.editor.line_height() as f64,
                         ));
                 }
             }
@@ -328,7 +328,7 @@ impl LapceEditorView {
     ) -> Rect {
         // TODO: scroll margin (in number of lines) should be configurable.
         const MARGIN_LINES: usize = 1;
-        let line_height = editor_config.line_height;
+        let line_height = editor_config.line_height();
 
         // The origin of a rect is its top-left corner.  Inflating a point
         // creates a rect that centers at the point.
@@ -416,7 +416,7 @@ impl LapceEditorView {
         position: Option<&EnsureVisiblePosition>,
         env: &Env,
     ) {
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let editor_size = *data.editor.size.borrow();
         let size = LapceEditor::get_size(data, ctx.text(), editor_size, panel, env);
 
@@ -469,7 +469,7 @@ impl LapceEditorView {
                 &data.config,
             )
             .x;
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
 
         let y = if data.editor.is_code_lens() {
             let empty_vec = Vec::new();
@@ -876,14 +876,14 @@ impl Widget<LapceTabData> for LapceEditorView {
         }
 
         if let Some(syntax) = editor_data.doc.syntax() {
-            if syntax.line_height != data.config.editor.line_height
+            if syntax.line_height != data.config.editor.line_height()
                 || syntax.lens_height != data.config.editor.code_lens_font_size
             {
                 let content = editor_data.doc.content().clone();
                 let tab_id = data.id;
                 let event_sink = ctx.get_external_handle();
                 let mut syntax = syntax.clone();
-                let line_height = data.config.editor.line_height;
+                let line_height = data.config.editor.line_height();
                 let lens_height = data.config.editor.code_lens_font_size;
                 rayon::spawn(move || {
                     syntax.update_lens_height(line_height, lens_height);

--- a/lapce-ui/src/hover.rs
+++ b/lapce-ui/src/hover.rs
@@ -323,7 +323,7 @@ impl Widget<LapceTabData> for Hover {
                 self.active_diagnostic_layout.layout_metrics();
 
             diagnostic_text_metrics.size.height
-                + data.config.editor.line_height as f64
+                + data.config.editor.line_height() as f64
         };
 
         Size::new(
@@ -356,7 +356,7 @@ impl Widget<LapceTabData> for Hover {
 
             let side_margin =
                 env.get(theme::SCROLLBAR_WIDTH) + env.get(theme::SCROLLBAR_PAD);
-            let line_height = data.config.editor.line_height as f64;
+            let line_height = data.config.editor.line_height() as f64;
 
             // Create a separating line
             let line = {

--- a/lapce-ui/src/picker.rs
+++ b/lapce-ui/src/picker.rs
@@ -255,7 +255,7 @@ impl Widget<LapceTabData> for FilePickerPwd {
         data: &LapceTabData,
         env: &Env,
     ) -> Size {
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let input_bc = BoxConstraints::tight(Size::new(
             bc.max().width - 20.0 - line_height - 30.0,
             bc.max().height,

--- a/lapce-ui/src/problem.rs
+++ b/lapce-ui/src/problem.rs
@@ -51,7 +51,6 @@ fn is_collapsed(data: &LapceTabData, path: &Path) -> bool {
 struct ProblemContent {
     severity: DiagnosticSeverity,
     mouse_pos: Point,
-    line_height: f64,
     content_height: f64,
 }
 
@@ -60,7 +59,6 @@ impl ProblemContent {
         Self {
             severity,
             mouse_pos: Point::ZERO,
-            line_height: 25.0,
             content_height: 0.0,
         }
     }
@@ -76,7 +74,8 @@ impl ProblemContent {
             return;
         }
 
-        let click_line = (mouse_event.pos.y / self.line_height).floor() as usize;
+        let line_height = data.config.editor.line_height() as f64;
+        let click_line = (mouse_event.pos.y / line_height).floor() as usize;
 
         let items = data.main_split.diagnostics_items(self.severity);
 

--- a/lapce-ui/src/problem.rs
+++ b/lapce-ui/src/problem.rs
@@ -296,14 +296,14 @@ impl Widget<LapceTabData> for ProblemContent {
                 }
             })
             .sum::<usize>();
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         self.content_height = line_height * lines as f64;
 
         Size::new(bc.max().width, self.content_height.max(bc.max().height))
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, _env: &Env) {
-        let line_height = data.config.editor.line_height as f64;
+        let line_height = data.config.editor.line_height() as f64;
         let padding = (line_height - 14.0) / 2.0;
         let size = ctx.size();
         let mouse_line = (self.mouse_pos.y / line_height).floor() as usize;

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -554,7 +554,11 @@ impl LapceSettingsItem {
     ) -> Self {
         let input = match &value {
             serde_json::Value::Number(n) => {
-                Some((n.to_string(), SettingsValueKind::Number))
+                if n.is_f64() {
+                    Some((n.to_string(), SettingsValueKind::Float))
+                } else {
+                    Some((n.to_string(), SettingsValueKind::Integer))
+                }
             }
             serde_json::Value::String(s) => {
                 Some((s.to_string(), SettingsValueKind::String))


### PR DESCRIPTION
Closes #1230

1.35 might be too tight, so we might want to either make it configurable directly, or provide a few presets. I think this is VSCode's default and I personally find this a good, comfortable spacing.

This PR also removes the assumption that problem panel lines are 25px high.