### PR TITLE
fix(search): use esc to close search regardless of current mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Now use `esc` to close searchbar regarless of the current focus
+
 ### Features/Changes
 
 ### Bug Fixes

--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -131,7 +131,7 @@ mode = "i"
 [[keymaps]]
 key = "esc"
 command = "clear_search"
-when = "search_focus"
+when = "search_active"
 
 [[keymaps]]
 key = "ctrl+shift+up"
@@ -295,21 +295,26 @@ mode = "i"
 
 [[keymaps]]
 key = "esc"
+command = "clear_search"
+when = "!modal_focus"
+
+[[keymaps]]
+key = "esc"
 command = "normal_mode"
 mode = "niv"
-when = "!search_focus && !modal_focus"
+when = "!search_focus && !modal_focus && !search_active"
 
 [[keymaps]]
 key="ctrl+c"
 command = "normal_mode"
 mode = "niv"
-when = "!search_focus && !modal_focus"
+when = "!search_focus && !modal_focus && !search_active"
 
 [[keymaps]]
 key = "ctrl+["
 command = "normal_mode"
 mode = "niv"
-when = "!search_focus"
+when = "!search_focus && !search_active"
 
 [[keymaps]]
 key = ":"

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -2386,6 +2386,13 @@ impl KeyPressFocus for LapceEditorBufferData {
 
     fn check_condition(&self, condition: &str) -> bool {
         match condition {
+            "search_active" => {
+                if self.config.core.modal && !self.editor.cursor.is_normal() {
+                    false
+                } else {
+                    self.find.visual
+                }
+            }
             "search_focus" => {
                 self.editor.content == BufferContent::Local(LocalBufferKind::Search)
                     && self.editor.parent_view_id.is_some()


### PR DESCRIPTION
Closes #

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users