### PR TITLE
fix: use link colour for empty editor buttons

### DIFF
--- a/lapce-ui/src/split.rs
+++ b/lapce-ui/src/split.rs
@@ -1328,7 +1328,7 @@ impl Widget<LapceTabData> for LapceSplit {
                     )
                     .text_color(
                         data.config
-                            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+                            .get_color_unchecked(LapceTheme::EDITOR_LINK)
                             .clone(),
                     )
                     .build()


### PR DESCRIPTION
Should give an idea to users that those can be clicked