### PR TITLE
add editor and terminal zoom commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#1686](https://github.com/lapce/lapce/pull/1686): Add zoom in/out keybindings for editor and terminal
+
 ### Features/Changes
 
 ### Bug Fixes

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -457,6 +457,22 @@ pub enum LapceWorkbenchCommand {
     #[strum(message = "Toggle Inlay Hints")]
     ToggleInlayHints,
 
+    #[strum(serialize = "zoom_editor_in")]
+    #[strum(message = "Zoom In on Editor")]
+    ZoomInEditor,
+
+    #[strum(serialize = "zoom_editor_out")]
+    #[strum(message = "Zoom Out on Editor")]
+    ZoomOutEditor,
+
+    #[strum(serialize = "zoom_terminal_in")]
+    #[strum(message = "Zoom In on Terminal")]
+    ZoomInTerminal,
+
+    #[strum(serialize = "zoom_terminal_out")]
+    #[strum(message = "Zoom Out on Terminal")]
+    ZoomOutTerminal,
+
     #[strum(serialize = "restart_to_update")]
     RestartToUpdate,
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -1420,6 +1420,24 @@ impl LapceConfig {
         }
     }
 
+    pub fn zoom_editor_font_size(&mut self, out: bool) {
+        if out && self.editor.font_size > 2 {
+            self.editor.font_size -= 1
+        } else if !out && self.editor.font_size < 200 {
+            self.editor.font_size += 1
+        }
+    }
+
+    pub fn zoom_terminal_font_size(&mut self, out: bool) {
+        if self.terminal.font_size != 0 {
+            if out && self.terminal.font_size > 2 {
+                self.terminal.font_size -= 1
+            } else if !out && self.terminal.font_size < 200 {
+                self.terminal.font_size += 1
+            }
+        }
+    }
+
     pub fn terminal_font_size(&self) -> usize {
         if self.terminal.font_size > 0 {
             self.terminal.font_size

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1851,6 +1851,22 @@ impl LapceTabData {
             LapceWorkbenchCommand::Quit => {
                 ctx.submit_command(druid::commands::QUIT_APP);
             }
+            LapceWorkbenchCommand::ZoomInEditor => {
+                let config = Arc::make_mut(&mut self.config);
+                config.zoom_editor_font_size(false);
+            }
+            LapceWorkbenchCommand::ZoomOutEditor => {
+                let config = Arc::make_mut(&mut self.config);
+                config.zoom_editor_font_size(true);
+            }
+            LapceWorkbenchCommand::ZoomInTerminal => {
+                let config = Arc::make_mut(&mut self.config);
+                config.zoom_terminal_font_size(false);
+            }
+            LapceWorkbenchCommand::ZoomOutTerminal => {
+                let config = Arc::make_mut(&mut self.config);
+                config.zoom_terminal_font_size(true);
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Partially fixes #785, while it does not handle scaling, it allows an easy way to change the font's size