### PR TITLE
Add g++ in Ubuntu building from source guide

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -8,7 +8,7 @@ It is easy to build Lapce from source on a GNU/Linux distribution. Cargo handles
 
 #### Ubuntu
 ```sh
-sudo apt install cmake pkg-config libfontconfig-dev libgtk-3-dev
+sudo apt install cmake pkg-config libfontconfig-dev libgtk-3-dev g++
 ```
 #### Fedora
 ```sh


### PR DESCRIPTION
Fixes #1586
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users