### PR TITLE
Check if get_editor request is non-scratch before early-returning

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -2400,7 +2400,7 @@ impl LapceMainSplitData {
         scratch: bool,
         config: &LapceConfig,
     ) -> &mut LapceEditorData {
-        if path.is_none() {
+        if path.is_none() && !scratch {
             let editor_tab = self.editor_tabs.get(&editor_tab_id).unwrap();
             if let Some(EditorTabChild::Editor(id, _, _)) = editor_tab.active_child()
             {


### PR DESCRIPTION
This fixes a bug where Ctrl+N to create a new scratch file would replace the current open editortab, uncaring of whether there was edits or not.

