### PR TITLE
Fix proxy hang due to held lock

### DIFF
--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -385,7 +385,8 @@ impl ProxyRpcHandler {
         id: RequestId,
         result: Result<ProxyResponse, RpcError>,
     ) {
-        if let Some(handler) = self.pending.lock().remove(&id) {
+        let handler = { self.pending.lock().remove(&id) };
+        if let Some(handler) = handler {
             handler.invoke(result);
         }
     }


### PR DESCRIPTION
#1336 removed the block around variable for the `if let`.  
However, `if let Some(handler) = self.pending.lock().remove(&id)` would drop the lock at the end of the statement, which is after the if statement has ran.    
(The easiest way to trigger the hand for me was to remove or create a file in the file listing)