### PR TITLE
fix incorrect path when going from url -> pathbuf

### DIFF
--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -756,7 +756,7 @@ pub fn path_from_url(url: &Url) -> PathBuf {
 
 #[cfg(not(windows))]
 pub fn path_from_url(url: &Url) -> PathBuf {
-    PathBuf::from(url.path())
+    url.to_file_path().unwrap_or(PathBuf::from(url.path()))
 }
 
 fn parse_arch(arch: &str) -> HostArchitecture {

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -756,7 +756,8 @@ pub fn path_from_url(url: &Url) -> PathBuf {
 
 #[cfg(not(windows))]
 pub fn path_from_url(url: &Url) -> PathBuf {
-    url.to_file_path().unwrap_or(PathBuf::from(url.path()))
+    url.to_file_path()
+        .unwrap_or_else(|_| PathBuf::from(url.path()))
 }
 
 fn parse_arch(arch: &str) -> HostArchitecture {


### PR DESCRIPTION
when file paths include symbols such as `@` they are not being correctly converted from urls to paths.

Currently:
`node_modules/%40types/...` is parsed as `node_modules/%40types/...`
instead of `node_modules/@types/...`

I added a unwrap_or in the case that it fails, we default to the previous implementation. This may be slightly overkill but I do know everywhere where path_from_url is being used