### PR TITLE
Display the keybinding of a command within the palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features/Changes
 - [#1720](https://github.com/lapce/lapce/pull/1720): Display signature/parameter information from LSP
+- [#1723](https://github.com/lapce/lapce/pull/1723): In the palette, display the keybind for a command adjacent to it
 
 ### Bug Fixes
 

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -25,7 +25,7 @@ use lapce_core::{
     directory::Directory,
     editor::EditType,
     meta,
-    mode::MotionMode,
+    mode::{Mode, MotionMode},
     movement::Movement,
     register::Register,
     selection::Selection,
@@ -981,6 +981,24 @@ impl LapceTabData {
 
     pub fn is_drag_editor(&self) -> bool {
         matches!(&*self.drag, Some((_, _, DragContent::EditorTab(..))))
+    }
+
+    /// Get the mode for the current editor or terminal
+    pub fn mode(&self) -> Mode {
+        if self.config.core.modal {
+            let mode = if self.focus_area == FocusArea::Panel(PanelKind::Terminal) {
+                self.terminal
+                    .terminals
+                    .get(&self.terminal.active_term_id)
+                    .map(|terminal| terminal.mode)
+            } else {
+                self.main_split.active_editor().map(|e| e.cursor.get_mode())
+            };
+
+            mode.unwrap_or(Mode::Normal)
+        } else {
+            Mode::Insert
+        }
     }
 
     pub fn update_from_editor_buffer_data(

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -38,7 +38,7 @@ use crate::{
     document::BufferContent,
     editor::EditorLocation,
     find::Find,
-    keypress::{KeyPressData, KeyPressFocus},
+    keypress::{KeyMap, KeyPressData, KeyPressFocus},
     list::ListData,
     panel::PanelKind,
     proxy::{path_from_url, LapceProxy},
@@ -358,6 +358,12 @@ pub struct PaletteListData {
     /// Should only be `None` when it hasn't been updated initially  
     /// We need this just for some rendering, and not editing it.
     pub workspace: Option<Arc<LapceWorkspace>>,
+    /// Should only be `None` when it hasn't been updated initially.
+    /// We need this just for some rendering, and not editing it.
+    pub keymaps: Option<Arc<Vec<KeyMap>>>,
+    /// The mode of the current editor/terminal/none
+    #[data(eq)]
+    pub mode: Option<Mode>,
 }
 
 #[derive(Clone)]
@@ -443,8 +449,15 @@ impl PaletteData {
         let widget_id = WidgetId::next();
         let scroll_id = WidgetId::next();
         let preview_editor = WidgetId::next();
-        let mut list_data =
-            ListData::new(config, widget_id, PaletteListData { workspace: None });
+        let mut list_data = ListData::new(
+            config,
+            widget_id,
+            PaletteListData {
+                workspace: None,
+                keymaps: None,
+                mode: None,
+            },
+        );
         // TODO: Make these configurable
         list_data.line_height = Some(25);
         list_data.max_displayed_items = 15;

--- a/lapce-ui/src/status.rs
+++ b/lapce-ui/src/status.rs
@@ -8,8 +8,8 @@ use lapce_core::mode::Mode;
 use lapce_data::{
     command::{CommandKind, LapceCommand, LapceWorkbenchCommand, LAPCE_COMMAND},
     config::{LapceConfig, LapceIcons, LapceTheme},
-    data::{FocusArea, LapceTabData},
-    panel::{PanelContainerPosition, PanelKind},
+    data::LapceTabData,
+    panel::PanelContainerPosition,
 };
 
 use crate::tab::LapceIcon;
@@ -330,16 +330,7 @@ impl Widget<LapceTabData> for LapceStatus {
         let mut _right = 0.0;
 
         if data.config.core.modal {
-            let mode = if data.focus_area == FocusArea::Panel(PanelKind::Terminal) {
-                data.terminal
-                    .terminals
-                    .get(&data.terminal.active_term_id)
-                    .map(|terminal| terminal.mode)
-            } else {
-                data.main_split.active_editor().map(|e| e.cursor.get_mode())
-            };
-
-            let (mode, color) = match mode.unwrap_or(Mode::Normal) {
+            let (mode, color) = match data.mode() {
                 Mode::Normal => ("Normal", LapceTheme::STATUS_MODAL_NORMAL),
                 Mode::Insert => ("Insert", LapceTheme::STATUS_MODAL_INSERT),
                 Mode::Visual => ("Visual", LapceTheme::STATUS_MODAL_VISUAL),


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users  
  
This PR adds the keybinding for a command as the hint in the palette. Fixes #1683. This will make it easier for users to know the keybinding for a command they might be using often.  
![image](https://user-images.githubusercontent.com/13157904/202920062-99363e02-0621-43c6-b6c9-d682e470145e.png)


It pays attention to what mode the user is in, so it won't recommend completely incorrect keybinds.

----
  
Could be improved with some better alignment of the keybindings?
I think this could also be improved by taking into account `when` the keybind can be used.