### PR TITLE
fix: correct joining PATH

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -283,10 +283,11 @@ impl LapceData {
             if let Some(path) = path.parent() {
                 if let Some(path) = path.to_str() {
                     if let Ok(current_path) = env::var("PATH") {
-                        env::set_var(
-                            "PATH",
-                            env::join_paths([path, &current_path])?,
+                        let mut paths = vec![PathBuf::from(path)];
+                        paths.append(
+                            &mut env::split_paths(&current_path).collect::<Vec<_>>(),
                         );
+                        env::set_var("PATH", env::join_paths(paths)?);
                     }
                 }
             }

--- a/lapce-proxy/src/lib.rs
+++ b/lapce-proxy/src/lib.rs
@@ -135,10 +135,14 @@ pub fn mainloop() {
         if let Some(path) = path.parent() {
             if let Some(path) = path.to_str() {
                 if let Ok(current_path) = std::env::var("PATH") {
+                    let mut paths = vec![PathBuf::from(path)];
+                    paths.append(
+                        &mut std::env::split_paths(&current_path)
+                            .collect::<Vec<_>>(),
+                    );
                     std::env::set_var(
                         "PATH",
-                        std::env::join_paths([path, &current_path])
-                            .expect("Couldn't join PATH"),
+                        std::env::join_paths(paths).expect("Couldn't join PATH"),
                     );
                 }
             }


### PR DESCRIPTION
technically previous version works, but there is some weird behaviour with double quotes (at least on Windows)

```rs
        } else if v.contains(&sep) {
            joined.push(b'"' as u16);
            joined.extend_from_slice(&v[..]);
            joined.push(b'"' as u16);
```
https://github.com/rust-lang/rust/blob/33d351972ad9c43bc30e87edd2765de9a4898629/library/std/src/sys/windows/os.rs#L212