### PR TITLE
Fix enclosing parentheses crash

### DIFF
--- a/lapce-core/src/syntax/mod.rs
+++ b/lapce-core/src/syntax/mod.rs
@@ -792,6 +792,10 @@ impl Syntax {
     ) -> Option<(usize, usize)> {
         let tree = self.layers.try_tree()?;
         let mut node = tree.root_node().descendant_for_byte_range(offset, offset)?;
+        // If there is no text then the document can't have any bytes
+        if self.text.is_empty() {
+            return None;
+        }
 
         loop {
             let start = node.start_byte();
@@ -815,6 +819,10 @@ impl Syntax {
     pub fn find_enclosing_pair(&self, offset: usize) -> Option<(usize, usize)> {
         let tree = self.layers.try_tree()?;
         let mut node = tree.root_node().descendant_for_byte_range(offset, offset)?;
+        // If there is no text then the document can't have any bytes
+        if self.text.is_empty() {
+            return None;
+        }
 
         loop {
             let start = node.start_byte();


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users  

Fixes #1739   
Getting the root node of the tree and then finding a descendent for an offset would give a zero-sized node if the file is empty. This avoids that by checking whether there is any text in the file before accessing text at an index.  
It also adds this check to `find_enclosing_pair`, though I believe its caller avoids the issue by a separate check.