### PR TITLE
UI: Fix issue where 1st tab shows the close icon...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,21 @@
 
 ### Features/Changes
 
+- [#1483](https://github.com/lapce/lapce/pull/1483): Fix showing the close icon for the first tab when opening multiple tab
+
 ### Bug Fixes
 
 ## 0.2.1
 
 ### Features/Changes
+
 - [#1050](https://github.com/lapce/lapce/pull/1050): Collapse groups of problems in the problem list panel
 - [#1165](https://github.com/lapce/lapce/pull/1165): Command to reveal item in system file explorer
 - [#1196](https://github.com/lapce/lapce/pull/1196): Always show close button on focused editor tabs
 - [#1208](https://github.com/lapce/lapce/pull/1208): Sticky header breadcrumbs
   - This provides a header at the top which tells you information about the current scope! Especially useful for long blocks of code
   - ![image](https://user-images.githubusercontent.com/13157904/195404556-2c329ebb-f721-4d55-aa22-56a54f8e8454.png)
-  - As well, you can see that there is now a breadcrumb path to the current file. 
+  - As well, you can see that there is now a breadcrumb path to the current file.
   - A language with syntax highlighting can have this added, even without an LSP. Take a look at `language.rs` if your language isn't supported!
 - [#1198](https://github.com/lapce/lapce/pull/1198): Focus current theme/language in palette
 - [#1244](https://github.com/lapce/lapce/pull/1244); Prettier plugin panel
@@ -46,6 +49,7 @@
 - [#1419](https://github.com/lapce/lapce/pull/1419): Add atomic soft tabs: now you can move your cursor over four spaces as if it was a single block
 
 ### Syntax / Extensions
+
 - [#957](https://github.com/lapce/lapce/pull/957): Replace existing tree-sitter syntax highlighting code with part of Helix's better implementation
   - This means that syntax highlighting for more languages! Such as fixing markdown support, and making so that languages embedded in others (like JavaScript in HTML) work.
   - Note that not all themes have updated themselves to include the extra scopes/colors.
@@ -66,6 +70,7 @@
 - [#1450](https://github.com/lapce/lapce/pull/1450): Add `tf` extension for HCL
 
 ### Bug Fixes
+
 - [#1030](https://github.com/lapce/lapce/pull/1030): Don't try to open an font file with an empty name if there is no font family set
 - [9f0120d](https://github.com/lapce/lapce/commit/9f0120df85e3aaaef7fbb43385bb15d88443260a): Fix excessive CPU usage in part of the code
 - [bf5a98a](https://github.com/lapce/lapce/commit/bf5a98a6d432f9d2abdc1737da2d075e204771fb): Fix issue where sometimes Lapce can't open
@@ -89,6 +94,7 @@
 - Many more fixes!
 
 ### Other
+
 - [#1191](https://github.com/lapce/lapce/pull/1191): Tone down default inlay hint background color in Lapce dark theme
 - [#1227](https://github.com/lapce/lapce/pull/1227): Don't restore cursor mode on undo
 - [#1413](https://github.com/lapce/lapce/pull/1413): Disable format-on-save by default. Remember to re-enable this if you want it!

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -34,7 +34,7 @@ enum MouseAction {
 pub struct LapceEditorTabHeaderContent {
     pub widget_id: WidgetId,
     pub rects: Vec<TabRect>,
-    mouse_pos: Point,
+    mouse_pos: Option<Point>,
     mouse_down_target: Option<(MouseAction, usize)>,
 }
 
@@ -43,7 +43,7 @@ impl LapceEditorTabHeaderContent {
         Self {
             widget_id,
             rects: Vec::new(),
-            mouse_pos: Point::ZERO,
+            mouse_pos: None,
             mouse_down_target: None,
         }
     }
@@ -108,7 +108,7 @@ impl LapceEditorTabHeaderContent {
                         Target::Widget(editor_tab.children[tab_idx].widget_id()),
                     ));
                 }
-                self.mouse_pos = mouse_event.pos;
+                self.mouse_pos = Some(mouse_event.pos);
                 self.mouse_down_target = Some((MouseAction::Drag, tab_idx));
 
                 ctx.request_paint();
@@ -130,7 +130,7 @@ impl LapceEditorTabHeaderContent {
         data: &mut LapceTabData,
         mouse_event: &MouseEvent,
     ) {
-        self.mouse_pos = mouse_event.pos;
+        self.mouse_pos = Some(mouse_event.pos);
         if self.tab_hit_test(mouse_event) {
             ctx.set_cursor(&druid::Cursor::Pointer);
         } else {
@@ -431,7 +431,8 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
         }
 
         if ctx.is_hot() && data.is_drag_editor() {
-            let mouse_index = self.drag_target_idx(self.mouse_pos);
+            // SAFETY: unwrap here is safe because `ctx.is_hot` is true if mouse is hovered over it.
+            let mouse_index = self.drag_target_idx(self.mouse_pos.unwrap());
 
             let tab_rect;
             let x = if mouse_index == self.after_last_tab_index() {


### PR DESCRIPTION
When there are multiple tabs open using the file explorer. This happens because the `mouse_pos` is initialized to `Point::ZERO` which technically resides inside the rect of the first tab.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Edit: Do you want to include this to `CHANGELOG.md`?