### PR TITLE
Feat: Add setting Cursor Surrounding Lines (#1474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [#1441](https://github.com/lapce/lapce/pull/1441): Button for Case-Sensitive search
 - [#1471](https://github.com/lapce/lapce/pull/1471): Add command to (un)install Lapce from/to PATH
 - [#1419](https://github.com/lapce/lapce/pull/1419): Add atomic soft tabs: now you can move your cursor over four spaces as if it was a single block
+- [#1475](https://github.com/lapce/lapce/pull/1475): Add editor setting: "Cursor Surrounding Lines" which sets minimum number of lines above and below cursor
 
 ### Syntax / Extensions
 - [#957](https://github.com/lapce/lapce/pull/957): Replace existing tree-sitter syntax highlighting code with part of Helix's better implementation

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -13,6 +13,7 @@ tab-width = 4
 show-tab = true
 show-bread-crumbs = true
 scroll-beyond-last-line = true
+cursor-surrounding-lines = 1
 sticky-header = true
 completion-show-documentation = true
 auto-closing-matching-pairs = true

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -175,6 +175,10 @@ pub struct EditorConfig {
     #[field_names(desc = "If the editor can scroll beyond the last line")]
     pub scroll_beyond_last_line: bool,
     #[field_names(
+        desc = "Set the minimum number of visible lines above and below the cursor"
+    )]
+    pub cursor_surrounding_lines: usize,
+    #[field_names(
         desc = "Show code context like functions and classes at the top of editor when scroll"
     )]
     pub sticky_header: bool,

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -526,10 +526,14 @@ impl LapceEditorView {
             line as f64 * line_height
         };
 
+        let surrounding_lines_height =
+            (data.config.editor.cursor_surrounding_lines as f64 * line_height)
+                .min(data.editor.size.borrow().height / 2.);
+
         Rect::ZERO
             .with_size(Size::new(width, line_height))
             .with_origin(Point::new(cursor_x, y))
-            .inflate(width, line_height)
+            .inflate(width, surrounding_lines_height)
     }
 }
 


### PR DESCRIPTION
This is the minimum number of visible lines above and below the cursor. The default is 1 as per the editors current behavior.

- [ x] Added an entry to `CHANGELOG.md` if this change could be valuable to users