### PR TITLE
Fixed a bug in vims paste before command

### DIFF
--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -967,13 +967,11 @@ impl Editor {
             }
             PasteBefore => {
                 let offset = cursor.offset();
-                let line = buffer.line_of_offset(offset);
-                let line_offset = buffer.offset_of_line(line);
                 let data = register.unnamed.clone();
-                if offset > line_offset {
-                    cursor.set_offset(offset - 1, false, false);
-                }
-                Self::do_paste(cursor, buffer, &data)
+                let mut local_cursor =
+                    Cursor::new(CursorMode::Insert(Selection::new()), None, None);
+                local_cursor.set_offset(offset, false, false);
+                Self::do_paste(&mut local_cursor, buffer, &data)
             }
             NewLineAbove => {
                 let offset = cursor.offset();


### PR DESCRIPTION
Fixed a bug where the paste before command pasted after the selection, instead of before, when the line contains only one character. The bug is also mentioned in the original pull request of the paste before command #1251

The command no longer moves the cursor to the left and then pastes, but instead pastes using a Cursor::Insert. This results in (hopefully) all the desired behavior, and I am not aware of any problems with using this approach. But feel free to correct me. 