### PR TITLE
fix: set TERM for flatpak

### DIFF
--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -68,8 +68,8 @@ impl Terminal {
                 let args = if shell.is_empty() {
                     vec![
                         "--host".to_string(),
-                        "--env=TERM=alacritty".to_string(), 
-                        host_shell
+                        "--env=TERM=alacritty".to_string(),
+                        host_shell,
                     ]
                 } else {
                     vec![

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -66,10 +66,15 @@ impl Terminal {
                 let host_shell = flatpak_get_default_host_shell();
 
                 let args = if shell.is_empty() {
-                    vec!["--host".to_string(), host_shell]
+                    vec![
+                        "--host".to_string(),
+                        "--env=TERM=alacritty".to_string(), 
+                        host_shell
+                    ]
                 } else {
                     vec![
                         "--host".to_string(),
+                        "--env=TERM=alacritty".to_string(),
                         host_shell,
                         "-c".to_string(),
                         shell.to_string(),


### PR DESCRIPTION
Not setting the `TERM` variable causes weird graphical behavior in the integrated terminal. See #1695.