### PR TITLE
Wrap selected text with brackets/quotes

### DIFF
--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -91,6 +91,31 @@ impl Editor {
                         None
                     };
 
+                    // when text is selected, and [,{,(,'," is inserted
+                    // wrap the text with that char and its corresponding closing pair
+                    if region.start != region.end
+                        && (matching_pair_type.is_some() || c == '"' || c == '\'')
+                    {
+                        if (true == matching_pair_type.unwrap_or(false))
+                            || c == '"'
+                            || c == '\''
+                        {
+                            edits.push((
+                                Selection::region(region.min(), region.min()),
+                                c.to_string(),
+                            ));
+                            edits_after.push((
+                                idx,
+                                match c {
+                                    '"' => '"',
+                                    '\'' => '\'',
+                                    _ => matching_char(c).unwrap(),
+                                },
+                            ));
+                            continue;
+                        }
+                    }
+
                     if auto_closing_matching_pairs {
                         if (c == '"' || c == '\'') && cursor_char == Some(c) {
                             // Skip the closing character
@@ -212,7 +237,7 @@ impl Editor {
                     .map(|(idx, content)| {
                         let region = &selection.regions()[*idx];
                         (
-                            Selection::region(region.start, region.end),
+                            Selection::region(region.max(), region.max()),
                             content.to_string(),
                         )
                     })

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -93,11 +93,9 @@ impl Editor {
 
                     // when text is selected, and [,{,(,'," is inserted
                     // wrap the text with that char and its corresponding closing pair
-                    if region.start != region.end
-                        && (matching_pair_type.is_some() || c == '"' || c == '\'')
-                        && ((matching_pair_type.unwrap_or(false))
-                            || c == '"'
-                            || c == '\'')
+                    if region.start != region.end && matching_pair_type == Some(true)
+                        || c == '"'
+                        || c == '\''
                     {
                         edits.push((
                             Selection::region(region.min(), region.min()),

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -93,27 +93,21 @@ impl Editor {
 
                     // when text is selected, and [,{,(,'," is inserted
                     // wrap the text with that char and its corresponding closing pair
-                    if region.start != region.end
-                        && (matching_pair_type.is_some() || c == '"' || c == '\'')
-                    {
-                        if (true == matching_pair_type.unwrap_or(false))
-                            || c == '"'
-                            || c == '\''
-                        {
-                            edits.push((
-                                Selection::region(region.min(), region.min()),
-                                c.to_string(),
-                            ));
-                            edits_after.push((
-                                idx,
-                                match c {
-                                    '"' => '"',
-                                    '\'' => '\'',
-                                    _ => matching_char(c).unwrap(),
-                                },
-                            ));
-                            continue;
-                        }
+                    if region.start != region.end && (matching_pair_type.is_some() || c == '"' || c == '\'') && ((matching_pair_type.unwrap_or(false))
+                            || c == '"' || c == '\'') {
+                        edits.push((
+                            Selection::region(region.min(), region.min()),
+                            c.to_string(),
+                        ));
+                        edits_after.push((
+                            idx,
+                            match c {
+                                '"' => '"',
+                                '\'' => '\'',
+                                _ => matching_char(c).unwrap(),
+                            },
+                        ));
+                        continue;
                     }
 
                     if auto_closing_matching_pairs {

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -93,8 +93,12 @@ impl Editor {
 
                     // when text is selected, and [,{,(,'," is inserted
                     // wrap the text with that char and its corresponding closing pair
-                    if region.start != region.end && (matching_pair_type.is_some() || c == '"' || c == '\'') && ((matching_pair_type.unwrap_or(false))
-                            || c == '"' || c == '\'') {
+                    if region.start != region.end
+                        && (matching_pair_type.is_some() || c == '"' || c == '\'')
+                        && ((matching_pair_type.unwrap_or(false))
+                            || c == '"'
+                            || c == '\'')
+                    {
                         edits.push((
                             Selection::region(region.min(), region.min()),
                             c.to_string(),


### PR DESCRIPTION
when text is selected, and [, (, {, ", ' is typed, it wrapped the selected text with that character pair


https://user-images.githubusercontent.com/18101008/194603893-00ddcfd6-1c7f-4d7b-9c85-4cc0e15f1c8e.mov

