### PR TITLE
Improve Ctrl+Left-Arrow Keys behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features/Changes
 
+- [#1531](https://github.com/lapce/lapce/pull/1531): Improved Ctrl+Left command on spaces at the beginning of a line
 - [#1491](https://github.com/lapce/lapce/pull/1491): Added Vim shift+c to delete remainder of line
 - [#1508](https://github.com/lapce/lapce/pull/1508): Show in progress when Lapce is self updating
 - [#1475](https://github.com/lapce/lapce/pull/1475): Add editor setting: "Cursor Surrounding Lines" which sets minimum number of lines above and below cursor

--- a/lapce-core/src/word.rs
+++ b/lapce-core/src/word.rs
@@ -78,6 +78,14 @@ impl<'a> WordCursor<'a> {
                 if classify_boundary(prop_prev, prop).is_start() {
                     break;
                 }
+
+                // Stop if line beginning reached, without any non-whitespace characters
+                if prop_prev == CharClassification::Lf
+                    && prop == CharClassification::Space
+                {
+                    break;
+                }
+
                 prop = prop_prev;
                 candidate = self.inner.pos();
             }
@@ -465,6 +473,14 @@ mod test {
     fn prev_boundary_should_be_at_word_start() {
         let rope = Rope::from("Hello world");
         let mut cursor = WordCursor::new(&rope, 9);
+        let boundary = cursor.prev_boundary();
+        assert_eq!(boundary, Some(6));
+    }
+
+    #[test]
+    fn on_whitespace_prev_boundary_should_be_at_line_start() {
+        let rope = Rope::from("Hello\n    world");
+        let mut cursor = WordCursor::new(&rope, 10);
         let boundary = cursor.prev_boundary();
         assert_eq!(boundary, Some(6));
     }


### PR DESCRIPTION
As mentioned in the issue #1529, the Ctrl+Arrow keys behave slightly incorrectly, especially with regard to indentation where Ctrl+Left moves the cursor to the top line when it should move the cursor to the beginning of the line and the next time it should move to the top line
 
I don't know now but it looks like CHANGEMOD.md has been automated so I don't know if I should add an entry.