### PR TITLE
Make PSP/LSP api use number and string identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-lite"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98d245f26984add78277a5306ca0cf774863d4eddb4912b31d94ee3fa1a22d4"
+checksum = "bb4128aba82294c14af2998831c4df3c843940e92b5cfc41bac1229d1e63b88c"
 dependencies = [
  "serde 1.0.144",
  "serde_derive",

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -30,7 +30,7 @@ im = { version = "15.0.0", features = ["serde"] }
 crossbeam-channel = "0.5.0"
 crossbeam-utils = "0.8.4"
 regex = "1.5.6"
-jsonrpc-lite = "0.5.0"
+jsonrpc-lite = "0.6.0"
 parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
 thiserror = "1.0"
 anyhow = "1.0.32"

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -36,7 +36,7 @@ psp-types = { git = "https://github.com/lapce/psp-types" }
 # psp-types = { path = "../../psp-types" }
 parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
 crossbeam-channel = "0.5.0"
-jsonrpc-lite = "0.5.0"
+jsonrpc-lite = "0.6.0"
 serde_json = "1.0.59"
 anyhow = "1.0.32"
 toml_edit = { version = "0.14.4", features = ["easy"] }

--- a/lapce-proxy/src/plugin/lsp.rs
+++ b/lapce-proxy/src/plugin/lsp.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use jsonrpc_lite::Params;
+use jsonrpc_lite::{Id, Params};
 use lapce_rpc::{style::LineStyle, RpcError};
 use lsp_types::{
     notification::{Initialized, Notification},
@@ -87,7 +87,7 @@ impl PluginServerHandler for LspClient {
         }
     }
 
-    fn handle_host_request(&mut self, id: u64, method: String, params: Params) {
+    fn handle_host_request(&mut self, id: Id, method: String, params: Params) {
         let _ = self.host.handle_request(id, method, params);
     }
 

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -6,7 +6,6 @@ pub mod wasi;
 use anyhow::{anyhow, Result};
 use crossbeam_channel::{Receiver, Sender};
 use dyn_clone::DynClone;
-use jsonrpc_lite::Id;
 use lapce_rpc::core::CoreRpcHandler;
 use lapce_rpc::plugin::{PluginId, VoltInfo, VoltMetadata};
 use lapce_rpc::proxy::ProxyRpcHandler;
@@ -854,16 +853,6 @@ pub enum PluginNotification {
     MakeFileExecutable {
         path: PathBuf,
     },
-}
-
-fn number_from_id(id: &Id) -> u64 {
-    match *id {
-        Id::Num(n) => n as u64,
-        Id::Str(ref s) => s
-            .parse::<u64>()
-            .expect("failed to convert string id to u64"),
-        _ => panic!("unexpected value for id: None"),
-    }
 }
 
 pub fn download_volt(volt: VoltInfo, wasm: bool) -> Result<VoltMetadata> {

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use jsonrpc_lite::Params;
+use jsonrpc_lite::{Id, Params};
 use lapce_rpc::{
     plugin::{PluginId, VoltInfo, VoltMetadata},
     style::LineStyle,
@@ -116,7 +116,7 @@ impl PluginServerHandler for Plugin {
         let _ = self.host.handle_notification(method, params);
     }
 
-    fn handle_host_request(&mut self, id: u64, method: String, params: Params) {
+    fn handle_host_request(&mut self, id: Id, method: String, params: Params) {
         let _ = self.host.handle_request(id, method, params);
     }
 

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -27,7 +27,7 @@ im = { version = "15.0.0", features = ["serde"] }
 crossbeam-channel = "0.5.0"
 crossbeam-utils = "0.8.4"
 regex = "1.5.6"
-jsonrpc-lite = "0.5.0"
+jsonrpc-lite = "0.6.0"
 parking_lot = { version = "0.11.0", features = ["deadlock_detection"] }
 include_dir = "0.6.0"
 anyhow = "1.0.32"


### PR DESCRIPTION
The current implementation of the JSONRpc communication between Lapce and plugins or language servers assumes that all ids are integers, or strings that can be parsed as integers. However, the specification does not require that the strings be in any specific format.  
This was encountered because the Julia language server sends strings containing GUIDs, which are not representable as integers.  
~~I had to make a separate `HashId` structure, rather than using the `jsonrpc_lite::Id` structure because the latter does not derive `Hash` - which is needed for the `HashMap`.~~ I opened an issue on the `jsonrpc_lite` for deriving Hash, and they added it very quickly. So, the version for jsonrpc_lite is bumped up in all the places that use it.