### PR TITLE
changed python indent to conform with pep8

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -299,7 +299,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         highlight: tree_sitter_python::HIGHLIGHT_QUERY,
         injection: None,
         comment: "#",
-        indent: "\t",
+        indent: "    ",
         code_lens: (
             &[
                 "source_file",


### PR DESCRIPTION
* python-lang SyntaxProperties indent has four spaces rather than one tab
  * https://peps.python.org/pep-0008/#tabs-or-spaces
  * https://peps.python.org/pep-0008/#indentation