### PR TITLE
Fix incorrect status bar placement

### DIFF
--- a/lapce-ui/src/status.rs
+++ b/lapce-ui/src/status.rs
@@ -565,7 +565,7 @@ impl Widget<LapceTabData> for LapceStatus {
             if !string.is_empty() {
                 let (_, _, (point, text_layout)) = self
                     .paint_icon_with_label_from_right(
-                        right - text_layout.size().width,
+                        right - 10.0,
                         size.height,
                         None,
                         string,


### PR DESCRIPTION
we already compute the correct placement on line 495 / 504 when we return the "new right"

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users