### PR TITLE
Fix visual bug in search panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+ - [#1708](https://github.com/lapce/lapce/pull/1708): Fix visual issue when search panel is placed to either side panel
+
 ## 0.2.3
 
 ### Features/Changes

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -32,6 +32,7 @@ pub struct SearchInput {
     result_width: f64,
     search_input_padding: f64,
     mouse_pos: Point,
+    background_color: Option<&'static str>,
 }
 
 impl SearchInput {
@@ -64,7 +65,13 @@ impl SearchInput {
             icons,
             mouse_pos: Point::ZERO,
             search_input_padding,
+            background_color: Some(LapceTheme::EDITOR_BACKGROUND),
         }
+    }
+    
+    pub fn clear_background_color(mut self) -> Self {
+        self.background_color = None;
+        self
     }
 
     fn mouse_down(&self, ctx: &mut EventCtx, mouse_event: &MouseEvent) {
@@ -172,12 +179,14 @@ impl Widget<LapceTabData> for SearchInput {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, env: &Env) {
         let buffer = data.editor_view_content(self.parent_view_id);
 
-        let rect = ctx.size().to_rect();
-        ctx.fill(
-            rect,
-            data.config
-                .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
-        );
+        if let Some(background_color) = self.background_color {
+            let rect = ctx.size().to_rect();
+            ctx.fill(
+                rect,
+                data.config
+                    .get_color_unchecked(background_color),
+            );
+        }
         self.input.paint(ctx, data, env);
 
         let mut index = None;

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -281,7 +281,7 @@ pub fn new_search_panel(data: &LapceTabData) -> LapcePanel {
         .get(&data.search.editor_view_id)
         .unwrap();
 
-    let search_bar = SearchInput::new(editor_data.view_id);
+    let search_bar = SearchInput::new(editor_data.view_id).clear_background_color();
 
     let split = LapceSplit::new(data.search.split_id)
         .horizontal()

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -127,9 +127,9 @@ impl Widget<LapceTabData> for SearchInput {
         let icon_height = height - self.search_input_padding;
         let mut width = input_size.width + self.result_width + height * icon_len;
 
-        if width - 20.0 > bc.max().width {
+        if width > bc.max().width {
             let input_bc = BoxConstraints::tight(Size::new(
-                bc.max().width - height * icon_len - 20.0 - self.result_width,
+                bc.max().width - height * icon_len - self.result_width,
                 bc.max().height,
             ));
             input_size = self.input.layout(ctx, &input_bc, data, env);

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -68,7 +68,7 @@ impl SearchInput {
             background_color: Some(LapceTheme::EDITOR_BACKGROUND),
         }
     }
-    
+
     pub fn clear_background_color(mut self) -> Self {
         self.background_color = None;
         self
@@ -181,11 +181,7 @@ impl Widget<LapceTabData> for SearchInput {
 
         if let Some(background_color) = self.background_color {
             let rect = ctx.size().to_rect();
-            ctx.fill(
-                rect,
-                data.config
-                    .get_color_unchecked(background_color),
-            );
+            ctx.fill(rect, data.config.get_color_unchecked(background_color));
         }
         self.input.paint(ctx, data, env);
 


### PR DESCRIPTION
This PR removes a random margin and the background fill from the search panel input. This change fixes a visual issue when the search panel is placed to the left or the right panels.

Before:
![image](https://user-images.githubusercontent.com/977627/202109059-a12e7545-4eb6-43bb-8ded-93fae523e1bd.png)

After removing margin:
![image](https://user-images.githubusercontent.com/977627/202108862-0d77c1e1-e59b-4df9-baf6-e233fda25e15.png)

After removing background:
![image](https://user-images.githubusercontent.com/977627/202108999-ea61b344-d4e4-428d-8672-95ffacd7c48c.png)
