### PR TITLE
feat: improved multicursor selection

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -26,6 +26,8 @@ error-lens-end-of-line = true
 error-lens-font-family = ""
 error-lens-font-size = 0
 blink-interval = 500 # ms
+multicursor-case-sensitive = true
+multicursor-whole-words = true
 
 [terminal]
 font-family = ""

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -230,7 +230,7 @@ pub struct EditorConfig {
     #[field_names(
         desc = "Whether the multiple cursor selection only selects whole words."
     )]
-    pub multicursor_whole_words: bool
+    pub multicursor_whole_words: bool,
 }
 
 impl EditorConfig {

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -223,6 +223,14 @@ pub struct EditorConfig {
         desc = "Set the cursor blink interval (in milliseconds). Set to 0 to completely disable."
     )]
     pub blink_interval: u64, // TODO: change to u128 when upgrading config-rs to >0.11
+    #[field_names(
+        desc = "Whether the multiple cursor selection is case sensitive."
+    )]
+    pub multicursor_case_sensitive: bool,
+    #[field_names(
+        desc = "Whether the multiple cursor selection only selects whole words."
+    )]
+    pub multicursor_whole_words: bool
 }
 
 impl EditorConfig {

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1221,10 +1221,17 @@ impl Document {
                             (first.min(), first.max())
                         };
                         let search_str = self.buffer.slice_to_cow(start..end);
-                        let search_case_sensitive = config.editor.multicursor_case_sensitive;
-                        let search_whole_word = config.editor.multicursor_whole_words;
+                        let search_case_sensitive =
+                            config.editor.multicursor_case_sensitive;
+                        let search_whole_word =
+                            config.editor.multicursor_whole_words;
                         let mut find = Find::new(0);
-                        find.set_find(&search_str, search_case_sensitive, false, search_whole_word);
+                        find.set_find(
+                            &search_str,
+                            search_case_sensitive,
+                            false,
+                            search_whole_word,
+                        );
                         let mut offset = 0;
                         while let Some((start, end)) =
                             find.next(self.buffer.text(), offset, false, false)
@@ -1253,10 +1260,17 @@ impl Document {
                             let r = selection.last_inserted().unwrap();
                             let search_str =
                                 self.buffer.slice_to_cow(r.min()..r.max());
-                            let search_case_sensitive = config.editor.multicursor_case_sensitive;
-                            let search_whole_word = config.editor.multicursor_whole_words;
+                            let search_case_sensitive =
+                                config.editor.multicursor_case_sensitive;
+                            let search_whole_word =
+                                config.editor.multicursor_whole_words;
                             let mut find = Find::new(0);
-                            find.set_find(&search_str, search_case_sensitive, false, search_whole_word);
+                            find.set_find(
+                                &search_str,
+                                search_case_sensitive,
+                                false,
+                                search_whole_word,
+                            );
                             let mut offset = r.max();
                             let mut seen = HashSet::new();
                             while let Some((start, end)) =

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1212,8 +1212,7 @@ impl Document {
                 }
             }
             SelectAllCurrent => {
-                if let CursorMode::Insert(selection) = cursor.mode.clone() {
-                    let mut new_selection = Selection::new();
+                if let CursorMode::Insert(mut selection) = cursor.mode.clone() {
                     if !selection.is_empty() {
                         let first = selection.first().unwrap();
                         let (start, end) = if first.is_caret() {
@@ -1222,15 +1221,16 @@ impl Document {
                             (first.min(), first.max())
                         };
                         let search_str = self.buffer.slice_to_cow(start..end);
+                        let search_case_sensitive = config.editor.multicursor_case_sensitive;
+                        let search_whole_word = config.editor.multicursor_whole_words;
                         let mut find = Find::new(0);
-                        find.set_find(&search_str, false, false, false);
+                        find.set_find(&search_str, search_case_sensitive, false, search_whole_word);
                         let mut offset = 0;
                         while let Some((start, end)) =
                             find.next(self.buffer.text(), offset, false, false)
                         {
                             offset = end;
-                            new_selection
-                                .add_region(SelRegion::new(start, end, None));
+                            selection.add_region(SelRegion::new(start, end, None));
                         }
                     }
                     cursor.set_insert(selection);
@@ -1253,8 +1253,10 @@ impl Document {
                             let r = selection.last_inserted().unwrap();
                             let search_str =
                                 self.buffer.slice_to_cow(r.min()..r.max());
+                            let search_case_sensitive = config.editor.multicursor_case_sensitive;
+                            let search_whole_word = config.editor.multicursor_whole_words;
                             let mut find = Find::new(0);
-                            find.set_find(&search_str, false, false, false);
+                            find.set_find(&search_str, search_case_sensitive, false, search_whole_word);
                             let mut offset = r.max();
                             let mut seen = HashSet::new();
                             while let Some((start, end)) =


### PR DESCRIPTION
Possible implementation for #277.
I have added the option to for case sensitivity and "whole words only" for select_next_current.
To be persistent the options also affect select_all_current.
While working on it I found 2 bugs regarding select_all_current.
The first one occured because the wrong selection was used for `cursor.set_insert()`, I fixed this.
For the other one I created a new issue #1237