### PR TITLE
Fix overflow crash when editor is sluggish

### DIFF
--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -572,7 +572,7 @@ fn get_truncated_path(full_paths: &[PathBuf]) -> Vec<PathBuf> {
             let mut result = p
                 .iter()
                 .skip(skip_left)
-                .take(length - skip_left - skip_right)
+                .take(length.saturating_sub(skip_left).saturating_sub(skip_right))
                 .collect::<PathBuf>();
 
             if skip_left > 0 {


### PR DESCRIPTION
When running the editor in debug mode like `cargo run`, the editor will become sluggish and this crash will happen. A lot.

Visually, it looks like some details are not loaded at the same time (like file paths).

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users