### PR TITLE
Replace Branch-Selector dropdown with a List

### DIFF
--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -500,6 +500,10 @@ pub enum LapceUICommand {
     ShowAlert(AlertContentData),
     ShowMenu(Point, Arc<Vec<MenuKind>>),
     ShowWindow,
+    ShowGitBranches {
+        origin: Point,
+        branches: im::Vector<String>,
+    },
     UpdateSearchInput(String),
     UpdateSearch(String),
     GlobalSearchResult(String, Arc<HashMap<PathBuf, Vec<Match>>>),

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -81,6 +81,7 @@ use crate::{
     source_control::SourceControlData,
     split::{SplitDirection, SplitMoveDirection},
     terminal::TerminalSplitData,
+    title::TitleData,
     update::ReleaseInfo,
 };
 
@@ -571,6 +572,7 @@ pub enum FocusArea {
     Rename,
     Panel(PanelKind),
     FilePicker,
+    BranchPicker,
 }
 
 #[derive(Clone)]
@@ -586,6 +588,7 @@ pub struct LapceTabData {
     pub window_id: Arc<WindowId>,
     pub multiple_tab: bool,
     pub workspace: Arc<LapceWorkspace>,
+    pub title: Arc<TitleData>,
     pub main_split: LapceMainSplitData,
     pub completion: Arc<CompletionData>,
     pub hover: Arc<HoverData>,
@@ -665,6 +668,7 @@ impl LapceTabData {
             term_sender.clone(),
             event_sink.clone(),
         ));
+        let title = Arc::new(TitleData::new(config.clone()));
         let palette = Arc::new(PaletteData::new(config.clone(), proxy.clone()));
         let completion = Arc::new(CompletionData::new(config.clone()));
         let hover = Arc::new(HoverData::new());
@@ -776,6 +780,7 @@ impl LapceTabData {
             window_id: Arc::new(window_id),
             workspace: Arc::new(workspace),
             focus: Arc::new(focus),
+            title,
             main_split,
             completion,
             hover,

--- a/lapce-data/src/lib.rs
+++ b/lapce-data/src/lib.rs
@@ -30,4 +30,5 @@ pub mod signature;
 pub mod source_control;
 pub mod split;
 pub mod terminal;
+pub mod title;
 pub mod update;

--- a/lapce-data/src/source_control.rs
+++ b/lapce-data/src/source_control.rs
@@ -27,7 +27,7 @@ pub struct SourceControlData {
     pub commit_button_id: WidgetId,
     pub file_diffs: Vec<(FileDiff, bool)>,
     pub branch: String,
-    pub branches: Vec<String>,
+    pub branches: im::Vector<String>,
 }
 
 impl SourceControlData {
@@ -45,7 +45,7 @@ impl SourceControlData {
             split_direction: SplitDirection::Horizontal,
             file_diffs: Vec::new(),
             branch: "".to_string(),
-            branches: Vec::new(),
+            branches: im::Vector::new(),
         }
     }
 }

--- a/lapce-data/src/title.rs
+++ b/lapce-data/src/title.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use druid::{Env, EventCtx, Point, WidgetId};
+use lapce_core::{command::FocusCommand, mode::Mode};
+
+use crate::{
+    command::{CommandExecuted, CommandKind, LapceCommand},
+    config::Config,
+    keypress::KeyPressFocus,
+    list::ListData,
+};
+
+#[derive(Clone)]
+pub struct TitleData {
+    pub widget_id: WidgetId,
+    pub branches: BranchListData,
+}
+impl TitleData {
+    pub fn new(config: Arc<Config>) -> TitleData {
+        let widget_id = WidgetId::next();
+        TitleData {
+            widget_id,
+            branches: BranchListData::new(config, widget_id),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BranchListData {
+    pub list: ListData<String, ()>,
+    pub active: bool,
+    /// The origin the list should appear at, this is updated whenever the
+    /// branch list is opened in the titlebar
+    pub origin: Point,
+}
+impl BranchListData {
+    fn new(config: Arc<Config>, parent: WidgetId) -> Self {
+        let list = ListData::new(config, parent, ());
+        BranchListData {
+            list,
+            active: false,
+            origin: Point::ZERO,
+        }
+    }
+}
+impl KeyPressFocus for BranchListData {
+    fn get_mode(&self) -> Mode {
+        Mode::Insert
+    }
+
+    fn check_condition(&self, condition: &str) -> bool {
+        matches!(condition, "list_focus" | "modal_focus")
+    }
+
+    fn run_command(
+        &mut self,
+        ctx: &mut EventCtx,
+        command: &LapceCommand,
+        _count: Option<usize>,
+        _mods: druid::Modifiers,
+        _env: &Env,
+    ) -> CommandExecuted {
+        if let CommandKind::Focus(FocusCommand::ModalClose) = command.kind {
+            self.active = false;
+            return CommandExecuted::Yes;
+        }
+        self.list.run_command(ctx, command)
+    }
+
+    fn receive_char(&mut self, _ctx: &mut EventCtx, _c: &str) {
+        // Currently, this does not have any sort of input (such as for filtering)
+    }
+}

--- a/lapce-ui/src/palette.rs
+++ b/lapce-ui/src/palette.rs
@@ -259,24 +259,11 @@ impl PaletteContainer {
         data: &LapceTabData,
         env: &Env,
     ) {
-        let width = ctx.size().width;
-        // TODO: This function could just be on List?
-        let line_height = data.palette.list_data.line_height() as f64;
-        let rect =
-            Size::new(width, line_height as f64)
-                .to_rect()
-                .with_origin(Point::new(
-                    0.0,
-                    data.palette.list_data.selected_index as f64
-                        * line_height as f64,
-                ));
-        if self.content.widget_mut().scroll_to_visible(rect, env) {
-            ctx.submit_command(Command::new(
-                LAPCE_UI_COMMAND,
-                LapceUICommand::ResetFade,
-                Target::Widget(data.palette.scroll_id),
-            ));
-        }
+        self.content.widget_mut().ensure_item_visible(
+            ctx,
+            &data.palette.list_data.clone_with(data.config.clone()),
+            env,
+        );
     }
 }
 
@@ -322,8 +309,6 @@ impl Widget<LapceTabData> for PaletteContainer {
         env: &Env,
     ) {
         if old_data.palette.input != data.palette.input
-            || old_data.palette.list_data.selected_index
-                != data.palette.list_data.selected_index
             || old_data.palette.run_id != data.palette.run_id
         {
             self.ensure_item_visible(ctx, data, env);

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1009,7 +1009,8 @@ impl LapceTab {
                     LapceUICommand::UpdateDiffInfo(diff) => {
                         let source_control = Arc::make_mut(&mut data.source_control);
                         source_control.branch = diff.head.to_string();
-                        source_control.branches = diff.branches.clone();
+                        source_control.branches =
+                            diff.branches.iter().cloned().collect();
                         source_control.file_diffs = diff
                             .diffs
                             .iter()


### PR DESCRIPTION
This replaces the source control branch selector with a `List` widget, which allows: limiting the space it takes, adding more information (such as deviation from HEAD) in the future, and being more consistent.  
![image](https://user-images.githubusercontent.com/13157904/192125688-de558947-78b3-4c73-b868-951f4dd22fad.png)

There could probably be some improvements in the appearance. It has no visual icons of extra information like the palette/completion, and so can appear a bit bland.