### PR TITLE
Merge semantic and syntax highlighting

### DIFF
--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1369,19 +1369,17 @@ impl Document {
         let semantic_styles = self.semantic_styles.as_ref();
         let syntax_styles = self.syntax().and_then(|s| s.styles.as_ref());
 
-        if semantic_styles.is_some() && syntax_styles.is_some() {
-            let combined_styles = semantic_styles
-                .unwrap()
-                .merge(syntax_styles.unwrap(), |a, _| a.clone());
-
-            return Some(Arc::new(combined_styles));
-        } else if semantic_styles.is_some() {
-            return semantic_styles.cloned();
-        } else if syntax_styles.is_some() {
-            return syntax_styles.cloned();
+        match (semantic_styles, syntax_styles) {
+            (Some(semantic), Some(syntax)) => {
+                Some(Arc::new(syntax.merge(semantic, |a, b| match b {
+                    Some(b) => b.clone(),
+                    None => a.clone(),
+                })))
+            }
+            (Some(semantic), None) => Some(semantic.clone()),
+            (None, Some(syntax_styles)) => Some(syntax_styles.clone()),
+            (None, None) => None,
         }
-
-        None
     }
 
     fn line_style(&self, line: usize) -> Arc<Vec<LineStyle>> {

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1376,9 +1376,9 @@ impl Document {
 
             return Some(Arc::new(combined_styles));
         } else if semantic_styles.is_some() {
-            return semantic_styles.map(|s| s.clone());
+            return semantic_styles.cloned();
         } else if syntax_styles.is_some() {
-            return syntax_styles.map(|s| s.clone());
+            return syntax_styles.cloned();
         }
 
         None

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1367,9 +1367,9 @@ impl Document {
 
     pub fn styles(&self) -> Option<Arc<Spans<Style>>> {
         let semantic_styles = self.semantic_styles.as_ref();
-        let syntax_styles = self.syntax().and_then(|s| s.styles.as_ref());
+        let syntactic_styles = self.syntax().and_then(|s| s.styles.as_ref());
 
-        match (semantic_styles, syntax_styles) {
+        match (semantic_styles, syntactic_styles) {
             (Some(semantic), Some(syntax)) => {
                 Some(Arc::new(syntax.merge(semantic, |a, b| match b {
                     Some(b) => b.clone(),
@@ -1377,7 +1377,7 @@ impl Document {
                 })))
             }
             (Some(semantic), None) => Some(semantic.clone()),
-            (None, Some(syntax_styles)) => Some(syntax_styles.clone()),
+            (None, Some(syntactic)) => Some(syntactic.clone()),
             (None, None) => None,
         }
     }

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -779,25 +779,21 @@ impl Document {
 
                             let styles = styles_span.build();
 
-                            let mut syntactic_styles_spans = SpansBuilder::new(len);
+                            let merged_styles;
 
                             if let Some(syntactic_styles) = syntactic_styles {
-                                for (interval, style) in syntactic_styles.iter() {
-                                    syntactic_styles_spans
-                                        .add_span(interval, style.clone());
-                                }
+                                merged_styles = Arc::new(syntactic_styles.merge(
+                                    &styles,
+                                    |a, b| {
+                                        if let Some(b) = b {
+                                            return b.clone();
+                                        }
+                                        a.clone()
+                                    },
+                                ));
+                            } else {
+                                merged_styles = Arc::new(styles);
                             }
-                            let syntactic_styles_spans =
-                                syntactic_styles_spans.build();
-
-                            let merged_styles = Arc::new(
-                                syntactic_styles_spans.merge(&styles, |a, b| {
-                                    if let Some(b) = b {
-                                        return b.clone();
-                                    }
-                                    a.clone()
-                                }),
-                            );
 
                             let _ = event_sink.submit_command(
                                 LAPCE_UI_COMMAND,

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -998,7 +998,7 @@ impl Widget<LapceTabData> for LapceEditorView {
                 ctx.request_paint();
             }
             (Some(new), Some(old)) => {
-                if !new.same(old) {
+                if !new.same(&old) {
                     ctx.request_paint();
                 }
             }

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -998,7 +998,7 @@ impl Widget<LapceTabData> for LapceEditorView {
                 ctx.request_paint();
             }
             (Some(new), Some(old)) => {
-                if !new.same(&old) {
+                if !new.same(old) {
                     ctx.request_paint();
                 }
             }


### PR DESCRIPTION
semantic token highlighting from the lsp does not return all the highlights, instead we can combine it with the highlighting from tree sitter for a more complete experience

Before:

<img width="987" alt="Screenshot 2022-09-29 at 14 51 30" src="https://user-images.githubusercontent.com/18101008/193050070-85b6d3b8-b7ea-448f-9238-01e67dfa1520.png">

After:

<img width="987" alt="Screenshot 2022-09-29 at 14 50 25" src="https://user-images.githubusercontent.com/18101008/193049803-af9beced-e4f1-4ec0-a133-1cf584cc7cd5.png">

