### PR TITLE
add codelens and sticky headers for Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features/Changes
 
+- [#1690](https://github.com/lapce/lapce/pull/1690): Add codelens and sticky headers for Dart
+
 ### Bug Fixes
 
 ## 0.2.3

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -299,8 +299,16 @@ const LANGUAGES: &[SyntaxProperties] = &[
         injection: None,
         comment: "//",
         indent: "  ",
-        code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
-        sticky_headers: &[],
+        code_lens: (
+            &["program", "class_definition"],
+            &[
+                "program",
+                "import_or_export",
+                "comment",
+                "documentation_comment",
+            ],
+        ),
+        sticky_headers: &["class_definition"],
         extensions: &["dart"],
     },
     #[cfg(feature = "lang-dockerfile")]


### PR DESCRIPTION
This PR adds codelens and sticky headers support for Dart.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users