### PR TITLE
Minor changes of root `Cargo.toml`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
 rust-version = "1.62"
-resolver = "2"
+default-run = "lapce"
 
 [dependencies]
 lapce-ui = { path = "./lapce-ui" }


### PR DESCRIPTION
**Removed**:
- `resolver = "2"` is unnecessary due to in the 2021 edition `resolver` are by default is `2`. 

**Added**:
 - Set default crate to run by `cargo run/r` command.