### PR TITLE
fix: use proper colour for symbols

### DIFF
--- a/lapce-ui/src/palette.rs
+++ b/lapce-ui/src/palette.rs
@@ -677,7 +677,11 @@ impl ListPaint<PaletteListData> for PaletteItem {
                     .collect();
                 PaletteItemPaintInfo {
                     svg: data.config.symbol_svg(kind),
-                    svg_color: None,
+                    svg_color: Some(
+                        data.config
+                            .get_color_unchecked(LapceTheme::LAPCE_ICON_ACTIVE)
+                            .clone(),
+                    ),
                     text,
                     text_indices,
                     hint,
@@ -896,7 +900,11 @@ fn file_paint_symbols(
         .collect();
     PaletteItemPaintInfo {
         svg: config.symbol_svg(&kind),
-        svg_color: None,
+        svg_color: Some(
+            config
+                .get_color_unchecked(LapceTheme::LAPCE_ICON_ACTIVE)
+                .clone(),
+        ),
         text,
         text_indices,
         hint,


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users