### PR TITLE
Sticky header fixes

### DIFF
--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1447,16 +1447,8 @@ impl LapceEditor {
             }
         }
 
-        let mut i = 0;
         let total_stickly_lines = sticky_lines.len();
-        if last_sticky_should_scroll {
-            info.last_y_diff = y_diff;
-        } else {
-            info.last_y_diff = 0.0;
-        }
-        info.lines = sticky_lines.clone();
-        info.height = 0.0;
-        for line in sticky_lines {
+        for (i, line) in sticky_lines.iter().copied().enumerate() {
             let y_diff = if last_sticky_should_scroll && i == total_stickly_lines - 1
             {
                 y_diff
@@ -1485,17 +1477,21 @@ impl LapceEditor {
                     - y_diff;
                 ctx.draw_text(&text_layout.text, Point::new(x0, y));
             });
-            i += 1;
         }
 
-        if i > 0 {
-            info.height = i as f64 * line_height
-                - if last_sticky_should_scroll {
-                    y_diff
-                } else {
-                    0.0
-                };
-        }
+        let scroll_offset = if last_sticky_should_scroll {
+            y_diff
+        } else {
+            0.0
+        };
+
+        info.last_y_diff = scroll_offset;
+        info.height = if total_stickly_lines > 0 {
+            total_stickly_lines as f64 * line_height - scroll_offset
+        } else {
+            0.0
+        };
+        info.lines = sticky_lines;
     }
 
     fn paint_snippet(

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1471,7 +1471,7 @@ impl LapceEditor {
             // Clear background
             let sticky_area_rect = Size::new(
                 size.width,
-                (total_sticky_lines) as f64 * line_height - scroll_offset,
+                total_sticky_lines as f64 * line_height - scroll_offset,
             )
             .to_rect()
             .with_origin(Point::new(0.0, y0));
@@ -1490,17 +1490,25 @@ impl LapceEditor {
                     0.0
                 };
 
-                let text_layout = data.doc.get_text_layout(
-                    ctx.text(),
-                    line,
-                    data.config.editor.font_size,
-                    &data.config,
-                );
-                let y = y0
-                    + line_height * i as f64
-                    + text_layout.text.y_offset(line_height)
-                    - y_diff;
-                ctx.draw_text(&text_layout.text, Point::new(x0, y));
+                ctx.with_save(|ctx| {
+                    let line_area_rect = Size::new(size.width, line_height - y_diff)
+                        .to_rect()
+                        .with_origin(Point::new(0.0, y0 + line_height * i as f64));
+
+                    ctx.clip(line_area_rect);
+
+                    let text_layout = data.doc.get_text_layout(
+                        ctx.text(),
+                        line,
+                        data.config.editor.font_size,
+                        &data.config,
+                    );
+                    let y = y0
+                        + line_height * i as f64
+                        + text_layout.text.y_offset(line_height)
+                        - y_diff;
+                    ctx.draw_text(&text_layout.text, Point::new(x0, y));
+                });
             }
         }
 

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1449,16 +1449,17 @@ impl LapceEditor {
 
         let total_sticky_lines = sticky_lines.len();
 
+        let scroll_offset = if total_sticky_lines > 0 && last_sticky_should_scroll {
+            y_diff
+        } else {
+            0.0
+        };
+
         if total_sticky_lines > 0 {
             // Clear background
             let sticky_area_rect = Size::new(
                 size.width,
-                (total_sticky_lines) as f64 * line_height
-                    - if last_sticky_should_scroll {
-                        y_diff
-                    } else {
-                        0.0
-                    },
+                (total_sticky_lines) as f64 * line_height - scroll_offset,
             )
             .to_rect()
             .with_origin(Point::new(0.0, y0));
@@ -1471,12 +1472,11 @@ impl LapceEditor {
 
             // Paint lines
             for (i, line) in sticky_lines.iter().copied().enumerate() {
-                let y_diff =
-                    if last_sticky_should_scroll && i == total_sticky_lines - 1 {
-                        y_diff
-                    } else {
-                        0.0
-                    };
+                let y_diff = if i == total_sticky_lines - 1 {
+                    scroll_offset
+                } else {
+                    0.0
+                };
                 let text_layout = data.doc.get_text_layout(
                     ctx.text(),
                     line,
@@ -1491,18 +1491,8 @@ impl LapceEditor {
             }
         }
 
-        let scroll_offset = if last_sticky_should_scroll {
-            y_diff
-        } else {
-            0.0
-        };
-
         info.last_y_diff = scroll_offset;
-        info.height = if total_sticky_lines > 0 {
-            total_sticky_lines as f64 * line_height - scroll_offset
-        } else {
-            0.0
-        };
+        info.height = total_sticky_lines as f64 * line_height - scroll_offset;
         info.lines = sticky_lines;
     }
 

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1447,9 +1447,9 @@ impl LapceEditor {
             }
         }
 
-        let total_stickly_lines = sticky_lines.len();
+        let total_sticky_lines = sticky_lines.len();
         for (i, line) in sticky_lines.iter().copied().enumerate() {
-            let y_diff = if last_sticky_should_scroll && i == total_stickly_lines - 1
+            let y_diff = if last_sticky_should_scroll && i == total_sticky_lines - 1
             {
                 y_diff
             } else {
@@ -1486,8 +1486,8 @@ impl LapceEditor {
         };
 
         info.last_y_diff = scroll_offset;
-        info.height = if total_stickly_lines > 0 {
-            total_stickly_lines as f64 * line_height - scroll_offset
+        info.height = if total_sticky_lines > 0 {
+            total_sticky_lines as f64 * line_height - scroll_offset
         } else {
             0.0
         };

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1473,7 +1473,8 @@ impl LapceEditor {
         };
 
         // Clear background
-        let area_height = total_sticky_lines as f64 * line_height - scroll_offset;
+        let area_height =
+            total_sticky_lines as f64 * line_height - scroll_offset + 1.0;
         let sticky_area_rect = Size::new(size.width, area_height)
             .to_rect()
             .with_origin(Point::new(0.0, y0));

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1449,6 +1449,18 @@ impl LapceEditor {
 
         let total_sticky_lines = sticky_lines.len();
 
+        let paint_last_line = total_sticky_lines > 0
+            && (last_sticky_should_scroll
+                || y_diff != 0.0
+                || start_line != *sticky_lines.last().unwrap());
+
+        // Fix up the line count in case we don't need to paint the last one.
+        let total_sticky_lines = if paint_last_line {
+            total_sticky_lines
+        } else {
+            total_sticky_lines.saturating_sub(1)
+        };
+
         let scroll_offset = if total_sticky_lines > 0 && last_sticky_should_scroll {
             y_diff
         } else {
@@ -1477,6 +1489,7 @@ impl LapceEditor {
                 } else {
                     0.0
                 };
+
                 let text_layout = data.doc.get_text_layout(
                     ctx.text(),
                     line,

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1448,23 +1448,35 @@ impl LapceEditor {
         }
 
         let total_sticky_lines = sticky_lines.len();
-        for (i, line) in sticky_lines.iter().copied().enumerate() {
-            let y_diff = if last_sticky_should_scroll && i == total_sticky_lines - 1
-            {
-                y_diff
-            } else {
-                0.0
-            };
-            let rect = Size::new(size.width, line_height - y_diff)
-                .to_rect()
-                .with_origin(Point::new(0.0, y0 + line_height * i as f64));
-            ctx.with_save(|ctx| {
-                ctx.clip(rect);
-                ctx.fill(
-                    rect,
-                    data.config
-                        .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
-                );
+
+        if total_sticky_lines > 0 {
+            // Clear background
+            let sticky_area_rect = Size::new(
+                size.width,
+                (total_sticky_lines) as f64 * line_height
+                    - if last_sticky_should_scroll {
+                        y_diff
+                    } else {
+                        0.0
+                    },
+            )
+            .to_rect()
+            .with_origin(Point::new(0.0, y0));
+
+            ctx.fill(
+                sticky_area_rect,
+                data.config
+                    .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
+            );
+
+            // Paint lines
+            for (i, line) in sticky_lines.iter().copied().enumerate() {
+                let y_diff =
+                    if last_sticky_should_scroll && i == total_sticky_lines - 1 {
+                        y_diff
+                    } else {
+                        0.0
+                    };
                 let text_layout = data.doc.get_text_layout(
                     ctx.text(),
                     line,
@@ -1476,7 +1488,7 @@ impl LapceEditor {
                     + text_layout.text.y_offset(line_height)
                     - y_diff;
                 ctx.draw_text(&text_layout.text, Point::new(x0, y));
-            });
+            }
         }
 
         let scroll_offset = if last_sticky_should_scroll {

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1473,12 +1473,10 @@ impl LapceEditor {
         };
 
         // Clear background
-        let sticky_area_rect = Size::new(
-            size.width,
-            total_sticky_lines as f64 * line_height - scroll_offset,
-        )
-        .to_rect()
-        .with_origin(Point::new(0.0, y0));
+        let area_height = total_sticky_lines as f64 * line_height - scroll_offset;
+        let sticky_area_rect = Size::new(size.width, area_height)
+            .to_rect()
+            .with_origin(Point::new(0.0, y0));
 
         ctx.fill(
             sticky_area_rect,
@@ -1516,7 +1514,7 @@ impl LapceEditor {
         }
 
         info.last_y_diff = scroll_offset;
-        info.height = total_sticky_lines as f64 * line_height - scroll_offset;
+        info.height = area_height;
         info.lines = sticky_lines;
     }
 

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1452,7 +1452,8 @@ impl LapceEditor {
         let paint_last_line = total_sticky_lines > 0
             && (last_sticky_should_scroll
                 || y_diff != 0.0
-                || start_line != *sticky_lines.last().unwrap());
+                || start_line + total_sticky_lines - 1
+                    != *sticky_lines.last().unwrap());
 
         // Fix up the line count in case we don't need to paint the last one.
         let total_sticky_lines = if paint_last_line {

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1462,55 +1462,57 @@ impl LapceEditor {
             total_sticky_lines.saturating_sub(1)
         };
 
-        let scroll_offset = if total_sticky_lines > 0 && last_sticky_should_scroll {
+        if total_sticky_lines == 0 {
+            return;
+        }
+
+        let scroll_offset = if last_sticky_should_scroll {
             y_diff
         } else {
             0.0
         };
 
-        if total_sticky_lines > 0 {
-            // Clear background
-            let sticky_area_rect = Size::new(
-                size.width,
-                total_sticky_lines as f64 * line_height - scroll_offset,
-            )
-            .to_rect()
-            .with_origin(Point::new(0.0, y0));
+        // Clear background
+        let sticky_area_rect = Size::new(
+            size.width,
+            total_sticky_lines as f64 * line_height - scroll_offset,
+        )
+        .to_rect()
+        .with_origin(Point::new(0.0, y0));
 
-            ctx.fill(
-                sticky_area_rect,
-                data.config
-                    .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
-            );
+        ctx.fill(
+            sticky_area_rect,
+            data.config
+                .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
+        );
 
-            // Paint lines
-            for (i, line) in sticky_lines.iter().copied().enumerate() {
-                let y_diff = if i == total_sticky_lines - 1 {
-                    scroll_offset
-                } else {
-                    0.0
-                };
+        // Paint lines
+        for (i, line) in sticky_lines.iter().copied().enumerate() {
+            let y_diff = if i == total_sticky_lines - 1 {
+                scroll_offset
+            } else {
+                0.0
+            };
 
-                ctx.with_save(|ctx| {
-                    let line_area_rect = Size::new(size.width, line_height - y_diff)
-                        .to_rect()
-                        .with_origin(Point::new(0.0, y0 + line_height * i as f64));
+            ctx.with_save(|ctx| {
+                let line_area_rect = Size::new(size.width, line_height - y_diff)
+                    .to_rect()
+                    .with_origin(Point::new(0.0, y0 + line_height * i as f64));
 
-                    ctx.clip(line_area_rect);
+                ctx.clip(line_area_rect);
 
-                    let text_layout = data.doc.get_text_layout(
-                        ctx.text(),
-                        line,
-                        data.config.editor.font_size,
-                        &data.config,
-                    );
-                    let y = y0
-                        + line_height * i as f64
-                        + text_layout.text.y_offset(line_height)
-                        - y_diff;
-                    ctx.draw_text(&text_layout.text, Point::new(x0, y));
-                });
-            }
+                let text_layout = data.doc.get_text_layout(
+                    ctx.text(),
+                    line,
+                    data.config.editor.font_size,
+                    &data.config,
+                );
+                let y = y0
+                    + line_height * i as f64
+                    + text_layout.text.y_offset(line_height)
+                    - y_diff;
+                ctx.draw_text(&text_layout.text, Point::new(x0, y));
+            });
         }
 
         info.last_y_diff = scroll_offset;

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -532,6 +532,16 @@ impl LapceEditorGutter {
 
         let info = data.editor.sticky_header.borrow();
 
+        let sticky_area_rect = Size::new(size.width, info.height)
+            .to_rect()
+            .with_origin(Point::new(0.0, 0.0));
+
+        ctx.fill(
+            sticky_area_rect,
+            data.config
+                .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
+        );
+
         let total_lines = info.lines.len();
         for (i, line) in info.lines.iter().enumerate() {
             let y_diff = if i == total_lines - 1 {
@@ -545,11 +555,6 @@ impl LapceEditorGutter {
                 .with_origin(Point::new(0.0, line_height * i as f64));
             ctx.with_save(|ctx| {
                 ctx.clip(rect);
-                ctx.fill(
-                    rect,
-                    data.config
-                        .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
-                );
                 let text_layout = ctx
                     .text()
                     .new_text_layout((line + 1).to_string())


### PR DESCRIPTION
cc #1296 - while this PR doesn't render caret, at least the first line is no longer always overdrawn. Also fixes a weirdness with the shadow.

This PR also optimizes background clearing when multiple sticky lines are visible. Nothing major, but still.

In general, I'm not pleased with how this PR looks but my brain doesn't work this late. Suggestions are welcome.

Before:

1px of overlap above shadow (on a high-DPI display, Surface Laptop Studio):
<img width="391" alt="image" src="https://user-images.githubusercontent.com/977627/192355951-d63cd901-e078-4a51-9956-91d9868bb61c.png">

First line is always hidden below a sticky header:
<img width="148" alt="image" src="https://user-images.githubusercontent.com/977627/192356047-17658bbb-83d2-499b-9b46-e48d085870bf.png">


After:

First line is no longer sticky except if scrolled:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/977627/192356153-ab6568fe-0970-4ba4-ad4a-ba9a8de0673b.png">
<img width="176" alt="image" src="https://user-images.githubusercontent.com/977627/192356185-5587e232-966d-454c-92b0-402e3f4e5d48.png">

Overlap is gone:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/977627/192356239-4118f363-93d3-47d8-8573-aef2890f931e.png">
