### PR TITLE
Log panics with full backtrace as errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "lapce-data",
  "lapce-rpc",
  "log 0.4.17",
+ "log-panics",
  "lsp-types",
  "once_cell",
  "open",
@@ -2853,6 +2854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "log-panics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
+dependencies = [
+ "log 0.4.17",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
+ "backtrace",
  "log 0.4.17",
 ]
 

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -15,7 +15,7 @@ rayon = "1.5.1"
 alacritty_terminal = "0.16"
 config = "0.11"
 itertools = "0.10.1"
-log-panics = "2.1.0"
+log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 unicode-width = "0.1.8"
 im = { version = "15.0.0", features = ["serde"] }
 regex = "1.5.6"

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -15,6 +15,7 @@ rayon = "1.5.1"
 alacritty_terminal = "0.16"
 config = "0.11"
 itertools = "0.10.1"
+log-panics = "2.1.0"
 unicode-width = "0.1.8"
 im = { version = "15.0.0", features = ["serde"] }
 regex = "1.5.6"

--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -89,7 +89,9 @@ pub fn launch() {
         Err(e) => eprintln!("Initialising logging failed {e:?}"),
     }
 
-    log_panics::init();
+    log_panics::Config::new()
+        .backtrace_mode(log_panics::BacktraceMode::Resolved)
+        .install_panic_hook();
 
     let mut launcher = AppLauncher::new().delegate(LapceAppDelegate::new());
     let mut data = LapceData::load(launcher.get_external_handle(), paths);

--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -89,6 +89,8 @@ pub fn launch() {
         Err(e) => eprintln!("Initialising logging failed {e:?}"),
     }
 
+    log_panics::init();
+
     let mut launcher = AppLauncher::new().delegate(LapceAppDelegate::new());
     let mut data = LapceData::load(launcher.get_external_handle(), paths);
     for (_window_id, window_data) in data.windows.iter_mut() {


### PR DESCRIPTION
This PR captures and logs panics as errors. No backtrace is captured right now but it can be enabled using the `with-backtrace` feature flag and some configuring on the log-panic side.