### PR TITLE
Fix regex search within the terminal

### DIFF
--- a/lapce-data/src/terminal.rs
+++ b/lapce-data/src/terminal.rs
@@ -598,7 +598,7 @@ impl LapceTerminalData {
         search_string: &str,
         direction: Direction,
     ) {
-        if let Ok(dfas) = RegexSearch::new(search_string) {
+        if let Ok(dfas) = RegexSearch::new(&regex::escape(search_string)) {
             let mut point = term.renderable_content().cursor.point;
             if direction == Direction::Right {
                 if point.column.0 < term.last_column() {

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -834,7 +834,7 @@ impl Widget<LapceTabData> for LapceTerminal {
         }
         if data.find.visual {
             if let Some(search_string) = data.find.search_string.as_ref() {
-                if let Ok(dfas) = RegexSearch::new(search_string) {
+                if let Ok(dfas) = RegexSearch::new(&regex::escape(search_string)) {
                     let mut start = alacritty_terminal::index::Point::new(
                         alacritty_terminal::index::Line(
                             -(content.display_offset as i32),


### PR DESCRIPTION
Escape search string to create safe regex search within the terminal. Otherwise regex meta characters within the search string could freeze the whole editor.

Closes #1183 