### PR TITLE
fix: fix tabstop for postfix completions

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -508,15 +508,24 @@ impl LapceEditorBufferData {
                                     .concat(),
                                     EditType::Completion,
                                 );
+
                             let selection = selection.apply_delta(
                                 &delta,
                                 true,
                                 InsertDrift::Default,
                             );
 
+                            let start_offset = additional_edit
+                                .iter()
+                                .map(|(selection, _)| selection.min_offset())
+                                .min()
+                                .map(|offset| {
+                                    offset.min(start_offset).min(edit_start)
+                                })
+                                .unwrap_or(start_offset);
+
                             let mut transformer = Transformer::new(&delta);
-                            let offset = transformer
-                                .transform(start_offset.min(edit_start), false);
+                            let offset = transformer.transform(start_offset, false);
                             let snippet_tabs = snippet.tabs(offset);
 
                             if snippet_tabs.is_empty() {


### PR DESCRIPTION
This PR fix an issue where cursor position was not correctly positioned after applying postfix completion. 

## Example: 

```rust
fn main() {"a".let}
//-------------- ^
                     "." at offset 15 trigger a `let` postfix  
```
Lsp server send a `CompletionItem` containing the following
 - `text edit` 
    - starting offset: `15` 
    - end offset: `18`
    - snippet: `let $0 = "a";` (to replace the postfix identifier `.let`)
- `additional_text_edits`
    - starting offset: `11` 
    - end offset: `15`
    - snippet: `""` (to replace the postfixed expression `"a"`)

Previously the additional edit was not taken into account when updating the tabstop selection start offset. This ended in tabstop offset being apply to the main textEdit, instead of the additional one. Resulting in a wrong cursor position, potentially out of bound if we are editing the last line of the document. 

Closes #1359