### PR TITLE
Detect the .Containerfile file extension as a Dockerfile

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -311,7 +311,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         indent: "  ",
         code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
         sticky_headers: &[],
-        extensions: &["dockerfile"],
+        extensions: &["containerfile", "dockerfile"],
     },
     #[cfg(feature = "lang-elixir")]
     SyntaxProperties {
@@ -1143,7 +1143,7 @@ mod test {
     }
     #[cfg(feature = "lang-dockerfile")]
     fn test_dockerfile_lang() {
-        assert_language(LapceLanguage::Dockerfile, &["dockerfile"]);
+        assert_language(LapceLanguage::Dockerfile, &["containerfile", "dockerfile"]);
     }
     #[cfg(feature = "lang-csharp")]
     fn test_csharp_lang() {


### PR DESCRIPTION
Fixes #1602 

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users