### PR TITLE
Fix save-delay: Call callback of handle_server_request even though no plugins exist

### DIFF
--- a/lapce-proxy/src/plugin/catalog.rs
+++ b/lapce-proxy/src/plugin/catalog.rs
@@ -99,8 +99,7 @@ impl PluginCatalog {
         if let Some(request_sent) = request_sent {
             // if there are no plugins installed the callback of the client is not called
             // so check if plugins list is empty
-            if self.new_plugins.len() == 0 {
-
+            if self.new_plugins.is_empty() {
                 // Add a request
                 request_sent.fetch_add(1, Ordering::Relaxed);
 

--- a/lapce-proxy/src/plugin/catalog.rs
+++ b/lapce-proxy/src/plugin/catalog.rs
@@ -97,7 +97,25 @@ impl PluginCatalog {
         }
 
         if let Some(request_sent) = request_sent {
-            request_sent.fetch_add(self.new_plugins.len(), Ordering::Relaxed);
+            // if there are no plugins installed the callback of the client is not called
+            // so check if plugins list is empty
+            if self.new_plugins.len() == 0 {
+
+                // Add a request
+                request_sent.fetch_add(1, Ordering::Relaxed);
+
+                // make a direct callback with an "error"
+                f(
+                    lapce_rpc::plugin::PluginId(0),
+                    Err(RpcError {
+                        code: 0,
+                        message: "no available plugin could make a callback, because the plugins list is empty".to_string(),
+                    }),
+                );
+                return;
+            } else {
+                request_sent.fetch_add(self.new_plugins.len(), Ordering::Relaxed);
+            }
         }
         for (plugin_id, plugin) in self.new_plugins.iter() {
             let f = dyn_clone::clone_box(&*f);


### PR DESCRIPTION
On handle_server_request no method was called to communicate with the server, so there is no callback executed, if there are no plugins installed.
The calls are always (as I can see) based on plugins.

So if there are no plugins, just execute the callback directly, without making a request to the server.

Fixes #1128 