### PR TITLE
Load shell environment when launching from GUI

### DIFF
--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -41,7 +41,7 @@ pub fn build_window(data: &mut LapceWindowData) -> impl Widget<LapceData> {
 pub fn launch() {
     // if PWD is not set, then we are not being launched via a terminal
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    if !std::env::var("PWD").is_ok() {
+    if std::env::var("PWD").is_err() {
         load_shell_env();
     }
 
@@ -244,6 +244,7 @@ fn macos_window_desc<T: druid::Data>(desc: WindowDesc<T>) -> WindowDesc<T> {
 }
 
 /// Uses a login shell to load the correct shell environment for the current user.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn load_shell_env() {
     use std::process::Command;
 
@@ -269,8 +270,8 @@ fn load_shell_env() {
         }
     };
 
-    env.split("\n")
-        .filter_map(|line| line.split_once("="))
+    env.split('\n')
+        .filter_map(|line| line.split_once('='))
         .for_each(|(key, value)| {
             std::env::set_var(key, value);
         })


### PR DESCRIPTION
When lapce attempts to launch sub-processes (i.e. a LSP) that depend on environment variables like a customized `PATH` it will fail as long as it has been launched from the GUI (at least on macOS). 

This is due to the fact that i.e. macOS does not load the user's shell environment when launching an app. This can be mitigated by starting a login shell and extracting all environment variables from it. A strategy described in [this comment](https://github.com/atom/atom/issues/18318#issuecomment-439175987) on the Atom Editor project.

I have tested this on macOS, and it resolved all issues of lapce not being able to find LSP executables like `pylsp`. For Linux, I do not know if it is actually necessary or if the correct environment is available to lapce there.