### PR TITLE
fix(editor): diagnosis cause cursor x calculate error

### DIFF
--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -465,6 +465,8 @@ impl LapceEditorView {
     fn cursor_region(data: &LapceEditorBufferData, text: &mut PietText) -> Rect {
         let offset = data.editor.cursor.offset();
         let (line, col) = data.doc.buffer().offset_to_line_col(offset);
+        let inlay_hints = data.doc.line_phantom_text(&data.config, line);
+        let col = inlay_hints.col_after(col, false);
 
         let width = data.config.editor_char_width(text);
         let cursor_x = data

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -465,8 +465,6 @@ impl LapceEditorView {
     fn cursor_region(data: &LapceEditorBufferData, text: &mut PietText) -> Rect {
         let offset = data.editor.cursor.offset();
         let (line, col) = data.doc.buffer().offset_to_line_col(offset);
-        let inlay_hints = data.doc.line_phantom_text(&data.config, line);
-        let col = inlay_hints.col_at(col);
 
         let width = data.config.editor_char_width(text);
         let cursor_x = data


### PR DESCRIPTION
I don't think this should take into account the width of the inline diagnosis when focusing the cursor, otherwise it will cause  #1611 issue，So I delete the diagnosis col.