### PR TITLE
Add save without formatting; Allow toggling of formatting for autosave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 - [#1720](https://github.com/lapce/lapce/pull/1720): Display signature/parameter information from LSP
 - [#1723](https://github.com/lapce/lapce/pull/1723): In the palette, display the keybind for a command adjacent to it
+- [#1722](https://github.com/lapce/lapce/pull/1722): Add 'Save without Formatting'; Add option to disable formatting on autosave
 
 ### Bug Fixes
 

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -26,6 +26,7 @@ modal-mode-relative-line-numbers = true
 format-on-save = false
 highlight-matching-brackets = true
 autosave-interval = 0
+format-on-autosave = true
 enable-inlay-hints = true
 inlay-hint-font-family = ""
 inlay-hint-font-size = 0

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -304,6 +304,9 @@ pub enum FocusCommand {
     #[strum(message = "Save")]
     #[strum(serialize = "save")]
     Save,
+    #[strum(message = "Save Without Formatting")]
+    #[strum(serialize = "save_without_format")]
+    SaveWithoutFormatting,
     #[strum(serialize = "save_and_exit")]
     SaveAndExit,
     #[strum(serialize = "force_exit")]

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -422,6 +422,10 @@ pub struct EditorConfig {
     )]
     pub autosave_interval: u64,
     #[field_names(
+        desc = "Whether the document should be formatted when an autosave is triggered (required Format on Save)"
+    )]
+    pub format_on_autosave: bool,
+    #[field_names(
         desc = "If enabled the cursor treats leading soft tabs as if they are hard tabs."
     )]
     pub atomic_soft_tabs: bool,

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1342,7 +1342,7 @@ impl LapceEditorBufferData {
         }
     }
 
-    fn save(&mut self, ctx: &mut EventCtx, exit: bool) {
+    fn save(&mut self, ctx: &mut EventCtx, exit: bool, allow_formatting: bool) {
         if self.doc.buffer().is_pristine() && self.doc.content().is_file() {
             if exit {
                 ctx.submit_command(Command::new(
@@ -1358,7 +1358,8 @@ impl LapceEditorBufferData {
         }
 
         if let BufferContent::File(path) = self.doc.content() {
-            let format_on_save = self.config.editor.format_on_save;
+            let format_on_save =
+                allow_formatting && self.config.editor.format_on_save;
             let path = path.clone();
             let proxy = self.proxy.clone();
             let rev = self.doc.rev();
@@ -2278,10 +2279,13 @@ impl LapceEditorBufferData {
                 }
             }
             SaveAndExit => {
-                self.save(ctx, true);
+                self.save(ctx, true, true);
             }
             Save => {
-                self.save(ctx, false);
+                self.save(ctx, false, true);
+            }
+            SaveWithoutFormatting => {
+                self.save(ctx, false, false);
             }
             Rename => {
                 if let BufferContent::File(path) = self.doc.content() {

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -628,10 +628,17 @@ impl Widget<LapceTabData> for LapceEditorView {
                         if ctx.is_focused() {
                             let doc = data.main_split.editor_doc(self.view_id);
                             if !doc.buffer().is_pristine() {
+                                let save_cmd =
+                                    if data.config.editor.format_on_autosave {
+                                        FocusCommand::Save
+                                    } else {
+                                        FocusCommand::SaveWithoutFormatting
+                                    };
+
                                 ctx.submit_command(Command::new(
                                     LAPCE_COMMAND,
                                     LapceCommand {
-                                        kind: CommandKind::Focus(FocusCommand::Save),
+                                        kind: CommandKind::Focus(save_cmd),
                                         data: None,
                                     },
                                     Target::Widget(editor.view_id),


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users  
  
This PR does two things:  
- Adds a command to save without formatting. This is in other editors. It is also generally useful (ex: large files where formatting is slow; or where you're occasionally editing a library file which doesn't use the same formatting as the rest of your code, like in C/C++)  
- Allows disabling formatting on autosave. Fixes #1650.  I set it to true by default, though it should perhaps be false by default since formatting on autosave can be annoying?  
  
It would be beneficial to allow 'forcing' a save. Other editors allow saving the file even if there are no edits. This would allow manual saving to then apply formatting for users with autosave enabled.