### PR TITLE
Cases get handled correctly when generating keyboard shortcuts from UI

### DIFF
--- a/lapce-ui/src/keymap.rs
+++ b/lapce-ui/src/keymap.rs
@@ -138,7 +138,8 @@ impl Widget<LapceTabData> for LapceKeymap {
             }
             Event::KeyDown(key_event) => {
                 if let Some((_keymap, keys)) = self.active_keymap.as_mut() {
-                    if let Some(keypress) = KeyPressData::keypress(key_event) {
+                    if let Some(mut keypress) = KeyPressData::keypress(key_event) {
+                        keypress.key = druid::KbKey::Character(keypress.key.to_string().to_lowercase());
                         if keys.len() == 2 {
                             keys.clear();
                         }

--- a/lapce-ui/src/keymap.rs
+++ b/lapce-ui/src/keymap.rs
@@ -139,7 +139,9 @@ impl Widget<LapceTabData> for LapceKeymap {
             Event::KeyDown(key_event) => {
                 if let Some((_keymap, keys)) = self.active_keymap.as_mut() {
                     if let Some(mut keypress) = KeyPressData::keypress(key_event) {
-                        keypress.key = druid::KbKey::Character(keypress.key.to_string().to_lowercase());
+                        keypress.key = druid::KbKey::Character(
+                            keypress.key.to_string().to_lowercase(),
+                        );
                         if keys.len() == 2 {
                             keys.clear();
                         }


### PR DESCRIPTION
Characters now get unshifted when creating keyboard shortcuts from the UI. Fixes #1312 