### PR TITLE
Fix kts files not being recognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [#1477](https://github.com/lapce/lapce/pull/1477): Now use `esc` to close searchbar regarless of the current focus
 - [#1507](https://github.com/lapce/lapce/pull/1507): Fixed a crash when scratch buffer is closed
 - [#1547](https://github.com/lapce/lapce/pull/1547): Fix infinite cycle in workspace symbol search
+- [#1628](https://github.com/lapce/lapce/pull/1541): Fix kts files not being recognized
 
 ## 0.2.1
 

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -515,7 +515,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         indent: "  ",
         code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
         sticky_headers: &[],
-        extensions: &["kt"],
+        extensions: &["kt", "kts"],
     },
     #[cfg(feature = "lang-latex")]
     SyntaxProperties {
@@ -1187,7 +1187,7 @@ mod test {
     }
     #[cfg(feature = "lang-kotlin")]
     fn test_kotlin_lang() {
-        assert_language(LapceLanguage::Kotlin, &["kt"]);
+        assert_language(LapceLanguage::Kotlin, &["kt", "kts"]);
     }
     #[cfg(feature = "lang-vue")]
     fn test_vue_lang() {

--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -204,6 +204,7 @@ pub fn language_id_from_path(path: &Path) -> Option<&'static str> {
                     "jsx" => "javascriptreact",
                     "json" => "json",
                     "jl" => "julia",
+                    "kt" | "kts" => "kotlin",
                     "less" => "less",
                     "lua" => "lua",
                     "makefile" | "gnumakefile" => "makefile",


### PR DESCRIPTION
Registers `kts` files to the Kotlin language.
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users