### PR TITLE
feat(editor): add autosave configuration

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -18,6 +18,7 @@ completion-show-documentation = true
 hover-delay = 300             # ms
 modal-mode-relative-line-numbers = true
 format-on-save = true
+autosave-interval = 0
 enable-inlay-hints = true
 inlay-hint-font-family = ""
 inlay-hint-font-size = 0

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -232,6 +232,10 @@ pub struct EditorConfig {
         desc = "How the editor should render whitespace characters.\nOptions: none, all, boundary, trailing."
     )]
     pub render_whitespace: String,
+    #[field_names(
+        desc = "Set the auto save delay (in milliseconds), Set to 0 to completely disable"
+    )]
+    pub autosave_interval: u64,
 }
 
 impl EditorConfig {


### PR DESCRIPTION
This add an `autosave-interval` key to editor config, allowing to set up autosave. 
The config setting default to zero, which disable auto-saving. 

Closes #248