### PR TITLE
Correct terminal font sizing

### DIFF
--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -995,14 +995,13 @@ impl LapceConfig {
 
     /// Calculate the width of the character "W" (being the widest character)
     /// in the editor's current font family at the specified font size.
-    pub fn char_width(&self, text: &mut PietText, font_size: f64) -> f64 {
-        Self::editor_text_size_internal(
-            self.editor.font_family(),
-            font_size,
-            text,
-            "W",
-        )
-        .width
+    pub fn char_width(
+        &self,
+        text: &mut PietText,
+        font_size: f64,
+        font_family: FontFamily,
+    ) -> f64 {
+        Self::text_size_internal(font_family, font_size, text, "W").width
     }
 
     pub fn terminal_font_family(&self) -> FontFamily {
@@ -1032,7 +1031,11 @@ impl LapceConfig {
     /// Calculate the width of the character "W" (being the widest character)
     /// in the editor's current font family and current font size.
     pub fn editor_char_width(&self, text: &mut PietText) -> f64 {
-        self.char_width(text, self.editor.font_size as f64)
+        self.char_width(
+            text,
+            self.editor.font_size as f64,
+            self.editor.font_family(),
+        )
     }
 
     /// Calculate the width of `text_to_measure` in the editor's current font family and font size.
@@ -1041,7 +1044,7 @@ impl LapceConfig {
         text: &mut PietText,
         text_to_measure: &str,
     ) -> f64 {
-        Self::editor_text_size_internal(
+        Self::text_size_internal(
             self.editor.font_family(),
             self.editor.font_size as f64,
             text,
@@ -1056,7 +1059,7 @@ impl LapceConfig {
         text: &mut PietText,
         text_to_measure: &str,
     ) -> Size {
-        Self::editor_text_size_internal(
+        Self::text_size_internal(
             self.editor.font_family(),
             self.editor.font_size as f64,
             text,
@@ -1064,9 +1067,48 @@ impl LapceConfig {
         )
     }
 
+    /// Calculate the width of the character "W" (being the widest character)
+    /// in the editor's current font family and current font size.
+    pub fn terminal_char_width(&self, text: &mut PietText) -> f64 {
+        self.char_width(
+            text,
+            self.terminal_font_size() as f64,
+            self.terminal_font_family(),
+        )
+    }
+
+    /// Calculate the width of `text_to_measure` in the editor's current font family and font size.
+    pub fn terminal_text_width(
+        &self,
+        text: &mut PietText,
+        text_to_measure: &str,
+    ) -> f64 {
+        Self::text_size_internal(
+            self.terminal_font_family(),
+            self.terminal_font_size() as f64,
+            text,
+            text_to_measure,
+        )
+        .width
+    }
+
+    /// Calculate the size of `text_to_measure` in the terminal's current font family and font size.
+    pub fn terminal_text_size(
+        &self,
+        text: &mut PietText,
+        text_to_measure: &str,
+    ) -> Size {
+        Self::text_size_internal(
+            self.terminal_font_family(),
+            self.terminal_font_size() as f64,
+            text,
+            text_to_measure,
+        )
+    }
+
     /// Efficiently calculate the size of a piece of text, without allocating.
     /// This function should not be made public, use one of the public wrapper functions instead.
-    fn editor_text_size_internal(
+    fn text_size_internal(
         font_family: FontFamily,
         font_size: f64,
         text: &mut PietText,

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1160,7 +1160,14 @@ impl LapceEditorBufferData {
                 )
             };
 
-            (line, config.char_width(text, font_size as f64))
+            (
+                line,
+                config.char_width(
+                    text,
+                    font_size as f64,
+                    config.editor.font_family(),
+                ),
+            )
         } else if let Some(compare) = self.editor.compare.as_ref() {
             let line = (pos.y / config.editor.line_height() as f64).floor() as usize;
             let line = self.doc.history_actual_line_from_visual(compare, line);

--- a/lapce-ui/src/terminal.rs
+++ b/lapce-ui/src/terminal.rs
@@ -665,7 +665,7 @@ impl Widget<LapceTabData> for LapceTerminal {
         if self.width != size.width || self.height != size.height {
             self.width = size.width;
             self.height = size.height;
-            let width = data.config.editor_char_width(ctx.text());
+            let width = data.config.terminal_char_width(ctx.text());
             let line_height = data.config.terminal_line_height() as f64;
             let width = if width > 0.0 {
                 (self.width / width).floor() as usize
@@ -683,7 +683,7 @@ impl Widget<LapceTabData> for LapceTerminal {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, _env: &Env) {
-        let char_size = data.config.editor_text_size(ctx.text(), "W");
+        let char_size = data.config.terminal_text_size(ctx.text(), "W");
         let char_width = char_size.width;
         let line_height = data.config.terminal_line_height() as f64;
 


### PR DESCRIPTION
Fixes #1002.

I was having this issue last night:

<img width="1095" alt="Screenshot 2022-10-05 at 12 02 25 AM" src="https://user-images.githubusercontent.com/1950680/194146566-53f841eb-2975-4154-970f-cc6258228310.png">

With my current changes:

<img width="1096" alt="Screenshot 2022-10-05 at 3 32 51 PM" src="https://user-images.githubusercontent.com/1950680/194146642-32feeb28-f383-4d90-8716-bf3d46f836ff.png">
