### PR TITLE
feat: added show hover keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features/Changes
 
+- [#1620](https://github.com/lapce/lapce/pull/1620): Added "Show Hover" keybinding that will trigger the hover at the cursor location
 - [#1619](https://github.com/lapce/lapce/pull/1619):
   - Add active/inactive tab colours
   - Add primary button colour

--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -392,6 +392,11 @@ command = "goto_definition"
 mode = "n"
 
 [[keymaps]]
+key = "g h"
+command = "show_hover"
+mode = "n"
+
+[[keymaps]]
 key = "p"
 command = "paste"
 mode = "nv"

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -267,6 +267,9 @@ pub enum FocusCommand {
     #[strum(message = "Go to Type Definition")]
     #[strum(serialize = "goto_type_definition")]
     GotoTypeDefinition,
+    #[strum(message = "Show Hover")]
+    #[strum(serialize = "show_hover")]
+    ShowHover,
     #[strum(serialize = "jump_location_backward")]
     JumpLocationBackward,
     #[strum(serialize = "jump_location_forward")]

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -2082,6 +2082,10 @@ impl LapceEditorBufferData {
                     );
                 }
             }
+            ShowHover => {
+                let offset = self.editor.cursor.offset();
+                self.update_hover(ctx, offset);
+            }
             JumpLocationBackward => {
                 self.jump_location_backward(ctx);
             }


### PR DESCRIPTION
Issue: #1621

Added a new keyboard shortcut, that triggers the hover effect at the cursor location. Very useful for people that use vim-like bindings. The suggested shortcut, `g h`, is what is used by vscode's popular vim plugin, but some other popular defaults might be `ctrl + k`, `k`, `K` among others can be seen in the wild.

As a future improvement we might want to change how mouse events dismiss the hover as currently any mouse event that isn't over the cursor position or hover triggers the hover to become inactive.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users