### PR TITLE
fix: backward word deletion respect whitespaces

### DIFF
--- a/lapce-core/src/buffer/mod.rs
+++ b/lapce-core/src/buffer/mod.rs
@@ -912,6 +912,10 @@ impl Buffer {
     pub fn move_n_words_backward(&self, offset: usize, count: usize) -> usize {
         self.find_nth_word(offset, count, |cursor| cursor.prev_boundary())
     }
+
+    pub fn move_word_backward_deletion(&self, offset: usize) -> usize {
+        self.find_nth_word(offset, 1, |cursor| cursor.prev_deletion_boundary())
+    }
 }
 
 fn shuffle_tombstones(

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -1139,7 +1139,7 @@ impl Editor {
                         let selection = cursor.edit_selection(buffer);
 
                         for region in selection.regions() {
-                            let end = buffer.move_word_backward(region.end);
+                            let end = buffer.move_word_backward_deletion(region.end);
                             let new_region = SelRegion::new(region.start, end, None);
                             new_selection.add_region(new_region);
                         }


### PR DESCRIPTION
Closes #778. The solution provided in #863 PR doesn't work correctly, because the logic for backward word movement is a bit different from backward word deletion.

For instance, in this case (`|` matches cursor position):

```rust
fn main() {}
|
```
Pressing `Ctrl` + `←` should place the cursor in the position:
```rust
fn main() |{}

```
But, the `Ctrl` + `Backspace` should transform code like this:
```rust
fn main() {}|
```

The function `prev_boundary` is working correctly, so its logic cannot be changed. Instead, I've created the function `prev_deletion_boundary`, which calculates the correct position for the cursor.

The new backward word deletion logic (`|` - cursor position, `◦` - space symbol):

<table><tr>
<th>Code</th>
<th>After transformation</th>
<th>Description</th>
</tr>
<tr>
<td>

```rust
fn◦main()◦{}
◦◦◦|
```

</td><td>

```rust
fn◦main()◦{}
|
```

</td><td>
When there are no other characters between the line beginning and the cursor, all whitespace characters are erased till the beginning of the line
</td></tr><tr></tr>
<tr><td>

```rust
fn◦main()◦{}◦◦◦
|
```

</td>
<td>

```rust
fn◦main()◦{}|
```

</td>
<td>

If the cursor is placed right before the line break, erase the line break and all trailing whitespaces in the previous line[^1].

</td></tr>
<tr></tr>
<tr><td>

```rust
fn◦main()◦|{}
```

</td><td>

```rust
fn◦main|{}
```

</td><td>
If there is one whitespace between cursor and word, erasing word & space
</td></tr>
<tr></tr>
<tr><td>

```rust
fn◦main()◦◦|{}
```

</td><td>

```rust
fn◦main()|{}
```

</td><td>

If there are several whitespaces between cursor and word, erasing all whitespaces before the word[^2]

</td></tr>
</table>

[^1]: This behaviour differs from VSCode. The VSCode just removes line break, keeping all trailing whitespaces in the previous line. I thought it will be more logical to erase them.
[^2]: This behaviour was not mentioned in the issue, but VSCode does that, so I decided to reproduce that.