### PR TITLE
Limit search response size to avoid crash/perf issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1737](https://github.com/lapce/lapce/pull/1726): Fix an issue that plugins can't be upgraded
 
 - [#1724](https://github.com/lapce/lapce/pull/1724): files and hidden folders no longer will be considered when trying to open a plugin base folder
+- [#1753](https://github.com/lapce/lapce/pull/1753): Limit proxy search response size in order to avoid issues with absurdly long lines
 
 ## 0.2.4
 


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

There was a bug where searching in a workspace with files with large one-liner text would cause the editor to die (sometimes crash, sometimes visual artifacts due to creating a too large text layout and maybe messing with GPU memory or something). A common example would be minified javascript files, which are on a singular line and are quite massive.  
The issue was that the search would respond with the *entire* line's text, which could be a lot (ex: one of my files was 500kb of text in a single line)! This wouldn't be too bad by itself, though it would probably stress search performance if you had a lot of them, but the main issue comes from trying to render it. It would try creating a text layout, which would then cause issues due to it being so large.  
  
The fix is just to take a part of the line, 100 characters before and 100 characters after the end of the match, and restrict the text sent (and thus displayed) to that.  
  