### PR TITLE
Add rust enums to sticky headers list

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -211,7 +211,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
             &["source_file", "impl_item", "trait_item", "declaration_list"],
             &["source_file", "use_declaration", "line_comment"],
         ),
-        sticky_headers: &["struct_item", "function_item", "impl_item"],
+        sticky_headers: &["struct_item", "enum_item", "function_item", "impl_item"],
         extensions: &["rs"],
     },
     #[cfg(feature = "lang-go")]


### PR DESCRIPTION
Fixes #1298

![image](https://user-images.githubusercontent.com/977627/192606322-63c59047-fcfe-427a-a806-23c1281cf914.png)
