### PR TITLE
Try to fix windows self-update

### DIFF
--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -43,6 +43,9 @@ pub fn launch() {
         return;
     }
 
+    #[cfg(feature = "updater")]
+    lapce_data::update::cleanup();
+
     let mut log_dispatch = fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(


### PR DESCRIPTION
cc #1351

I think this will only fix portable Lapce because the install directory might be read-only, but we'll see.

This PR fixes the issue that an exe can't delete itself, which makes self-update on Windows fail on the extract step.