### PR TITLE
Fix auto-completion crash

### DIFF
--- a/lapce-core/src/syntax/edit.rs
+++ b/lapce-core/src/syntax/edit.rs
@@ -106,9 +106,7 @@ pub fn generate_edits(
 
         // We have to keep track of a shift because the deletions aren't properly moved forward
         let mut shift = insertions.inserts_len();
-        // I believe this is the correct `CountMatcher` to use for this iteration, since it is what they use
-        // for deleting a subset from a string.
-        for (start, end) in deletions.range_iter(CountMatcher::Zero) {
+        for (start, end) in deletions.range_iter(CountMatcher::NonZero) {
             edits.push(create_delete_edit(&text, start + shift, end + shift));
 
             let delete_delta = RopeDelta::simple_edit(


### PR DESCRIPTION
When a suggestion by the auto-completion is accepted, lapce crashes. Let's imagine a scenario that we type in 3 letters ("com" of "compile") and accept a suggestion with the following delta, which is neither a simple insert nor a simple delete.

    Copy(0, 1230), # Insertion position is 1230
    Insert("compile_only(exercise)"), # Accepted suggestion of length 22
    Copy(1233, 6140). # The 3-letter hint for the auto-completion

When we factor this delta into insertions and deletions we get the following insert-only delta

    Copy(0, 1230),
    Insert("compile_only(exercise)"),
    Copy(1230, 6140),

and segments representing the deletions

    {len: 1230, count: 0},
    {len: 3, count: 1},
    {len: 4907, count: 0}.

In this scenario `shift` is 22 and `CountMatcher::Zero` matches the zero counts of deletion segments yielding (0, 1230) for (start, end) in the first iteration, which leads to an overflow crash in

    shift -= end - start.

Here, we should use `CountMatcher::NonZero` so that the iterator yields (1230, 1233) and the overflow is avoided since one can expect suggestions have more characters than the hints we type in for the suggestions.