### PR TITLE
WIP: History based tab switching

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -40,6 +40,7 @@ multicursor-whole-words = true
 render-whitespace = "none"
 show-indent-guide = true
 atomic-soft-tabs = false
+historic-next-tab = false
 
 [terminal]
 font-family = ""

--- a/extra/schemas/settings.json
+++ b/extra/schemas/settings.json
@@ -274,6 +274,9 @@
                 },
                 "atomic-soft-tabs": {
                     "type": "boolean"
+                },
+                "historic-next-tab": {
+                    "type": "boolean"
                 }
             },
             "required": [],

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -429,6 +429,10 @@ pub struct EditorConfig {
         desc = "If enabled the cursor treats leading soft tabs as if they are hard tabs."
     )]
     pub atomic_soft_tabs: bool,
+    #[field_names(
+        desc = "If enabled the cursor treats leading soft tabs as if they are hard tabs."
+    )]
+    pub historic_next_tab: bool,
 }
 
 impl EditorConfig {

--- a/lapce-data/src/db.rs
+++ b/lapce-data/src/db.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use crossbeam_channel::{unbounded, Sender};
 use druid::{ExtEventSink, Point, Rect, Size, Vec2, WidgetId};
+use im::Vector;
 use lapce_core::directory::Directory;
 use lapce_xi_rope::Rope;
 use serde::{Deserialize, Serialize};
@@ -100,24 +101,27 @@ impl EditorTabInfo {
         event_sink: ExtEventSink,
     ) -> LapceEditorTabData {
         let editor_tab_id = WidgetId::next();
+        let children: Vector<EditorTabChild> = self
+            .children
+            .iter()
+            .map(|child| {
+                child.to_data(
+                    data,
+                    editor_tab_id,
+                    editor_positions,
+                    tab_id,
+                    config,
+                    event_sink.clone(),
+                )
+            })
+            .collect();
+        let history = children.iter().enumerate().map(|(i, _)| i).collect();
         let editor_tab_data = LapceEditorTabData {
             widget_id: editor_tab_id,
             split,
             active: self.active,
-            children: self
-                .children
-                .iter()
-                .map(|child| {
-                    child.to_data(
-                        data,
-                        editor_tab_id,
-                        editor_positions,
-                        tab_id,
-                        config,
-                        event_sink.clone(),
-                    )
-                })
-                .collect(),
+            children,
+            history,
             layout_rect: Rc::new(RefCell::new(Rect::ZERO)),
             content_is_hot: Rc::new(RefCell::new(false)),
         };

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -111,12 +111,7 @@ impl LapceEditorTabHeaderContent {
                     || editor_tab.active != tab_idx
                 {
                     data.main_split.active_tab = Arc::new(Some(self.widget_id));
-                    editor_tab.active = tab_idx;
-                    ctx.submit_command(Command::new(
-                        LAPCE_UI_COMMAND,
-                        LapceUICommand::Focus,
-                        Target::Widget(editor_tab.children[tab_idx].widget_id()),
-                    ));
+                    editor_tab.focus_tab(tab_idx, ctx);
                 }
                 self.mouse_pos = Some(mouse_event.pos);
                 self.mouse_down_target = Some((MouseAction::Drag, tab_idx));


### PR DESCRIPTION
This patch adds a setting to change the behavior of the NextEditorTab and PreviousEditorTab to switch to the most recently used tab/least recently used tab.

This is my first PR for this project and so am anxious to get some feedback.  I am (admittedly biased) used to using vscode where ctrl-tab and ctrl-shift-tab switch to most recently used/least recently used tabs as opposed to next/previous in tab index order.

This PR adds a setting to alternate between these behaviors.  However after doing this, I'm thinking a more appropriate solution would be to keep  `NextEditorTab`/`PreviousEditorTab` with existing behavior and add new LapceUICommand commands such as `SwitchMostRecentlyUsedTab`/`SwitchLeastRecentlyUsedTab` and instead of using a editor setting to change behavior, rely on user changing key bindings.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users