### PR TITLE
fix: stackoverflow on sorting large number of PaletteItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features/Changes
 
+- [#1617](https://github.com/lapce/lapce/pull/1617): Fixed a stack overflow that would crash lapce when attempting to sort a large number of PaletteItems
 - [#1609](https://github.com/lapce/lapce/pull/1609): Add syntax highlighting for erlang
 - [#1590](https://github.com/lapce/lapce/pull/1590): Added ability to open file and file diff from source control context menu
 - [#1570](https://github.com/lapce/lapce/pull/1570): Added a basic tab context menu with common close actions


### PR DESCRIPTION
As reported in #1606, for large numbers of PaletteItems (5k+) `im::Vector` causes a stackoverflow by recursively calling a sort function. This PR collects the `im::Vector` into a `Vec` and uses `std`'s sorting implementation instead, which does not exhibit this behaviour. 

I've added a unit test to guard against this regressing.


- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users