### PR TITLE
Add error dialog for invalid syntax highlighting schemes

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, path::Path, str::FromStr};
 use strum_macros::{Display, EnumString};
 use tree_sitter::TreeCursor;
 
-use crate::syntax::highlight::HighlightConfiguration;
+use crate::syntax::highlight::{HighlightConfiguration, HighlightIssue};
 
 //
 // To add support for an hypothetical language called Foo, for example, using
@@ -978,7 +978,9 @@ impl LapceLanguage {
         self.properties().indent
     }
 
-    pub(crate) fn new_highlight_config(&self) -> Option<HighlightConfiguration> {
+    pub(crate) fn new_highlight_config(
+        &self,
+    ) -> Result<HighlightConfiguration, HighlightIssue> {
         let props = self.properties();
         let language = (props.language)();
         let query = props.highlight;
@@ -989,10 +991,11 @@ impl LapceLanguage {
             injection.unwrap_or(""),
             "",
         ) {
-            Ok(x) => Some(x),
+            Ok(x) => Ok(x),
             Err(x) => {
-                log::error!("Encountered {x:?} while trying to construct HighlightConfiguration for {self}");
-                None
+                let str = format!("Encountered {x:?} while trying to construct HighlightConfiguration for {self}");
+                log::error!("{str}");
+                Err(HighlightIssue::Error(str))
             }
         }
     }

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -978,14 +978,23 @@ impl LapceLanguage {
         self.properties().indent
     }
 
-    pub(crate) fn new_highlight_config(&self) -> HighlightConfiguration {
+    pub(crate) fn new_highlight_config(&self) -> Option<HighlightConfiguration> {
         let props = self.properties();
         let language = (props.language)();
         let query = props.highlight;
         let injection = props.injection;
-
-        HighlightConfiguration::new(language, query, injection.unwrap_or(""), "")
-            .unwrap()
+        match HighlightConfiguration::new(
+            language,
+            query,
+            injection.unwrap_or(""),
+            "",
+        ) {
+            Ok(x) => Some(x),
+            Err(x) => {
+                log::error!("Encountered {x:?} while trying to construct HighlightConfiguration for {self}");
+                None
+            }
+        }
     }
 
     pub(crate) fn walk_tree(

--- a/lapce-core/src/syntax/highlight.rs
+++ b/lapce-core/src/syntax/highlight.rs
@@ -31,18 +31,18 @@ macro_rules! declare_language_highlights {
             use once_cell::sync::Lazy;
             use crate::language::LapceLanguage;
             use std::sync::Arc;
-            use super::HighlightConfiguration;
+            use super::{HighlightConfiguration, HighlightIssue};
 
             // We use Arcs because in the future we may want to load highlight configurations at runtime
             $(
                 #[cfg(feature = $feature_name)]
-                pub static $name: Lazy<Option<Arc<HighlightConfiguration>>> = Lazy::new(|| {
+                pub static $name: Lazy<Result<Arc<HighlightConfiguration>, HighlightIssue>> = Lazy::new(|| {
                     LapceLanguage::$name.new_highlight_config().map(Arc::new)
                 });
             )*
         }
 
-        pub(crate) fn get_highlight_config(lang: LapceLanguage) -> Option<Arc<HighlightConfiguration>> {
+        pub(crate) fn get_highlight_config(lang: LapceLanguage) -> Result<Arc<HighlightConfiguration>, HighlightIssue> {
             match lang {
                 $(
                     #[cfg(feature = $feature_name)]
@@ -113,6 +113,12 @@ declare_language_highlights!(
 /// Indicates which highlight should be applied to a region of source code.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Highlight(pub usize);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HighlightIssue {
+    Error(String),
+    NotAvailable,
+}
 
 /// Represents a single step in rendering a syntax-highlighted document.
 #[derive(Copy, Clone, Debug)]

--- a/lapce-core/src/syntax/highlight.rs
+++ b/lapce-core/src/syntax/highlight.rs
@@ -36,11 +36,13 @@ macro_rules! declare_language_highlights {
             // We use Arcs because in the future we may want to load highlight configurations at runtime
             $(
                 #[cfg(feature = $feature_name)]
-                pub static $name: Lazy<Arc<HighlightConfiguration>> = Lazy::new(|| Arc::new(LapceLanguage::$name.new_highlight_config()));
+                pub static $name: Lazy<Option<Arc<HighlightConfiguration>>> = Lazy::new(|| {
+                    LapceLanguage::$name.new_highlight_config().map(Arc::new)
+                });
             )*
         }
 
-        pub(crate) fn get_highlight_config(lang: LapceLanguage) -> Arc<HighlightConfiguration> {
+        pub(crate) fn get_highlight_config(lang: LapceLanguage) -> Option<Arc<HighlightConfiguration>> {
             match lang {
                 $(
                     #[cfg(feature = $feature_name)]

--- a/lapce-core/src/syntax/mod.rs
+++ b/lapce-core/src/syntax/mod.rs
@@ -173,7 +173,9 @@ impl SyntaxLayers {
         queue.push_back(self.root);
 
         let injection_callback = |language: &str| {
-            LapceLanguage::from_name(language).map(get_highlight_config)
+            LapceLanguage::from_name(language)
+                .map(get_highlight_config)
+                .unwrap_or(None)
         };
 
         let mut edits = Vec::new();
@@ -551,21 +553,23 @@ impl std::fmt::Debug for Syntax {
 
 impl Syntax {
     pub fn init(path: &Path) -> Option<Syntax> {
-        LapceLanguage::from_path(path).map(Syntax::from_language)
+        LapceLanguage::from_path(path)
+            .map(Syntax::from_language)
+            .unwrap_or(None)
     }
 
-    pub fn from_language(language: LapceLanguage) -> Syntax {
-        Syntax {
+    pub fn from_language(language: LapceLanguage) -> Option<Syntax> {
+        get_highlight_config(language).map(|x| Syntax {
             rev: 0,
             language,
             text: Rope::from(""),
-            layers: SyntaxLayers::new_empty(get_highlight_config(language)),
+            layers: SyntaxLayers::new_empty(x),
             lens: Self::lens_from_normal_lines(0, 0, 0, &Vec::new()),
             line_height: 0,
             lens_height: 0,
             normal_lines: Vec::new(),
             styles: None,
-        }
+        })
     }
 
     pub fn parse(

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -428,7 +428,7 @@ impl Document {
                     "Syntax Highlighting failed".to_owned(),
                     ShowMessageParams {
                         typ: MessageType::ERROR,
-                        message: format!("An error occured trying to load syntax highlighting info: {x}. Please report this."),
+                        message: format!("An error occurred trying to load syntax highlighting info: {x}."),
                     },
                 );
                 None

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -24,7 +24,7 @@ use lapce_core::{
     register::{Clipboard, Register, RegisterData},
     selection::{SelRegion, Selection},
     style::line_styles,
-    syntax::edit::SyntaxEdit,
+    syntax::{edit::SyntaxEdit, highlight::HighlightIssue},
     syntax::{util::matching_pair_direction, Syntax},
     word::WordCursor,
 };
@@ -40,7 +40,7 @@ use lapce_xi_rope::{
 };
 use lsp_types::{
     CodeActionOrCommand, CodeActionResponse, DiagnosticSeverity, InlayHint,
-    InlayHintLabel,
+    InlayHintLabel, MessageType, ShowMessageParams,
 };
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -376,7 +376,9 @@ impl Document {
         proxy: Arc<LapceProxy>,
     ) -> Self {
         let syntax = match &content {
-            BufferContent::File(path) => Syntax::init(path),
+            BufferContent::File(path) => {
+                Self::syntax_to_option(&proxy, Syntax::init(path))
+            }
             BufferContent::Local(_) => None,
             BufferContent::SettingsValue(..) => None,
             BufferContent::Scratch(..) => None,
@@ -414,6 +416,26 @@ impl Document {
         }
     }
 
+    fn syntax_to_option(
+        proxy: &Arc<LapceProxy>,
+        syntax: Result<Syntax, HighlightIssue>,
+    ) -> Option<Syntax> {
+        match syntax {
+            Ok(x) => Some(x),
+            Err(HighlightIssue::NotAvailable) => None,
+            Err(HighlightIssue::Error(x)) => {
+                proxy.core_rpc.show_message(
+                    "Syntax Highlighting failed".to_owned(),
+                    ShowMessageParams {
+                        typ: MessageType::ERROR,
+                        message: format!("An error occured trying to load syntax highlighting info: {x}. Please report this."),
+                    },
+                );
+                None
+            }
+        }
+    }
+
     pub fn id(&self) -> BufferId {
         self.id
     }
@@ -425,7 +447,9 @@ impl Document {
     pub fn set_content(&mut self, content: BufferContent) {
         self.content = content;
         self.syntax = match &self.content {
-            BufferContent::File(path) => Syntax::init(path),
+            BufferContent::File(path) => {
+                Self::syntax_to_option(&self.proxy, Syntax::init(path))
+            }
             BufferContent::Local(_) => None,
             BufferContent::SettingsValue(..) => None,
             BufferContent::Scratch(..) => None,
@@ -449,7 +473,8 @@ impl Document {
     }
 
     pub fn set_language(&mut self, language: LapceLanguage) {
-        self.syntax = Syntax::from_language(language);
+        self.syntax =
+            Self::syntax_to_option(&self.proxy, Syntax::from_language(language));
     }
 
     pub fn set_diagnostics(&mut self, diagnostics: &[EditorDiagnostic]) {

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -449,7 +449,7 @@ impl Document {
     }
 
     pub fn set_language(&mut self, language: LapceLanguage) {
-        self.syntax = Some(Syntax::from_language(language));
+        self.syntax = Syntax::from_language(language);
     }
 
     pub fn set_diagnostics(&mut self, diagnostics: &[EditorDiagnostic]) {

--- a/lapce-data/src/history.rs
+++ b/lapce-data/src/history.rs
@@ -268,7 +268,7 @@ impl DocumentHistory {
 
             let content = self.buffer.as_ref().unwrap().text().clone();
             rayon::spawn(move || {
-                if let Some(mut syntax) = Syntax::init(&path) {
+                if let Ok(mut syntax) = Syntax::init(&path) {
                     syntax.parse(0, content, None);
                     if let Some(styles) = syntax.styles {
                         let _ = event_sink.submit_command(

--- a/lapce-data/src/markdown/mod.rs
+++ b/lapce-data/src/markdown/mod.rs
@@ -166,7 +166,7 @@ pub fn highlight_as_code(
     text: &str,
     start_offset: usize,
 ) {
-    let syntax = language.map(Syntax::from_language);
+    let syntax = language.map(Syntax::from_language).unwrap_or(None);
 
     let styles = syntax.and_then(|mut syntax| {
         syntax.parse(0, Rope::from(text), None);


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This is a follow-up to the syntax highlighting issues #1762 #1764 #1768 #1769 #1771.

This PR adds proper and visible failure handling of any future encounter with invalid syntax highlighting .scm files. When such a file is invalid, as soon as an associated file is opened, there will be a dialog saying 
![image](https://user-images.githubusercontent.com/48156391/205072413-a564073a-c9b5-4d6d-93cb-7b2d8ff0cb5c.png)
The error will also be logged.

All the info from the panic is there, but without the confusion of "Why did lapce just crash???".