### PR TITLE
Add duplicate_line_up/down commands

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -278,6 +278,16 @@ command = "insert_new_line"
 when = "!list_focus"
 mode = "i"
 
+[[keymaps]]
+key = "alt+shift+up"
+command = "duplicate_line_up"
+mode = "i"
+
+[[keymaps]]
+key = "alt+shift+down"
+command = "duplicate_line_down"
+mode = "i"
+
 # ------------------------------------ Modal -----------------------------------------
 
 [[keymaps]]

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -86,6 +86,10 @@ pub enum EditCommand {
     ToggleLinewiseVisualMode,
     #[strum(serialize = "toggle_blockwise_visual_mode")]
     ToggleBlockwiseVisualMode,
+    #[strum(serialize = "duplicate_line_up")]
+    DuplicateLineUp,
+    #[strum(serialize = "duplicate_line_down")]
+    DuplicateLineDown,
 }
 
 #[derive(

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -555,17 +555,15 @@ impl Editor {
                 }
             }
             for line in start_line..=end_line {
-                if lines.contains(&line) {
-                    continue;
+                if lines.insert(line) {
+                    let line_content = buffer.line_content(line);
+                    if line_content == "\n" || line_content == "\r\n" {
+                        continue;
+                    }
+                    let nonblank = buffer.first_non_blank_character_on_line(line);
+                    let edit = crate::indent::create_edit(buffer, nonblank, indent);
+                    edits.push(edit);
                 }
-                lines.insert(line);
-                let line_content = buffer.line_content(line);
-                if line_content == "\n" || line_content == "\r\n" {
-                    continue;
-                }
-                let nonblank = buffer.first_non_blank_character_on_line(line);
-                let edit = crate::indent::create_edit(buffer, nonblank, indent);
-                edits.push(edit);
             }
         }
 
@@ -590,19 +588,17 @@ impl Editor {
                 }
             }
             for line in start_line..=end_line {
-                if lines.contains(&line) {
-                    continue;
-                }
-                lines.insert(line);
-                let line_content = buffer.line_content(line);
-                if line_content == "\n" || line_content == "\r\n" {
-                    continue;
-                }
-                let nonblank = buffer.first_non_blank_character_on_line(line);
-                if let Some(edit) =
-                    crate::indent::create_outdent(buffer, nonblank, indent)
-                {
-                    edits.push(edit);
+                if lines.insert(line) {
+                    let line_content = buffer.line_content(line);
+                    if line_content == "\n" || line_content == "\r\n" {
+                        continue;
+                    }
+                    let nonblank = buffer.first_non_blank_character_on_line(line);
+                    if let Some(edit) =
+                        crate::indent::create_outdent(buffer, nonblank, indent)
+                    {
+                        edits.push(edit);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #1060

I miss my old idea of placing markers in test strings to also test cursor positions... oh well, trust me, they are mostly correct.

PR contains a drive-by cleanup