### PR TITLE
fix: remove -Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- [#1505](https://github.com/lapce/lapce/pull/1505): Fix proxy download for hosts with curl without -Z flag
+
 ## 0.2.1
 
 ### Features/Changes

--- a/extra/proxy.sh
+++ b/extra/proxy.sh
@@ -65,7 +65,7 @@ _URL="https://github.com/lapce/lapce/releases/download/${_VER}/lapce-proxy-${_OS
 if test_cmd 'curl'; then
   # How old curl has these options? we'll find out
   printf 'Downloading using curl\n'
-  curl --proto '=https' --tlsv1.2 -LZfS -O "${_URL}"
+  curl --proto '=https' --tlsv1.2 -LfS -O "${_URL}"
   # curl --proto '=https' --tlsv1.2 -LZfS -o "${_TMP}/lapce-proxy-${_OS}-${_ARCH}.gz" "${_URL}"
 elif test_cmd 'wget'; then
   printf 'Downloading using wget\n'


### PR DESCRIPTION
parallel isn't required and might be missing on some hosts fixes #1504

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users