### PR TITLE
Added vims paste before 'P'

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -384,6 +384,11 @@ command = "paste"
 mode = "nv"
 
 [[keymaps]]
+key = "shift+p"
+command = "paste_before"
+mode = "nv"
+
+[[keymaps]]
 key = "shift+j"
 command = "join_lines"
 mode = "n"

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -67,6 +67,8 @@ pub enum EditCommand {
     Yank,
     #[strum(serialize = "paste")]
     Paste,
+    #[strum(serialize = "paste_before")]
+    PasteBefore,
 
     #[strum(serialize = "normal_mode")]
     NormalMode,

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -935,6 +935,16 @@ impl Editor {
                 let data = register.unnamed.clone();
                 Self::do_paste(cursor, buffer, &data)
             }
+            PasteBefore => {
+                let offset = cursor.offset();
+                let line = buffer.line_of_offset(offset);
+                let line_offset = buffer.offset_of_line(line);
+                let data = register.unnamed.clone();
+                if offset > line_offset {
+                    cursor.set_offset(offset - 1, false, false);
+                }
+                Self::do_paste(cursor, buffer, &data)
+            }
             NewLineAbove => {
                 let offset = cursor.offset();
                 let line = buffer.line_of_offset(offset);


### PR DESCRIPTION
`P` behaves like `p` but instead of inserting after the cursor `P` inserts before the cursor. `P` moves the cursor one to the left before pasting. This move does not occur if the cursor is at the beginning of the line and therefore behaves like vims `P`.