### PR TITLE
(band-aid) fix opening some file types crashing lapce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#1737](https://github.com/lapce/lapce/pull/1726): Fix an issue that plugins can't be upgraded
 - [#1724](https://github.com/lapce/lapce/pull/1724): files and hidden folders no longer will be considered when trying to open a plugin base folder
 - [#1753](https://github.com/lapce/lapce/pull/1753): Limit proxy search response size in order to avoid issues with absurdly long lines
+- [#1764](https://github.com/lapce/lapce/pull/1764): (band-aid) fix opening some file types crashing lapce
 
 ## 0.2.4
 

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -964,14 +964,25 @@ impl LapceLanguage {
         self.properties().indent
     }
 
-    pub(crate) fn new_highlight_config(&self) -> HighlightConfiguration {
+    pub(crate) fn new_highlight_config(&self) -> Option<HighlightConfiguration> {
         let props = self.properties();
         let language = (props.language)();
         let query = props.highlight;
         let injection = props.injection;
-
-        HighlightConfiguration::new(language, query, injection.unwrap_or(""), "")
-            .unwrap()
+        // TODO: This is a temporary band-aid fix for some languages causing Lapce to panic.
+        // These languages will now no longer be highlighted.
+        match HighlightConfiguration::new(
+            language,
+            query,
+            injection.unwrap_or(""),
+            "",
+        ) {
+            Ok(x) => Some(x),
+            Err(x) => {
+                log::error!("Encountered {x:?} while trying to construct HighlightConfiguration for {self}");
+                None
+            }
+        }
     }
 
     pub(crate) fn walk_tree(

--- a/lapce-core/src/syntax/highlight.rs
+++ b/lapce-core/src/syntax/highlight.rs
@@ -37,10 +37,7 @@ macro_rules! declare_language_highlights {
             $(
                 #[cfg(feature = $feature_name)]
                 pub static $name: Lazy<Option<Arc<HighlightConfiguration>>> = Lazy::new(|| {
-                    match LapceLanguage::$name.new_highlight_config() {
-                        Some(x) => Some(Arc::new(x)),
-                        None => None
-                    }
+                    LapceLanguage::$name.new_highlight_config().map(Arc::new)
                 });
             )*
         }

--- a/lapce-core/src/syntax/highlight.rs
+++ b/lapce-core/src/syntax/highlight.rs
@@ -36,11 +36,16 @@ macro_rules! declare_language_highlights {
             // We use Arcs because in the future we may want to load highlight configurations at runtime
             $(
                 #[cfg(feature = $feature_name)]
-                pub static $name: Lazy<Arc<HighlightConfiguration>> = Lazy::new(|| Arc::new(LapceLanguage::$name.new_highlight_config()));
+                pub static $name: Lazy<Option<Arc<HighlightConfiguration>>> = Lazy::new(|| {
+                    match LapceLanguage::$name.new_highlight_config() {
+                        Some(x) => Some(Arc::new(x)),
+                        None => None
+                    }
+                });
             )*
         }
 
-        pub(crate) fn get_highlight_config(lang: LapceLanguage) -> Arc<HighlightConfiguration> {
+        pub(crate) fn get_highlight_config(lang: LapceLanguage) -> Option<Arc<HighlightConfiguration>> {
             match lang {
                 $(
                     #[cfg(feature = $feature_name)]

--- a/lapce-core/src/syntax/mod.rs
+++ b/lapce-core/src/syntax/mod.rs
@@ -173,7 +173,9 @@ impl SyntaxLayers {
         queue.push_back(self.root);
 
         let injection_callback = |language: &str| {
-            LapceLanguage::from_name(language).map(get_highlight_config)
+            LapceLanguage::from_name(language)
+                .map(get_highlight_config)
+                .unwrap_or(None)
         };
 
         let mut edits = Vec::new();
@@ -551,21 +553,23 @@ impl std::fmt::Debug for Syntax {
 
 impl Syntax {
     pub fn init(path: &Path) -> Option<Syntax> {
-        LapceLanguage::from_path(path).map(Syntax::from_language)
+        LapceLanguage::from_path(path)
+            .map(Syntax::from_language)
+            .unwrap_or(None)
     }
 
-    pub fn from_language(language: LapceLanguage) -> Syntax {
-        Syntax {
+    pub fn from_language(language: LapceLanguage) -> Option<Syntax> {
+        get_highlight_config(language).map(|x| Syntax {
             rev: 0,
             language,
             text: Rope::from(""),
-            layers: SyntaxLayers::new_empty(get_highlight_config(language)),
+            layers: SyntaxLayers::new_empty(x),
             lens: Self::lens_from_normal_lines(0, 0, 0, &Vec::new()),
             line_height: 0,
             lens_height: 0,
             normal_lines: Vec::new(),
             styles: None,
-        }
+        })
     }
 
     pub fn parse(

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -449,7 +449,7 @@ impl Document {
     }
 
     pub fn set_language(&mut self, language: LapceLanguage) {
-        self.syntax = Some(Syntax::from_language(language));
+        self.syntax = Syntax::from_language(language);
     }
 
     pub fn set_diagnostics(&mut self, diagnostics: &[EditorDiagnostic]) {

--- a/lapce-data/src/markdown/mod.rs
+++ b/lapce-data/src/markdown/mod.rs
@@ -166,7 +166,7 @@ pub fn highlight_as_code(
     text: &str,
     start_offset: usize,
 ) {
-    let syntax = language.map(Syntax::from_language);
+    let syntax = language.map(Syntax::from_language).unwrap_or(None);
 
     let styles = syntax.and_then(|mut syntax| {
         syntax.parse(0, Rope::from(text), None);


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

THIS IS NOT A FULL FIX! It only fixes the *crash*, but not the underlying issue, as that is somewhere in the dependencies and I'm unable to find out how to fix it. The error will still be logged, but will not crash lapce.

I might look into the issue further, but suggest adding this band-aid so we at least don't get a crash.

Example of a logged error: `[2022-11-30][08:31:11][lapce_core::language][ERROR] Encountered QueryError { row: 52, column: 3, offset: 702, message: "expansion_flags", kind: NodeType } while trying to construct HighlightConfiguration for bash` - all information from the panic message is still present after this fix.

Shell scripts, and potentially other languages, make lapce panic when opened. This is explained further in the issue this PR closes.

Closes: #1762
Opens: Something like "Lapce does not highlight .sh and .bash files"