### PR TITLE
feat: add goto definition and typeDefinition via link support

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1935,8 +1935,11 @@ impl LapceEditorBufferData {
                                         }
                                     }
                                     GotoDefinitionResponse::Link(
-                                        _location_links,
-                                    ) => None,
+                                        location_links,
+                                    ) => {
+                                        let location_link = location_links[0].clone();
+                                        Some(Location { uri: location_link.target_uri, range:location_link.target_selection_range  })
+                                    },
                                 } {
                                     if location.range.start == start_position {
                                         proxy.proxy_rpc.get_references(
@@ -2051,8 +2054,28 @@ impl LapceEditorBufferData {
                                         }
                                     }
                                     GotoTypeDefinitionResponse::Link(
-                                        _location_links,
-                                    ) => {}
+                                        location_links,
+                                    ) => {
+                                        let location_link = location_links[0].clone();
+                                        let _ = event_sink.submit_command(
+                                            LAPCE_UI_COMMAND,
+                                            LapceUICommand::GotoDefinition {
+                                                editor_view_id,
+                                                offset,
+                                                location: EditorLocation {
+                                                    path: path_from_url(
+                                                        &location_link.target_uri,
+                                                    ),
+                                                    position: Some(
+                                                        location_link.target_selection_range.start
+                                                    ),
+                                                    scroll_offset: None,
+                                                    history: None,
+                                                },
+                                            },
+                                            Target::Auto,
+                                        );
+                                    }
                                 }
                             }
                         },

--- a/lapce-proxy/src/plugin/lsp.rs
+++ b/lapce-proxy/src/plugin/lsp.rs
@@ -351,6 +351,9 @@ impl LspClient {
                     link_support: Some(false),
                     ..Default::default()
                 }),
+                definition: Some(GotoCapability {
+                    ..Default::default()
+                }),
                 ..Default::default()
             }),
             window: Some(WindowClientCapabilities {


### PR DESCRIPTION
Lapce-vue use the [volar](https://github.com/johnsoncodehk/volar) lsp server, volar response the goto definition request via [locationLink](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#locationLink), But This not
 be implemented by Lapce，This causes vue can't go to definition (xiaoxin-sky/lapce-vue/issues/5). So add code to support 
handle locationLink response.
**preview**
![QQ20221023-160412 (1)](https://user-images.githubusercontent.com/42181585/197381379-6834efc1-f47b-4ec8-a636-757643968fc4.gif)
