### PR TITLE
feature: add vim shift+c to delete remainder of line

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -300,7 +300,7 @@ mode = "niv"
 when = "!search_focus && !modal_focus"
 
 [[keymaps]]
-key="ctrl+c"
+key = "ctrl+c"
 command = "normal_mode"
 mode = "niv"
 when = "!search_focus && !modal_focus"
@@ -655,3 +655,8 @@ mode = "v"
 key = "<"
 command = "outdent_line"
 mode = "v"
+
+[[keymaps]]
+key = "shift+c"
+command = "delete_to_end_and_insert"
+mode = "n"

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -38,6 +38,8 @@ pub enum EditCommand {
     DeleteWordBackward,
     #[strum(serialize = "delete_to_beginning_of_line")]
     DeleteToBeginningOfLine,
+    #[strum(serialize = "delete_to_end_and_insert")]
+    DeleteToEndOfLineAndInsert,
     #[strum(message = "Join Lines")]
     #[strum(serialize = "join_lines")]
     JoinLines,


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users