### PR TITLE
Fix hover hints + show multiple hover hint items

### DIFF
--- a/lapce-data/src/hover.rs
+++ b/lapce-data/src/hover.rs
@@ -118,8 +118,13 @@ impl HoverData {
                     {
                         let items = parse_hover_resp(hover, &p_config);
 
-                        // reverse the order of the items so that the most relevant is at the top
-                        let items = Arc::new(items.into_iter().rev().collect());
+                        let items = Arc::new(
+                            items
+                                .into_iter()
+                                .filter(|i| !i.is_empty())
+                                .rev()
+                                .collect(),
+                        );
 
                         let _ = event_sink.submit_command(
                             LAPCE_UI_COMMAND,

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -15,21 +15,22 @@ use lsp_types::notification::{DidOpenTextDocument, Notification};
 use lsp_types::request::{
     CodeActionRequest, Completion, DocumentSymbolRequest, Formatting,
     GotoDefinition, GotoTypeDefinition, GotoTypeDefinitionParams,
-    GotoTypeDefinitionResponse, InlayHintRequest, PrepareRenameRequest, References,
-    Rename, Request, ResolveCompletionItem, SelectionRangeRequest,
-    SemanticTokensFullRequest, WorkspaceSymbol,
+    GotoTypeDefinitionResponse, HoverRequest, InlayHintRequest,
+    PrepareRenameRequest, References, Rename, Request, ResolveCompletionItem,
+    SelectionRangeRequest, SemanticTokensFullRequest, WorkspaceSymbol,
 };
 use lsp_types::{
     CodeActionContext, CodeActionParams, CodeActionResponse, CompletionItem,
     CompletionParams, CompletionResponse, DidOpenTextDocumentParams,
     DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
     FormattingOptions, GotoDefinitionParams, GotoDefinitionResponse, Hover,
-    InlayHint, InlayHintParams, Location, PartialResultParams, Position,
-    PrepareRenameResponse, Range, ReferenceContext, ReferenceParams, RenameParams,
-    SelectionRange, SelectionRangeParams, SemanticTokens, SemanticTokensParams,
-    SymbolInformation, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, TextEdit, Url, VersionedTextDocumentIdentifier,
-    WorkDoneProgressParams, WorkspaceEdit, WorkspaceSymbolParams,
+    HoverParams, InlayHint, InlayHintParams, Location, PartialResultParams,
+    Position, PrepareRenameResponse, Range, ReferenceContext, ReferenceParams,
+    RenameParams, SelectionRange, SelectionRangeParams, SemanticTokens,
+    SemanticTokensParams, SymbolInformation, TextDocumentIdentifier,
+    TextDocumentItem, TextDocumentPositionParams, TextEdit, Url,
+    VersionedTextDocumentIdentifier, WorkDoneProgressParams, WorkspaceEdit,
+    WorkspaceSymbolParams,
 };
 use parking_lot::Mutex;
 use serde::de::DeserializeOwned;
@@ -718,12 +719,13 @@ impl PluginCatalogRpcHandler {
         cb: impl FnOnce(PluginId, Result<Hover, RpcError>) + Clone + Send + 'static,
     ) {
         let uri = Url::from_file_path(path).unwrap();
-        let method = SelectionRangeRequest::METHOD;
-        let params = SelectionRangeParams {
-            text_document: TextDocumentIdentifier { uri },
-            positions: vec![position],
+        let method = HoverRequest::METHOD;
+        let params = HoverParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position,
+            },
             work_done_progress_params: WorkDoneProgressParams::default(),
-            partial_result_params: Default::default(),
         };
         let language_id =
             Some(language_id_from_path(path).unwrap_or("").to_string());

--- a/lapce-ui/src/hover.rs
+++ b/lapce-ui/src/hover.rs
@@ -239,24 +239,27 @@ impl Widget<LapceTabData> for Hover {
         data: &LapceTabData,
         _env: &Env,
     ) {
-        // If the active item has changed or we've switched our current item existence status
         // or we've gotten new diagnostic text
         // then update the layout
         if old_data.hover.request_id != data.hover.request_id
             || old_data.hover.get_current_items().is_some()
                 != data.hover.get_current_items().is_some()
+            || old_data.hover.len() != data.hover.len()
             || !old_data
                 .hover
                 .diagnostic_content
                 .same(&data.hover.diagnostic_content)
         {
-            for (i, item) in data.hover.items.iter().enumerate() {
-                if i >= self.active_layout.len() {
-                    self.active_layout.push(TextLayout::new());
-                }
-                let layout = &mut self.active_layout[i];
-                layout.set_text(item.clone());
-            }
+            self.active_layout = data
+                .hover
+                .items
+                .iter()
+                .map(|item| {
+                    let mut layout = TextLayout::new();
+                    layout.set_text(item.clone());
+                    layout
+                })
+                .collect();
 
             if let Some(diagnostic_content) = &data.hover.diagnostic_content {
                 self.active_diagnostic_layout

--- a/lapce-ui/src/hover.rs
+++ b/lapce-ui/src/hover.rs
@@ -198,10 +198,7 @@ impl Hover {
 
     fn new() -> Self {
         Hover {
-            active_layout: {
-                let layout = Vec::new();
-                layout
-            },
+            active_layout: { Vec::new() },
             active_diagnostic_layout: {
                 let mut layout = TextLayout::new();
                 layout.set_text(RichText::new(ArcStr::from("")));


### PR DESCRIPTION
Changes:
 - fixes hover hints (currently broken on master
 - adds support for multiple hover items
 - adds padding at top of hover box
 - filters out empty hints

Before:

<img width="987" alt="Screenshot 2022-09-27 at 22 51 08" src="https://user-images.githubusercontent.com/18101008/192642331-1ea6a1a0-8a77-47c4-8786-e300fe48e0ec.png">

After:

<img width="987" alt="Screenshot 2022-09-27 at 22 52 40" src="https://user-images.githubusercontent.com/18101008/192642535-3ed7b66e-27be-4915-b7ee-e414a28b17af.png">


(the syntax highlighting being broken isn't related to this PR)
