### PR TITLE
Add sticky header theming option

### DIFF
--- a/defaults/dark-theme.toml
+++ b/defaults/dark-theme.toml
@@ -106,6 +106,7 @@ yellow = "#E5C07B"
 "editor.indent_guide" = "$grey"
 "editor.drag_drop_background" = "#79c1fc55"
 "editor.drag_drop_tab_background" = "#0b0e1455"
+"editor.sticky_header_background" = "$black"
 
 "inlay_hint.foreground" = "$white"
 "inlay_hint.background" = "#528abF37"

--- a/defaults/light-theme.toml
+++ b/defaults/light-theme.toml
@@ -132,6 +132,7 @@ yellow = "#C18401"
 "editor.indent_guide" = "$grey"
 "editor.drag_drop_background" = "#79c1fc33"
 "editor.drag_drop_tab_background" = "#0b0e1433"
+"editor.sticky_header_background" = "$white"
 
 "inlay_hint.foreground" = "$black"
 "inlay_hint.background" = "#528bFF55"

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -153,6 +153,7 @@ magenta = "#C678DD"
 "editor.indent_guide" = "$grey"
 "editor.drag_drop_background" = "#79c1fc55"
 "editor.drag_drop_tab_background" = "#0b0e1455"
+"editor.sticky_header_background" = "$black"
 
 "inlay_hint.foreground" = "$white"
 "inlay_hint.background" = "#528bFF88"

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -82,7 +82,8 @@ impl LapceTheme {
     pub const EDITOR_VISIBLE_WHITESPACE: &str = "editor.visible_whitespace";
     pub const EDITOR_INDENT_GUIDE: &str = "editor.indent_guide";
     pub const EDITOR_DRAG_DROP_BACKGROUND: &str = "editor.drag_drop_background";
-    pub const EDITOR_STICKY_HEADER_BACKGROUND: &str = "editor.sticky_header_background";
+    pub const EDITOR_STICKY_HEADER_BACKGROUND: &str =
+        "editor.sticky_header_background";
     pub const EDITOR_DRAG_DROP_TAB_BACKGROUND: &str =
         "editor.drag_drop_tab_background";
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -82,6 +82,7 @@ impl LapceTheme {
     pub const EDITOR_VISIBLE_WHITESPACE: &str = "editor.visible_whitespace";
     pub const EDITOR_INDENT_GUIDE: &str = "editor.indent_guide";
     pub const EDITOR_DRAG_DROP_BACKGROUND: &str = "editor.drag_drop_background";
+    pub const EDITOR_STICKY_HEADER_BACKGROUND: &str = "editor.sticky_header_background";
     pub const EDITOR_DRAG_DROP_TAB_BACKGROUND: &str =
         "editor.drag_drop_tab_background";
 

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -1618,7 +1618,7 @@ impl LapceEditor {
         ctx.fill(
             sticky_area_rect,
             data.config
-                .get_color_unchecked(LapceTheme::EDITOR_BACKGROUND),
+                .get_color_unchecked(LapceTheme::EDITOR_STICKY_HEADER_BACKGROUND),
         );
 
         // Paint lines


### PR DESCRIPTION
- Added `editor.sticky_header_background` to allow different color for sticky header, defaults to $black in base
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users