### PR TITLE
format keybinding name on settings to Capital case.

### DIFF
--- a/lapce-ui/src/keymap.rs
+++ b/lapce-ui/src/keymap.rs
@@ -274,15 +274,17 @@ impl Widget<LapceTabData> for LapceKeymap {
                         ));
                         let text_layout = ctx
                             .text()
-                            .new_text_layout(
-                                match cmd.kind.desc() {
-                                    Some(desc) => desc.to_string(),
-                                    None => {
-                                        let mut formatted = cmd.kind.str().replace("_", " ");
-                                        format!("{}{formatted}", formatted.remove(0).to_uppercase())
-                                    }
+                            .new_text_layout(match cmd.kind.desc() {
+                                Some(desc) => desc.to_string(),
+                                None => {
+                                    let mut formatted =
+                                        cmd.kind.str().replace('_', " ");
+                                    format!(
+                                        "{}{formatted}",
+                                        formatted.remove(0).to_uppercase()
+                                    )
                                 }
-                            )
+                            })
                             .font(
                                 data.config.ui.font_family(),
                                 data.config.ui.font_size() as f64,
@@ -382,15 +384,17 @@ impl Widget<LapceTabData> for LapceKeymap {
                         ));
                         let text_layout = ctx
                             .text()
-                            .new_text_layout(
-                                match command.kind.desc() {
-                                    Some(desc) => desc.to_string(),
-                                    None => {
-                                        let mut formatted = command.kind.str().replace("_", " ");
-                                        format!("{}{formatted}", formatted.remove(0).to_uppercase())
-                                    }
+                            .new_text_layout(match command.kind.desc() {
+                                Some(desc) => desc.to_string(),
+                                None => {
+                                    let mut formatted =
+                                        command.kind.str().replace('_', " ");
+                                    format!(
+                                        "{}{formatted}",
+                                        formatted.remove(0).to_uppercase()
+                                    )
                                 }
-                            )
+                            })
                             .font(
                                 data.config.ui.font_family(),
                                 data.config.ui.font_size() as f64,

--- a/lapce-ui/src/keymap.rs
+++ b/lapce-ui/src/keymap.rs
@@ -275,7 +275,13 @@ impl Widget<LapceTabData> for LapceKeymap {
                         let text_layout = ctx
                             .text()
                             .new_text_layout(
-                                cmd.kind.desc().unwrap_or_else(|| cmd.kind.str()),
+                                match cmd.kind.desc() {
+                                    Some(desc) => desc.to_string(),
+                                    None => {
+                                        let mut formatted = cmd.kind.str().replace("_", " ");
+                                        format!("{}{formatted}", formatted.remove(0).to_uppercase())
+                                    }
+                                }
                             )
                             .font(
                                 data.config.ui.font_family(),
@@ -377,10 +383,13 @@ impl Widget<LapceTabData> for LapceKeymap {
                         let text_layout = ctx
                             .text()
                             .new_text_layout(
-                                command
-                                    .kind
-                                    .desc()
-                                    .unwrap_or_else(|| command.kind.str()),
+                                match command.kind.desc() {
+                                    Some(desc) => desc.to_string(),
+                                    None => {
+                                        let mut formatted = command.kind.str().replace("_", " ");
+                                        format!("{}{formatted}", formatted.remove(0).to_uppercase())
+                                    }
+                                }
                             )
                             .font(
                                 data.config.ui.font_family(),


### PR DESCRIPTION
With this PR, the keybindings which doesn't have a message/description will be `Capital case`d, instead of showing the `kebab_cased` name.

This is my first PR, let me know what you guys think
**Before**
<img width="794" alt="Before" src="https://user-images.githubusercontent.com/8536607/205472252-3268cfa2-e52b-409c-b365-f4220de0ab82.png">

**After**
<img width="800" alt="After" src="https://user-images.githubusercontent.com/8536607/205472241-faedd59c-43cd-4e0e-b59a-ce9968336781.png">
