### PR TITLE
Fix multiple cursor offset after inserting opening pair

### DIFF
--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -232,7 +232,7 @@ impl Editor {
                 for region in selection.regions_mut().iter_mut().sorted_by(
                     |region_a, region_b| region_a.start.cmp(&region_b.start),
                 ) {
-                    *region = SelRegion::new(
+                    let new_region = SelRegion::new(
                         region.start + adjustment,
                         region.end + adjustment,
                         None,
@@ -251,6 +251,8 @@ impl Editor {
                     {
                         adjustment += inserted.len();
                     }
+
+                    *region = new_region;
                 }
 
                 cursor.mode = CursorMode::Insert(selection);

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -1585,5 +1585,30 @@ mod test {
         );
     }
 
+    #[test]
+    fn check_multiple_cursor_match_insertion() {
+        let mut buffer = Buffer::new(" 123 567 9ab def");
+        let mut selection = Selection::new();
+        selection.add_region(SelRegion::caret(0));
+        selection.add_region(SelRegion::caret(4));
+        selection.add_region(SelRegion::caret(8));
+        selection.add_region(SelRegion::caret(12));
+        let mut cursor = Cursor::new(CursorMode::Insert(selection), None, None);
+
+        Editor::insert(&mut cursor, &mut buffer, "(", None, true);
+
+        assert_eq!(
+            "() 123() 567() 9ab() def",
+            buffer.slice_to_cow(0..buffer.len())
+        );
+
+        let mut end_selection = Selection::new();
+        end_selection.add_region(SelRegion::caret(1));
+        end_selection.add_region(SelRegion::caret(7));
+        end_selection.add_region(SelRegion::caret(13));
+        end_selection.add_region(SelRegion::caret(19));
+        assert_eq!(cursor.mode, CursorMode::Insert(end_selection));
+    }
+
     // TODO(dbuga): add tests duplicating selections (multiple line blocks)
 }

--- a/lapce-core/src/syntax/util.rs
+++ b/lapce-core/src/syntax/util.rs
@@ -26,6 +26,7 @@ impl<'a> TextProvider<'a> for RopeProvider<'a> {
     }
 }
 
+/// If the character is an opening bracket return Some(true), if closing, return Some(false)
 pub fn matching_pair_direction(c: char) -> Option<bool> {
     Some(match c {
         '{' => true,


### PR DESCRIPTION
Code was editing the region before comparing it to the previously inserted region.
Also add doc to matching_pair_direction function.

This closes #1374 