### PR TITLE
feat: handle LSP ResourceOp

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -57,6 +57,7 @@ use lsp_types::CompletionTextEdit;
 use lsp_types::DocumentChangeOperation;
 use lsp_types::DocumentChanges;
 use lsp_types::OneOf;
+use lsp_types::ResourceOp;
 use lsp_types::TextEdit;
 use lsp_types::Url;
 use lsp_types::WorkspaceEdit;
@@ -370,6 +371,17 @@ impl LapceEditorBufferData {
         ctx: &mut EventCtx,
         edit: &WorkspaceEdit,
     ) {
+        if let Some(DocumentChanges::Operations(op)) = edit.document_changes.as_ref()
+        {
+            op.iter()
+                .flat_map(|op| match op {
+                    DocumentChangeOperation::Op(op) => Some(op),
+                    _ => None,
+                })
+                .flat_map(workspace_operation)
+                .map(|cmd| Command::new(LAPCE_UI_COMMAND, cmd, Target::Auto))
+                .for_each(|cmd| ctx.submit_command(cmd));
+        }
         if let BufferContent::File(path) = &self.editor.content {
             if let Some(edits) = workspace_edits(edit) {
                 for (url, edits) in edits {
@@ -2560,6 +2572,21 @@ fn workspace_edits(edit: &WorkspaceEdit) -> Option<HashMap<Url, Vec<TextEdit>>> 
             .collect::<HashMap<Url, Vec<TextEdit>>>(),
     };
     Some(edits)
+}
+
+fn workspace_operation(op: &ResourceOp) -> Option<LapceUICommand> {
+    Some(match op {
+        ResourceOp::Create(p) => LapceUICommand::CreateFileOpen {
+            path: p.uri.to_file_path().ok()?,
+        },
+        ResourceOp::Rename(p) => LapceUICommand::RenamePath {
+            from: p.old_uri.to_file_path().ok()?,
+            to: p.new_uri.to_file_path().ok()?,
+        },
+        ResourceOp::Delete(p) => LapceUICommand::TrashPath {
+            path: p.uri.to_file_path().ok()?,
+        },
+    })
 }
 
 /// Check if a [`Url`] matches the path

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -656,10 +656,15 @@ impl ProxyHandler for Dispatcher {
                 self.respond_rpc(id, result);
             }
             CreateFile { path } => {
-                let result = std::fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(path)
+                let result = path
+                    .parent()
+                    .map_or(Ok(()), std::fs::create_dir_all)
+                    .and_then(|()| {
+                        std::fs::OpenOptions::new()
+                            .write(true)
+                            .create_new(true)
+                            .open(path)
+                    })
                     .map(|_| ProxyResponse::Success {})
                     .map_err(|e| RpcError {
                         code: 0,
@@ -668,7 +673,7 @@ impl ProxyHandler for Dispatcher {
                 self.respond_rpc(id, result);
             }
             CreateDirectory { path } => {
-                let result = std::fs::create_dir(path)
+                let result = std::fs::create_dir_all(path)
                     .map(|_| ProxyResponse::Success {})
                     .map_err(|e| RpcError {
                         code: 0,


### PR DESCRIPTION
This PR makes the suggestions I mentioned in #1233 functional. For `<modname>/mod.rs`, the directory also needs to be created, so I changed the CreateFile implementation to call `std::fs::create_dir_all` on the directory first. I also changed the CreateDirectory implementation, even if unused by LSP, for consistency.