### PR TITLE
Improve search-bar workflow.

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -292,7 +292,7 @@ mode = "i"
 
 [[keymaps]]
 key = "esc"
-command = "normal_mode"
+command = "clear_search"
 mode = "niv"
 when = "!search_focus && !modal_focus"
 


### PR DESCRIPTION
As described in this issue, #1309 the search bar (Ctrl+f) is only closed by pressing the Esc key if it has focus. So if you write code after opening a search, you have to click again to close it, which is not very usable. 

So I propose this simple modification which solves this problem by allowing you to close the search bar while writing code.