### PR TITLE
Make side mouse buttons able to jump in code

### DIFF
--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -230,7 +230,21 @@ impl LapceEditor {
                 editor_data.cancel_hover();
             }
             MouseButton::Middle => {}
-            _ => (),
+            MouseButton::X1 => {
+                let command = LapceCommand {
+                    kind: CommandKind::Focus(FocusCommand::JumpLocationBackward),
+                    data: None
+                };
+                editor_data.run_command(ctx, &command, None, Modifiers::empty(), &Env::empty());
+            }
+            MouseButton::X2 => {
+                let command = LapceCommand {
+                    kind: CommandKind::Focus(FocusCommand::JumpLocationForward),
+                    data: None
+                };
+                editor_data.run_command(ctx, &command, None, Modifiers::empty(), &Env::empty());
+            }
+            _ => ()
         }
     }
 


### PR DESCRIPTION
Currently there's `ctrl+-` and `ctrl+shift+-` to jump forward and back, but ideally this should also be possible with mouse. I initially looked into adding mouse buttons as options for key binds but that seemed like a much taller task than expected, so I settled on simply baking it into the program. This might not be something you want, but it does what it has to so do with this what you will.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users