### PR TITLE
Split up SettingItem code

### DIFF
--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -52,7 +52,6 @@ use crate::{
     history::DocumentHistory,
     proxy::LapceProxy,
     selection_range::{SelectionRangeDirection, SyntaxSelectionRanges},
-    settings::SettingsValueKind,
 };
 use lapce_rpc::plugin::PluginId;
 
@@ -132,7 +131,8 @@ pub enum LocalBufferKind {
 pub enum BufferContent {
     File(PathBuf),
     Local(LocalBufferKind),
-    SettingsValue(String, SettingsValueKind, String, String),
+    /// A setting input; with its name.
+    SettingsValue(String),
     Scratch(BufferId, String),
 }
 

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -24,7 +24,6 @@ use lapce_data::{
     keypress::KeyPressFocus,
     palette::PaletteStatus,
     panel::{PanelData, PanelKind},
-    settings::SettingsValueKind,
 };
 
 use crate::{
@@ -44,7 +43,6 @@ pub struct LapceEditorView {
     pub find: Option<WidgetPod<LapceTabData, Box<dyn Widget<LapceTabData>>>>,
     cursor_blink_timer: TimerToken,
     autosave_timer: TimerToken,
-    last_idle_timer: TimerToken,
     display_border: bool,
     background_color_name: &'static str,
     ime: ImeComponent,
@@ -98,7 +96,6 @@ impl LapceEditorView {
             find,
             cursor_blink_timer: TimerToken::INVALID,
             autosave_timer: TimerToken::INVALID,
-            last_idle_timer: TimerToken::INVALID,
             display_border: true,
             background_color_name: LapceTheme::EDITOR_BACKGROUND,
             ime: ImeComponent::default(),
@@ -611,38 +608,6 @@ impl Widget<LapceTabData> for LapceEditorView {
                     }
                 }
             }
-            Event::Timer(id) if self.last_idle_timer == *id => {
-                ctx.set_handled();
-                let editor_data = data.editor_view_content(self.view_id);
-                if let BufferContent::SettingsValue(_, kind, parent, key) =
-                    &editor_data.editor.content
-                {
-                    let content = editor_data.doc.buffer().to_string();
-                    let new_value = match kind {
-                        SettingsValueKind::String => {
-                            Some(serde_json::json!(content))
-                        }
-                        SettingsValueKind::Integer => {
-                            content.parse::<i64>().ok().map(|n| serde_json::json!(n))
-                        }
-                        SettingsValueKind::Float => {
-                            content.parse::<f64>().ok().map(|n| serde_json::json!(n))
-                        }
-                        SettingsValueKind::Bool => None,
-                    };
-                    if let Some(new_value) = new_value {
-                        ctx.submit_command(Command::new(
-                            LAPCE_UI_COMMAND,
-                            LapceUICommand::UpdateSettingsFile(
-                                parent.to_string(),
-                                key.to_string(),
-                                new_value,
-                            ),
-                            Target::Widget(data.id),
-                        ));
-                    }
-                }
-            }
             Event::Timer(id) if self.autosave_timer == *id => {
                 ctx.set_handled();
                 if let Some(editor) = data
@@ -909,18 +874,6 @@ impl Widget<LapceTabData> for LapceEditorView {
 
         let old_editor_data = old_data.editor_view_content(self.view_id);
         let editor_data = data.editor_view_content(self.view_id);
-
-        if let BufferContent::SettingsValue(..) = &editor_data.editor.content {
-            if !editor_data.doc.buffer().is_pristine()
-                && (editor_data.doc.buffer().len()
-                    != old_editor_data.doc.buffer().len()
-                    || editor_data.doc.buffer().text().slice_to_cow(..)
-                        != old_editor_data.doc.buffer().text().slice_to_cow(..))
-            {
-                self.last_idle_timer =
-                    ctx.request_timer(Duration::from_millis(500), None);
-            }
-        }
 
         let offset = editor_data.editor.cursor.offset();
         let old_offset = old_editor_data.editor.cursor.offset();

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -566,9 +566,7 @@ struct LapceSettingsItem {
     value: serde_json::Value,
     padding: f64,
     checkbox_width: f64,
-    input_max_width: f64,
     width: f64,
-    cursor: usize,
     input: String,
     value_changed: bool,
     last_idle_timer: TimerToken,
@@ -643,8 +641,6 @@ impl LapceSettingsItem {
             padding: 10.0,
             width: 0.0,
             checkbox_width: 20.0,
-            input_max_width: 500.0,
-            cursor: 0,
             input: "".to_string(),
             value_changed: false,
             last_idle_timer: TimerToken::INVALID,
@@ -842,40 +838,7 @@ impl Widget<LapceTabData> for LapceSettingsItem {
         }
         match event {
             Event::MouseDown(mouse_event) => {
-                // ctx.request_focus();
-                let input = self.input.clone();
-                if let Some(_text) = self.value(ctx.text(), data) {
-                    let text = ctx
-                        .text()
-                        .new_text_layout(input)
-                        .font(
-                            data.config.ui.font_family(),
-                            data.config.ui.font_size() as f64,
-                        )
-                        .text_color(
-                            data.config
-                                .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
-                                .clone(),
-                        )
-                        .build()
-                        .unwrap();
-                    let mut height = self.name(ctx.text(), data).size().height;
-                    height += self.desc(ctx.text(), data).size().height;
-                    height += self.padding * 2.0 + self.padding;
-
-                    let rect = Size::new(
-                        ctx.size().width.min(self.input_max_width),
-                        text.size().height,
-                    )
-                    .to_rect()
-                    .with_origin(Point::new(0.0, height))
-                    .inflate(0.0, 8.0);
-                    if rect.contains(mouse_event.pos) {
-                        let pos = mouse_event.pos - (8.0, 0.0);
-                        let hit = text.hit_test_point(pos);
-                        self.cursor = hit.idx;
-                    }
-                } else if let serde_json::Value::Bool(checked) = self.value {
+                if let serde_json::Value::Bool(checked) = self.value {
                     let rect = Size::new(self.checkbox_width, self.checkbox_width)
                         .to_rect()
                         .with_origin(Point::new(

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1721,7 +1721,7 @@ impl LapceTab {
                             BufferContent::Local(kind) => {
                                 data.main_split.local_docs.get_mut(kind).unwrap()
                             }
-                            BufferContent::SettingsValue(name, _, _, _) => {
+                            BufferContent::SettingsValue(name) => {
                                 data.main_split.value_docs.get_mut(name).unwrap()
                             }
                             BufferContent::Scratch(id, _) => {


### PR DESCRIPTION
~~- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users~~

This PR splits up the `LapceSettingsItem` code into two separate structures for the String/Number input and the Checkbox. This makes it easier to add future item-kinds, and makes the code more manageable.  
There's now two structures, `InputSettingsItem` and `CheckBoxSettingsItem`. They have a common `SettingsItemInfo` structure which keeps track (and does the drawing) of the setting name/description.
- The first commit removes some code that was completely unused. The fields that it modified weren't paid attention to.
- Moves the code for special handling last-idle-timer with `BufferContent::SettingsValue` from `view.rs` into `settings.rs`
  - This simplifies `BufferContent::SettingsValue` due to not needing the extra copies of the fields if it isn't being handled from outside the `SettingsItem` code
- Removes some unneeded calculation code for `value`, which was (for some reason?) getting the height of the value text for layouting, which doesn't seem to actually be what we want? Just using the input-height is a better method. I presume this is a holdover from the old code.  