### PR TITLE
Indicate to download_volt that plugins without wasm files should not have wasm files

### DIFF
--- a/lapce-data/src/plugin.rs
+++ b/lapce-data/src/plugin.rs
@@ -198,8 +198,9 @@ impl PluginData {
         } else {
             std::thread::spawn(move || -> Result<()> {
                 let download_volt_result =
-                    download_volt(volt, true, &meta, &meta_str);
-                if download_volt_result.is_err() {
+                    download_volt(volt, false, &meta, &meta_str);
+                if let Err(err) = download_volt_result {
+                    log::warn!("download_volt err: {err:?}");
                     proxy.core_rpc.volt_installing(
                         meta.clone(),
                         "Could not download Volt".to_string(),


### PR DESCRIPTION
This fixes installing themes on master.  
It would error due to passing `true` instead of `false`, like it had been in the past.