### PR TITLE
Use upstream repo for tree-sitter-haxe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,8 +5039,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-haxe"
-version = "0.0.1"
-source = "git+https://github.com/VixieTSQ/tree-sitter-haxe#a3e23bc0f84a53371eb5d86229782ec6c21d3729"
+version = "0.2.2"
+source = "git+https://github.com/vantreeseba/tree-sitter-haxe#52e3d2b9c3955aca886bccc38b496ef99b603a09"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -44,7 +44,7 @@ tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql", versio
 tree-sitter-haskell = { git = "https://github.com/tree-sitter/tree-sitter-haskell", version = "0.14.0", optional = true }
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", version = "0.20.0", optional = true }
 tree-sitter-glimmer = { git = "https://github.com/VixieTSQ/tree-sitter-glimmer", version = "0.0.1", optional = true }
-tree-sitter-haxe = { git = "https://github.com/VixieTSQ/tree-sitter-haxe", version = "0.0.1", optional = true }
+tree-sitter-haxe = { git = "https://github.com/vantreeseba/tree-sitter-haxe", version = "0.2.2", optional = true }
 tree-sitter-hcl = { git = "https://github.com/VixieTSQ/tree-sitter-hcl", version = "0.0.1", optional = true }
 tree-sitter-scss = { git = "https://github.com/VixieTSQ/tree-sitter-scss", version = "0.0.1", branch = "patch-1", optional = true }
 tree-sitter-hare = { version = "0.20.7", optional = true }


### PR DESCRIPTION
The required changes have been merged upstream: https://github.com/vantreeseba/tree-sitter-haxe/pull/7. The fork is now out of date with other improvements so this PR updates the link to point to the upstream repo.