### PR TITLE
fix view tab drag-drop

### DIFF
--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -235,6 +235,8 @@ impl LapceEditorTab {
                                     LapceUICommand::Focus,
                                     Target::Widget(child.widget_id()),
                                 ));
+
+                                *Arc::make_mut(&mut data.drag) = None;
                             }
                             None => {
                                 if from_id == &self.widget_id {

--- a/lapce-ui/src/editor/tab.rs
+++ b/lapce-ui/src/editor/tab.rs
@@ -235,8 +235,6 @@ impl LapceEditorTab {
                                     LapceUICommand::Focus,
                                     Target::Widget(child.widget_id()),
                                 ));
-
-                                *Arc::make_mut(&mut data.drag) = None;
                             }
                             None => {
                                 if from_id == &self.widget_id {
@@ -277,6 +275,7 @@ impl LapceEditorTab {
                                 ));
                             }
                         }
+                        *Arc::make_mut(&mut data.drag) = None;
                     }
                 }
                 DragContent::Panel(..) => {}

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -614,7 +614,7 @@ impl LapceTab {
         &mut self,
         ctx: &mut EventCtx,
         event: &Event,
-        data: &mut LapceTabData,
+        _data: &mut LapceTabData,
         _env: &Env,
     ) {
         match event {
@@ -630,10 +630,6 @@ impl LapceTab {
             Event::MouseUp(mouse) => {
                 if mouse.button.is_left() && ctx.is_active() {
                     ctx.set_active(false);
-                }
-                if data.drag.is_some() {
-                    self.handle_panel_drop(ctx, data);
-                    *Arc::make_mut(&mut data.drag) = None;
                 }
             }
             _ => {}
@@ -1854,6 +1850,7 @@ impl Widget<LapceTabData> for LapceTab {
         self.handle_mouse_event(ctx, event, data, env);
 
         self.main_split.event(ctx, event, data, env);
+
         self.status.event(ctx, event, data, env);
         if data.panel.is_container_shown(&PanelContainerPosition::Left)
             || event.should_propagate_to_hidden()
@@ -1891,6 +1888,12 @@ impl Widget<LapceTabData> for LapceTab {
         }
 
         match event {
+            Event::MouseUp(_) => {
+                if data.drag.is_some() {
+                    self.handle_panel_drop(ctx, data);
+                    *Arc::make_mut(&mut data.drag) = None;
+                }
+            }
             Event::MouseMove(mouse) => {
                 self.mouse_pos = mouse.pos;
                 if ctx.is_active() {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -614,7 +614,7 @@ impl LapceTab {
         &mut self,
         ctx: &mut EventCtx,
         event: &Event,
-        _data: &mut LapceTabData,
+        data: &mut LapceTabData,
         _env: &Env,
     ) {
         match event {
@@ -630,6 +630,10 @@ impl LapceTab {
             Event::MouseUp(mouse) => {
                 if mouse.button.is_left() && ctx.is_active() {
                     ctx.set_active(false);
+                }
+                if let Some((_, _, DragContent::Panel(_, _))) = data.drag.as_ref() {
+                    self.handle_panel_drop(ctx, data);
+                    *Arc::make_mut(&mut data.drag) = None;
                 }
             }
             _ => {}
@@ -1888,12 +1892,6 @@ impl Widget<LapceTabData> for LapceTab {
         }
 
         match event {
-            Event::MouseUp(_) => {
-                if data.drag.is_some() {
-                    self.handle_panel_drop(ctx, data);
-                    *Arc::make_mut(&mut data.drag) = None;
-                }
-            }
             Event::MouseMove(mouse) => {
                 self.mouse_pos = mouse.pos;
                 if ctx.is_active() {


### PR DESCRIPTION
View tab dragging currently does nothing.

It originally broke 61f91c7635d3be37df03f110926fd322fe7a3adb

It currently does not work due to the  mouseUp event happening before 

```rs
self.main_split.event(ctx, event, data, env);
```

If anyone knows, I would love to understand why the event callback has to occur after that line