### PR TITLE
fix: too long socket

### DIFF
--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -622,15 +622,15 @@ struct SshRemote {
 }
 
 impl SshRemote {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     const SSH_ARGS: &'static [&'static str] = &["-o", "ConnectTimeout=15"];
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(unix)]
     const SSH_ARGS: &'static [&'static str] = &[
         "-o",
         "ControlMaster=auto",
         "-o",
-        "ControlPath=~/.ssh/cm-%r@%h:%p",
+        "ControlPath=~/.ssh/cm_%C",
         "-o",
         "ControlPersist=30m",
         "-o",


### PR DESCRIPTION
Fixes issue when `{user}@{host}:{port}` results in too long socket path (max: ~100 characters)
`%C` is a SHA1 hash of `%l%h%p%r`

too long socket paths can happen if someone uses for example gitpod.io, e.g.:
`/Users/pj/.ssh/cm-lapce-lapce-dvqmoe3x0a0@lapce-lapce-dvqmoe3x0a0.ssh.ws-eu64.gitpod.io:22.F2aSCVIZ0IHmNSrh`

using `%C`
`/Users/pj/.ssh/cm_067698ecd110d603843a371f498e878e5d18fbaa=`