### PR TITLE
Add rust-toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Without this change, some OS'es such as ArchLinux
will fail to build this project by default.

You would first need to run a specific rustup command to set your default toolchain,
that you as a Rust developer should know,
and only then the project would build using your
downloaded default toolchain.

Specifying the channel explicitly as done in this commit allows for Lapce to be build-able on a completely fresh (or isolated for security reasons) home directory, for those Operating Systems.