### PR TITLE
Removing unnecessary allocations and more

### DIFF
--- a/lapce-core/src/buffer/mod.rs
+++ b/lapce-core/src/buffer/mod.rs
@@ -882,7 +882,9 @@ impl Buffer {
         offset: usize,
     ) -> Option<usize> {
         if let Some(syntax) = syntax {
-            syntax.find_tag(offset, true, &c.to_string())
+            let mut char_buffer = [0_u8; 4];
+            let tag = c.encode_utf8(&mut char_buffer);
+            syntax.find_tag(offset, true, tag)
         } else {
             WordCursor::new(&self.text, offset).previous_unmatched(c)
         }

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -548,7 +548,14 @@ impl Editor {
                         let selection = cursor.edit_selection(buffer);
                         let data = match mode {
                             VisualMode::Linewise => data.content.clone(),
-                            _ => "\n".to_string() + &data.content,
+                            _ => {
+                                let mut content = String::with_capacity(
+                                    data.content.capacity() + 1,
+                                );
+                                content.push_str(&data.content);
+                                content.push_str("\n");
+                                content
+                            }
                         };
                         (selection, data)
                     }

--- a/lapce-data/src/alert.rs
+++ b/lapce-data/src/alert.rs
@@ -39,8 +39,8 @@ impl AlertData {
             widget_id: WidgetId::next(),
             active: false,
             content: AlertContentData {
-                title: "".to_string(),
-                msg: "".to_string(),
+                title: String::new(),
+                msg: String::new(),
                 buttons: Vec::new(),
             },
         }

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -1228,14 +1228,14 @@ impl LapceConfig {
     pub fn export_theme(&self) -> String {
         let mut table = toml::value::Table::new();
         let mut theme = self.color_theme.clone();
-        theme.name = "".to_string();
+        theme.name = String::new();
         theme.syntax.sort_keys();
         theme.ui.sort_keys();
         table.insert(
-            "color-theme".to_string(),
+            "color-theme".to_owned(),
             toml::Value::try_from(&theme).unwrap(),
         );
-        table.insert("ui".to_string(), toml::Value::try_from(&self.ui).unwrap());
+        table.insert("ui".to_owned(), toml::Value::try_from(&self.ui).unwrap());
         let value = toml::Value::Table(table);
         toml::to_string_pretty(&value).unwrap()
     }
@@ -1356,7 +1356,7 @@ impl LapceConfig {
         theme: &str,
         preview: bool,
     ) {
-        self.core.color_theme = theme.to_string();
+        self.core.color_theme = theme.to_owned();
         self.resolve_theme(workspace);
         if !preview {
             LapceConfig::update_file(
@@ -1373,7 +1373,7 @@ impl LapceConfig {
         theme: &str,
         preview: bool,
     ) {
-        self.core.icon_theme = theme.to_string();
+        self.core.icon_theme = theme.to_owned();
         self.resolve_theme(workspace);
         if !preview {
             LapceConfig::update_file(

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -3509,7 +3509,7 @@ impl LapceMainSplitData {
             main_split_data.split_id = Arc::new(split_data.widget_id);
             for (path, locations) in positions.into_iter() {
                 let unsaved_buffer = unsaved_buffers
-                    .get(&path.to_str().unwrap().to_string())
+                    .get(path.to_str().unwrap())
                     .map(Rope::from);
                 Arc::make_mut(main_split_data.open_docs.get_mut(&path).unwrap())
                     .retrieve_file(locations.clone(), unsaved_buffer, None);
@@ -3746,10 +3746,10 @@ impl LapceMainSplitData {
                                 doc.content().file_name()
                             ),
                             msg: "Your changes will be lost if you don't save them."
-                                .to_string(),
+                                .to_owned(),
                             buttons: vec![
                                 (
-                                    "Save".to_string(),
+                                    "Save".to_owned(),
                                     view_id,
                                     LapceCommand {
                                         kind: CommandKind::Focus(
@@ -3759,7 +3759,7 @@ impl LapceMainSplitData {
                                     },
                                 ),
                                 (
-                                    "Don't Save".to_string(),
+                                    "Don't Save".to_owned(),
                                     view_id,
                                     LapceCommand {
                                         kind: CommandKind::Focus(
@@ -4518,7 +4518,7 @@ impl std::fmt::Display for LapceWorkspace {
                 .as_ref()
                 .and_then(|p| p.to_str())
                 .map(|p| p.to_string())
-                .unwrap_or_else(|| "".to_string())
+                .unwrap_or_else(|| String::new())
         )
     }
 }

--- a/lapce-data/src/db.rs
+++ b/lapce-data/src/db.rs
@@ -629,13 +629,13 @@ impl LapceDb {
     fn insert_unsaved_buffer(&self, main_split: &LapceMainSplitData) -> Result<()> {
         let sled_db = self.get_db()?;
         // Vec of all unsaved buffers of format path_buff, file_content
-        let mut unsaved_buffers = Vec::new();
+        let mut unsaved_buffers = Vec::with_capacity(main_split.open_docs.len());
 
         for (path, doc) in &main_split.open_docs {
             if !doc.buffer().is_pristine() && doc.content().is_file() {
                 let path_str = path.to_str().unwrap();
                 let buf_text = doc.buffer().to_string();
-                unsaved_buffers.push(path_str.to_string());
+                unsaved_buffers.push(path_str.to_owned());
                 unsaved_buffers.push(buf_text);
             }
         }

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     collections::HashMap,
     iter::Iterator,
@@ -746,12 +747,11 @@ impl LapceEditorBufferData {
             .slice_to_cow(start_offset..end_offset)
             .to_string();
         let char = if start_offset == 0 {
-            "".to_string()
+            Cow::from("")
         } else {
             self.doc
                 .buffer()
                 .slice_to_cow(start_offset - 1..start_offset)
-                .to_string()
         };
         let completion = Arc::make_mut(&mut self.completion);
         if !display_if_empty_input && input.is_empty() && char != "." && char != ":"
@@ -771,7 +771,7 @@ impl LapceEditorBufferData {
                 completion.request(
                     self.proxy.clone(),
                     self.doc.content().path().unwrap().into(),
-                    "".to_string(),
+                    String::new(),
                     start_pos,
                 );
             }
@@ -799,7 +799,7 @@ impl LapceEditorBufferData {
         completion.request(
             self.proxy.clone(),
             self.doc.content().path().unwrap().into(),
-            "".to_string(),
+            String::new(),
             start_pos,
         );
 
@@ -1016,7 +1016,7 @@ impl LapceEditorBufferData {
                 path: path.to_path_buf(),
                 position: Some(offset),
                 scroll_offset: None,
-                history: Some("head".to_string()),
+                history: Some("head".to_owned()),
             };
             ctx.submit_command(Command::new(
                 LAPCE_UI_COMMAND,
@@ -2258,18 +2258,17 @@ impl LapceEditorBufferData {
                 };
                 let pattern = if region.is_caret() {
                     let (start, end) = self.doc.buffer().select_word(region.start);
-                    self.doc.buffer().slice_to_cow(start..end).to_string()
+                    self.doc.buffer().slice_to_cow(start..end)
                 } else {
                     self.doc
                         .buffer()
                         .slice_to_cow(region.min()..region.max())
-                        .to_string()
                 };
                 if !pattern.contains('\n') {
                     Arc::make_mut(&mut self.find).set_find(&pattern, false, false);
                     ctx.submit_command(Command::new(
                         LAPCE_UI_COMMAND,
-                        LapceUICommand::UpdateSearchInput(pattern),
+                        LapceUICommand::UpdateSearchInput(pattern.to_string()),
                         Target::Widget(*self.main_split.tab_id),
                     ));
                 }
@@ -2362,7 +2361,7 @@ impl LapceEditorBufferData {
                     self.proxy.proxy_rpc.rename(
                         self.rename.path.clone(),
                         self.rename.position,
-                        new_name.to_string(),
+                        new_name.to_owned(),
                         move |result| {
                             if let Ok(ProxyResponse::Rename { edit }) = result {
                                 let _ = event_sink.submit_command(
@@ -2563,7 +2562,7 @@ impl KeyPressFocus for LapceEditorBufferData {
         } else if let Some(direction) = self.editor.inline_find.clone() {
             self.inline_find(ctx, direction.clone(), c);
             let editor = Arc::make_mut(&mut self.editor);
-            editor.last_inline_find = Some((direction, c.to_string()));
+            editor.last_inline_find = Some((direction, c.to_owned()));
             editor.inline_find = None;
         }
     }

--- a/lapce-data/src/find.rs
+++ b/lapce-data/src/find.rs
@@ -175,7 +175,7 @@ impl Find {
 
         self.unset();
 
-        self.search_string = Some(search_string.to_string());
+        self.search_string = Some(search_string.to_owned());
         self.whole_words = whole_words;
 
         // create regex from untrusted input

--- a/lapce-data/src/history.rs
+++ b/lapce-data/src/history.rs
@@ -233,7 +233,7 @@ impl DocumentHistory {
                         id,
                         path,
                         rev,
-                        history: "head".to_string(),
+                        history: "head".to_owned(),
                         changes: Arc::new(changes),
                     },
                     Target::Widget(tab_id),

--- a/lapce-data/src/keypress/keypress.rs
+++ b/lapce-data/src/keypress/keypress.rs
@@ -66,10 +66,10 @@ impl KeyPress {
         let mut origin = origin;
         let mut keys = Vec::new();
         if self.mods.ctrl() {
-            keys.push("Ctrl".to_string());
+            keys.push("Ctrl".to_owned());
         }
         if self.mods.alt() {
-            keys.push("Alt".to_string());
+            keys.push("Alt".to_owned());
         }
         if self.mods.meta() {
             let keyname = match std::env::consts::OS {
@@ -77,10 +77,10 @@ impl KeyPress {
                 "windows" => "Win",
                 _ => "Meta",
             };
-            keys.push(keyname.to_string());
+            keys.push(keyname.to_owned());
         }
         if self.mods.shift() {
-            keys.push("Shift".to_string());
+            keys.push("Shift".to_owned());
         }
         match &self.key {
             druid::keyboard_types::Key::Character(c) => {
@@ -88,7 +88,7 @@ impl KeyPress {
                     && c.to_lowercase() != c.to_uppercase()
                     && !self.mods.shift()
                 {
-                    keys.push("Shift".to_string());
+                    keys.push("Shift".to_owned());
                 }
                 keys.push(c.to_uppercase());
             }
@@ -462,7 +462,7 @@ impl KeyPress {
 
             // Custom key name mappings
             "esc" => Escape,
-            "space" => Character(" ".to_string()),
+            "space" => Character(" ".to_owned()),
             "bs" => Backspace,
             "up" => ArrowUp,
             "down" => ArrowDown,

--- a/lapce-data/src/keypress/loader.rs
+++ b/lapce-data/src/keypress/loader.rs
@@ -120,8 +120,8 @@ impl KeyMapLoader {
             command: toml_keymap
                 .get("command")
                 .and_then(|c| c.as_str())
-                .map(|w| w.trim().to_string())
-                .unwrap_or_else(|| "".to_string()),
+                .map(|w| w.trim().to_owned())
+                .unwrap_or_else(|| String::new()),
         }))
     }
 }

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -170,7 +170,7 @@ impl KeyPressData {
             command_keymaps: Arc::new(command_keymaps),
             commands_with_keymap: Arc::new(Vec::new()),
             commands_without_keymap: Arc::new(Vec::new()),
-            filter_pattern: "".to_string(),
+            filter_pattern: String::new(),
             filtered_commands_with_keymap: Arc::new(Vec::new()),
             filtered_commands_without_keymap: Arc::new(Vec::new()),
             count: None,

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -66,18 +66,18 @@ pub enum PaletteType {
 impl PaletteType {
     fn string(&self) -> String {
         match &self {
-            PaletteType::Line => "/".to_string(),
-            PaletteType::DocumentSymbol => "@".to_string(),
-            PaletteType::WorkspaceSymbol => "#".to_string(),
-            PaletteType::GlobalSearch => "?".to_string(),
-            PaletteType::Workspace => ">".to_string(),
-            PaletteType::Command => ":".to_string(),
+            PaletteType::Line => "/".to_owned(),
+            PaletteType::DocumentSymbol => "@".to_owned(),
+            PaletteType::WorkspaceSymbol => "#".to_owned(),
+            PaletteType::GlobalSearch => "?".to_owned(),
+            PaletteType::Workspace => ">".to_owned(),
+            PaletteType::Command => ":".to_owned(),
             PaletteType::File
             | PaletteType::Reference
             | PaletteType::ColorTheme
             | PaletteType::IconTheme
             | PaletteType::SshHost
-            | PaletteType::Language => "".to_string(),
+            | PaletteType::Language => String::new(),
         }
     }
 
@@ -471,7 +471,7 @@ impl PaletteData {
             sender,
             receiver: Some(receiver),
             run_id: Uuid::new_v4().to_string(),
-            input: "".to_string(),
+            input: String::new(),
             cursor: 0,
             has_nonzero_default_index: false,
             total_items: im::Vector::new(),
@@ -535,7 +535,7 @@ impl PaletteViewData {
         }
         let palette = Arc::make_mut(&mut self.palette);
         palette.status = PaletteStatus::Inactive;
-        palette.input = "".to_string();
+        palette.input = String::new();
         palette.cursor = 0;
         palette.palette_type = PaletteType::File;
         palette.total_items.clear();
@@ -720,7 +720,7 @@ impl PaletteViewData {
         };
 
         if palette.cursor == start {
-            palette.input = "".to_string();
+            palette.input = String::new();
             palette.cursor = 0;
         } else {
             palette.input.replace_range(start..palette.cursor, "");
@@ -952,7 +952,7 @@ impl PaletteViewData {
     fn get_languages(&mut self, _ctx: &mut EventCtx) {
         let palette = Arc::make_mut(&mut self.palette);
         let mut langs = LapceLanguage::languages();
-        langs.push("Plain Text".to_string());
+        langs.push("Plain Text".to_owned());
         palette.total_items = langs
             .iter()
             .sorted()

--- a/lapce-data/src/plugin.rs
+++ b/lapce-data/src/plugin.rs
@@ -65,7 +65,7 @@ impl VoltsList {
             total: 0,
             status: PluginLoadStatus::Loading,
             loading: Arc::new(Mutex::new(false)),
-            query: "".to_string(),
+            query: String::new(),
             event_sink,
         }
     }
@@ -361,7 +361,7 @@ impl PluginData {
     }
 
     pub fn install_volt(proxy: Arc<LapceProxy>, volt: VoltInfo) -> Result<()> {
-        proxy.core_rpc.volt_installing(volt.clone(), "".to_string());
+        proxy.core_rpc.volt_installing(volt.clone(), String::new());
 
         if volt.wasm {
             proxy.proxy_rpc.install_volt(volt);
@@ -372,7 +372,7 @@ impl PluginData {
                     log::warn!("download_volt err: {err:?}");
                     proxy.core_rpc.volt_installing(
                         volt.clone(),
-                        "Could not download Plugin".to_string(),
+                        "Could not download Plugin".to_owned(),
                     );
                     return Ok(());
                 }
@@ -387,7 +387,7 @@ impl PluginData {
     }
 
     pub fn remove_volt(proxy: Arc<LapceProxy>, meta: VoltMetadata) -> Result<()> {
-        proxy.core_rpc.volt_removing(meta.clone(), "".to_string());
+        proxy.core_rpc.volt_removing(meta.clone(), String::new());
         if meta.wasm.is_some() {
             proxy.proxy_rpc.remove_volt(meta);
         } else {
@@ -395,14 +395,14 @@ impl PluginData {
                 let path = meta.dir.as_ref().ok_or_else(|| {
                     proxy.core_rpc.volt_removing(
                         meta.clone(),
-                        "Plugin Directory does not exist".to_string(),
+                        "Plugin Directory does not exist".to_owned(),
                     );
                     anyhow::anyhow!("don't have dir")
                 })?;
                 if std::fs::remove_dir_all(path).is_err() {
                     proxy.core_rpc.volt_removing(
                         meta.clone(),
-                        "Could not remove Plugin Directory".to_string(),
+                        "Could not remove Plugin Directory".to_owned(),
                     );
                 } else {
                     proxy.core_rpc.volt_removed(meta.info(), false);

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -377,7 +377,7 @@ impl LapceProxy {
 
     fn start_remote(&self, remote: impl Remote) -> Result<()> {
         let proxy_version = match *meta::RELEASE {
-            "Debug" | "Nightly" => "nightly".to_string(),
+            "Debug" | "Nightly" => "nightly".to_owned(),
             _ => format!("v{}", *meta::VERSION),
         };
 

--- a/lapce-data/src/rename.rs
+++ b/lapce-data/src/rename.rs
@@ -42,7 +42,7 @@ impl RenameData {
             from_editor: WidgetId::next(),
             start: 0,
             end: 0,
-            placeholder: "".to_string(),
+            placeholder: String::new(),
         }
     }
 

--- a/lapce-data/src/source_control.rs
+++ b/lapce-data/src/source_control.rs
@@ -44,7 +44,7 @@ impl SourceControlData {
             split_id: WidgetId::next(),
             split_direction: SplitDirection::Horizontal,
             file_diffs: Vec::new(),
-            branch: "".to_string(),
+            branch: String::new(),
             branches: im::Vector::new(),
         }
     }
@@ -187,7 +187,7 @@ impl KeyPressFocus for SourceControlData {
                                     .0
                                     .path()
                                     .clone(),
-                                "head".to_string(),
+                                "head".to_owned(),
                             ),
                             Target::Auto,
                         ));

--- a/lapce-data/src/svg.rs
+++ b/lapce-data/src/svg.rs
@@ -27,7 +27,7 @@ impl Default for SvgStore {
 impl SvgStore {
     fn new() -> Self {
         let mut svgs = HashMap::new();
-        svgs.insert("lapce_logo".to_string(), Svg::from_str(LOGO).unwrap());
+        svgs.insert("lapce_logo".to_owned(), Svg::from_str(LOGO).unwrap());
 
         Self {
             svgs,

--- a/lapce-data/src/terminal.rs
+++ b/lapce-data/src/terminal.rs
@@ -646,7 +646,7 @@ impl LapceTerminalData {
             widget_id,
             view_id,
             split_id,
-            title: "".to_string(),
+            title: String::new(),
             mode: Mode::Terminal,
             visual_mode: VisualMode::Normal,
             raw,

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -281,19 +281,19 @@ impl ProxyHandler for Dispatcher {
                     let result = file_get_head(workspace, &path);
                     if let Ok((_blob_id, content)) = result {
                         Ok(ProxyResponse::BufferHeadResponse {
-                            version: "head".to_string(),
+                            version: "head".to_owned(),
                             content,
                         })
                     } else {
                         Err(RpcError {
                             code: 0,
-                            message: "can't get file head".to_string(),
+                            message: "can't get file head".to_owned(),
                         })
                     }
                 } else {
                     Err(RpcError {
                         code: 0,
-                        message: "no workspace set".to_string(),
+                        message: "no workspace set".to_owned(),
                     })
                 };
                 self.respond_rpc(id, result);
@@ -356,7 +356,7 @@ impl ProxyHandler for Dispatcher {
                     } else {
                         Err(RpcError {
                             code: 0,
-                            message: "no workspace set".to_string(),
+                            message: "no workspace set".to_owned(),
                         })
                     };
                     proxy_rpc.handle_response(id, result);
@@ -628,7 +628,7 @@ impl ProxyHandler for Dispatcher {
                     } else {
                         Err(RpcError {
                             code: 0,
-                            message: "no workspace set".to_string(),
+                            message: "no workspace set".to_owned(),
                         })
                     };
                     proxy_rpc.handle_response(id, result);

--- a/lapce-proxy/src/plugin/catalog.rs
+++ b/lapce-proxy/src/plugin/catalog.rs
@@ -90,7 +90,7 @@ impl PluginCatalog {
                     plugin_id,
                     Err(RpcError {
                         code: 0,
-                        message: "plugin doesn't exist".to_string(),
+                        message: "plugin doesn't exist".to_owned(),
                     }),
                 );
             }
@@ -109,7 +109,7 @@ impl PluginCatalog {
                     lapce_rpc::plugin::PluginId(0),
                     Err(RpcError {
                         code: 0,
-                        message: "no available plugin could make a callback, because the plugins list is empty".to_string(),
+                        message: "no available plugin could make a callback, because the plugins list is empty".to_owned(),
                     }),
                 );
                 return;
@@ -309,7 +309,7 @@ impl PluginCatalog {
         } else {
             f.call(Err(RpcError {
                 code: 0,
-                message: "plugin doesn't exist".to_string(),
+                message: "plugin doesn't exist".to_owned(),
             }));
         }
     }

--- a/lapce-proxy/src/plugin/lsp.rs
+++ b/lapce-proxy/src/plugin/lsp.rs
@@ -310,7 +310,7 @@ impl LspClient {
                         snippet_support: Some(true),
                         resolve_support: Some(
                             CompletionItemCapabilityResolveSupport {
-                                properties: vec!["additionalTextEdits".to_string()],
+                                properties: vec!["additionalTextEdits".to_owned()],
                             },
                         ),
                         ..Default::default()
@@ -343,7 +343,7 @@ impl LspClient {
                 code_action: Some(CodeActionClientCapabilities {
                     data_support: Some(true),
                     resolve_support: Some(CodeActionCapabilityResolveSupport {
-                        properties: vec!["edit".to_string()],
+                        properties: vec!["edit".to_owned()],
                     }),
                     code_action_literal_support: Some(CodeActionLiteralSupport {
                         code_action_kind: CodeActionKindLiteralSupport {

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -807,7 +807,7 @@ impl PluginCatalogRpcHandler {
                             Err(RpcError {
                                 code: 0,
                                 message: "completion item deserialize error"
-                                    .to_string(),
+                                    .to_owned(),
                             })
                         }
                     }
@@ -882,7 +882,7 @@ impl PluginCatalogRpcHandler {
                             Err(RpcError {
                                 code: 0,
                                 message: "code_action item deserialize error"
-                                    .to_string(),
+                                    .to_owned(),
                             })
                         }
                     }
@@ -1034,7 +1034,7 @@ pub fn install_volt(
     if download_volt_result.is_err() {
         catalog_rpc
             .core_rpc
-            .volt_installing(volt, "Could not download Plugin".to_string());
+            .volt_installing(volt, "Could not download Plugin".to_owned());
     }
     let meta = download_volt_result?;
     let local_catalog_rpc = catalog_rpc.clone();
@@ -1054,14 +1054,14 @@ pub fn remove_volt(
         let path = volt.dir.as_ref().ok_or_else(|| {
             catalog_rpc
                 .core_rpc
-                .volt_removing(volt.clone(), "Plugin Directory not set".to_string());
+                .volt_removing(volt.clone(), "Plugin Directory not set".to_owned());
             anyhow::anyhow!("don't have dir")
         })?;
         if let Err(e) = std::fs::remove_dir_all(path) {
             eprintln!("Could not delete plugin folder: {}", e);
             catalog_rpc.core_rpc.volt_removing(
                 volt.clone(),
-                "Could not remove Plugin Directory".to_string(),
+                "Could not remove Plugin Directory".to_owned(),
             );
         } else {
             catalog_rpc.core_rpc.volt_removed(volt.info(), false);

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -309,7 +309,7 @@ impl PluginServerRpcHandler {
         rx.recv().unwrap_or_else(|_| {
             Err(RpcError {
                 code: 0,
-                message: "io error".to_string(),
+                message: "io error".to_owned(),
             })
         })
     }
@@ -393,7 +393,7 @@ impl PluginServerRpcHandler {
                     } else {
                         rh.invoke(Err(RpcError {
                             code: 0,
-                            message: "server not capable".to_string(),
+                            message: "server not capable".to_owned(),
                         }));
                     }
                 }
@@ -1004,7 +1004,7 @@ impl PluginHostHandler {
         )
         .ok_or_else(|| RpcError {
             code: 0,
-            message: "can't get styles".to_string(),
+            message: "can't get styles".to_owned(),
         });
         f.call(result);
     }

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -328,7 +328,7 @@ pub fn start_volt(
     let mut linker = wasmtime::Linker::new(&engine);
     wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
     HttpState::new()?.add_to_linker(&mut linker, |_| HttpCtx {
-        allowed_hosts: Some(vec!["insecure:allow-all".to_string()]),
+        allowed_hosts: Some(vec!["insecure:allow-all".to_owned()]),
         max_concurrent_requests: Some(100),
     })?;
 

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -62,16 +62,16 @@ impl Terminal {
             let mut parts = shell.split(' ');
 
             if flatpak_use_host_terminal {
-                let flatpak_spawn_path = "/usr/bin/flatpak-spawn".to_string();
+                let flatpak_spawn_path = "/usr/bin/flatpak-spawn".to_owned();
                 let host_shell = flatpak_get_default_host_shell();
 
                 let args = if shell.is_empty() {
-                    vec!["--host".to_string(), host_shell]
+                    vec!["--host".to_owned(), host_shell]
                 } else {
                     vec![
-                        "--host".to_string(),
+                        "--host".to_owned(),
                         host_shell,
-                        "-c".to_string(),
+                        "-c".to_owned(),
                         shell.to_string(),
                     ]
                 };

--- a/lapce-rpc/src/core.rs
+++ b/lapce-rpc/src/core.rs
@@ -194,7 +194,7 @@ impl CoreRpcHandler {
         rx.recv().unwrap_or_else(|_| {
             Err(RpcError {
                 code: 0,
-                message: "io error".to_string(),
+                message: "io error".to_owned(),
             })
         })
     }

--- a/lapce-rpc/src/parse.rs
+++ b/lapce-rpc/src/parse.rs
@@ -46,7 +46,7 @@ impl RpcObject {
     pub fn into_response(mut self) -> Result<Result<Value, Value>, String> {
         let _ = self
             .get_id()
-            .ok_or_else(|| "Response requires 'id' field.".to_string())?;
+            .ok_or_else(|| "Response requires 'id' field.".to_owned())?;
 
         if self.0.get("result").is_some() == self.0.get("error").is_some() {
             return Err("RPC response must contain exactly one of\

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -402,7 +402,7 @@ impl ProxyRpcHandler {
         rx.recv().unwrap_or_else(|_| {
             Err(RpcError {
                 code: 0,
-                message: "io error".to_string(),
+                message: "io error".to_owned(),
             })
         })
     }

--- a/lapce-ui/src/app.rs
+++ b/lapce-ui/src/app.rs
@@ -59,7 +59,7 @@ pub fn launch() {
     // small hack to unblock terminal if launched from it
     if !cli.wait {
         let mut args = std::env::args().collect::<Vec<_>>();
-        args.push("--wait".to_string());
+        args.push("--wait".to_owned());
         let mut cmd = std::process::Command::new(&args[0]);
         #[cfg(target_os = "windows")]
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW

--- a/lapce-ui/src/completion.rs
+++ b/lapce-ui/src/completion.rs
@@ -90,7 +90,7 @@ impl Snippet {
             return Some((
                 SnippetElement::PlaceHolder(
                     tab,
-                    vec![SnippetElement::Text("".to_string())],
+                    vec![SnippetElement::Text(String::new())],
                 ),
                 end,
             ));
@@ -106,33 +106,36 @@ impl Snippet {
         escs: Vec<&str>,
         loose_escs: Vec<&str>,
     ) -> Option<(SnippetElement, usize)> {
-        let mut s = &s[pos..];
-        let mut ele = "".to_string();
+        let mut ele = String::new();
         let mut end = pos;
-
-        while !s.is_empty() {
-            if s.len() >= 2 {
-                let esc = &s[..2];
-                let mut new_escs = escs.clone();
-                new_escs.extend_from_slice(&loose_escs);
-
-                if new_escs
-                    .iter()
-                    .map(|e| format!("\\{}", e))
-                    .any(|x| x == *esc)
-                {
-                    ele += &s[1..2];
-                    end += 2;
-                    s = &s[2..];
-                    continue;
+        let mut chars_iter = (&s[pos..]).chars().peekable();
+        loop {
+            match chars_iter.next() {
+                Some(char) => {
+                    if char == '\\' {
+                        if let Some(&next_char) = chars_iter.peek() {
+                            if escs.iter().chain(loose_escs.iter()).any(|str| {
+                                let mut chars = str.chars();
+                                chars.next() == Some(next_char)
+                                    && chars.next() == None
+                            }) {
+                                chars_iter.next();
+                                ele.push(next_char);
+                                end += 2;
+                                continue;
+                            }
+                        }
+                    }
+                    let mut buf = [0_u8; 4];
+                    let result = char.encode_utf8(&mut buf);
+                    if escs.contains(&&*result) {
+                        break;
+                    }
+                    ele.push(char);
+                    end += 1;
                 }
+                None => break,
             }
-            if escs.contains(&&s[0..1]) {
-                break;
-            }
-            ele += &s[0..1];
-            end += 1;
-            s = &s[1..];
         }
         if ele.is_empty() {
             return None;

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -192,18 +192,15 @@ impl LapceEditorGutter {
                         let actual_line = l - (line - len) + r.start;
 
                         let content = actual_line + 1;
+                        let mut text = content.to_string();
+                        text.push_str(
+                            &" ".repeat((last_line + 1).to_string().len() + 2),
+                        );
+                        text.push_str(" -");
 
                         let text_layout = ctx
                             .text()
-                            .new_text_layout(
-                                content.to_string()
-                                    + &vec![
-                                        " ";
-                                        (last_line + 1).to_string().len() + 2
-                                    ]
-                                    .join("")
-                                    + " -",
-                            )
+                            .new_text_layout(text)
                             .font(
                                 data.config.editor.font_family(),
                                 data.config.editor.font_size as f64,

--- a/lapce-ui/src/editor/header.rs
+++ b/lapce-ui/src/editor/header.rs
@@ -165,7 +165,7 @@ impl LapceEditorHeader {
                     .unwrap_or("")
                     .to_string();
                 if !data.doc.buffer().is_pristine() {
-                    file_name = "*".to_string() + &file_name;
+                    file_name = "*".to_owned() + &file_name;
                 }
                 if let Some(_compare) = data.editor.compare.as_ref() {
                     file_name += " (Working tree)";

--- a/lapce-ui/src/editor/tab_header.rs
+++ b/lapce-ui/src/editor/tab_header.rs
@@ -91,8 +91,8 @@ impl LapceEditorTabHeader {
     fn paint_header(&self, ctx: &mut PaintCtx, data: &LapceTabData) {
         let editor_tab = data.main_split.editor_tabs.get(&self.widget_id).unwrap();
         let child = editor_tab.active_child();
-        let mut text = "".to_string();
-        let mut hint = "".to_string();
+        let mut text = String::new();
+        let mut hint = String::new();
         let mut svg = data.config.ui_svg(LapceIcons::FILE);
         let mut svg_color = Some(
             data.config
@@ -136,7 +136,7 @@ impl LapceEditorTabHeader {
                     }
                 }
                 EditorTabChild::Settings { .. } => {
-                    text = "Settings".to_string();
+                    text = "Settings".to_owned();
                     hint = format!("ver. {}", *meta::VERSION);
                     svg = data.config.ui_svg(LapceIcons::SETTINGS);
                 }

--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -457,7 +457,7 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
         let mut x = 0.0;
 
         for child in editor_tab.children.iter() {
-            let mut text = "".to_string();
+            let mut text = String::new();
             let mut svg = data.config.ui_svg(LapceIcons::FILE);
             let mut svg_color = Some(
                 data.config

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -357,7 +357,7 @@ impl FileExplorer {
                             .and_then(|p| p.file_name())
                             .and_then(|s| s.to_str())
                             .map(|s| s.to_string())
-                            .unwrap_or_else(|| "No Folder Open".to_string())
+                            .unwrap_or_else(|| "No Folder Open".to_owned())
                             .into(),
                     ),
                     Self::new(data).boxed(),
@@ -1150,8 +1150,8 @@ impl OpenEditorList {
         active: bool,
     ) {
         let size = ctx.size();
-        let mut text = "".to_string();
-        let mut hint = "".to_string();
+        let mut text = String::new();
+        let mut hint = String::new();
         let mut svg = data.config.ui_svg(LapceIcons::FILE);
         let mut svg_color = Some(
             data.config
@@ -1192,7 +1192,7 @@ impl OpenEditorList {
                 }
             }
             EditorTabChild::Settings { .. } => {
-                text = "Settings".to_string();
+                text = "Settings".to_owned();
                 hint = format!("ver. {}", *meta::VERSION);
                 svg = data.config.ui_svg(LapceIcons::SETTINGS);
             }

--- a/lapce-ui/src/find.rs
+++ b/lapce-ui/src/find.rs
@@ -252,7 +252,7 @@ impl Widget<LapceTabData> for FindBox {
                     ),
                 }
             } else {
-                "No results".to_string()
+                "No results".to_owned()
             })
             .font(
                 data.config.ui.font_family(),

--- a/lapce-ui/src/ime.rs
+++ b/lapce-ui/src/ime.rs
@@ -27,7 +27,7 @@ impl Default for ImeComponent {
         let session = ImeSession {
             is_active: false,
             composition_range: None,
-            text: "".to_string(),
+            text: String::new(),
             input_text: None,
             orgin: Point::ZERO,
             shift: 0,

--- a/lapce-ui/src/message.rs
+++ b/lapce-ui/src/message.rs
@@ -187,7 +187,7 @@ impl LapceMessageItem {
         let text_width = 300.0;
         let text_line_height = 2.0;
         let text_layout = piet_text
-            .new_text_layout("".to_string())
+            .new_text_layout(String::new())
             .font(config.ui.font_family(), config.ui.font_size() as f64)
             .max_width(text_width)
             .set_line_height(text_line_height)

--- a/lapce-ui/src/search.rs
+++ b/lapce-ui/src/search.rs
@@ -210,7 +210,7 @@ impl Widget<LapceTabData> for SearchInput {
                     None => format!("{} results", match_count),
                 }
             } else {
-                "No results".to_string()
+                "No results".to_owned()
             })
             .font(
                 data.config.ui.font_family(),

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -667,7 +667,7 @@ impl SettingsItemInfo {
         // TODO: This could likely use smallvec, or even skip the allocs completely for
         // the *common* case of the name text not changing..
         let splits: Vec<&str> = self.key.rsplitn(2, '.').collect();
-        let mut name_text = "".to_string();
+        let mut name_text = String::new();
         if let Some(title) = splits.get(1) {
             for (i, part) in title.split('.').enumerate() {
                 if i > 0 {

--- a/lapce-ui/src/signature.rs
+++ b/lapce-ui/src/signature.rs
@@ -248,7 +248,7 @@ impl Signature {
 
     fn new() -> Signature {
         Self {
-            label: "".to_string(),
+            label: String::new(),
             label_offset: 0.0,
             label_layout: {
                 let mut layout = TextLayout::new();

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -34,7 +34,7 @@ pub fn new_source_control_panel(data: &LapceTabData) -> LapcePanel {
         LapceEditorView::new(editor_data.view_id, editor_data.editor_id, None)
             .hide_header()
             .hide_gutter()
-            .set_placeholder("Commit Message".to_string())
+            .set_placeholder("Commit Message".to_owned())
             .padding((15.0, 15.0));
 
     let commit_button = Button::new(data, "Commit")
@@ -195,7 +195,7 @@ impl Widget<LapceTabData> for SourceControlFileList {
                                             .0
                                             .path()
                                             .clone(),
-                                        "head".to_string(),
+                                        "head".to_owned(),
                                     ),
                                     Target::Widget(data.id),
                                 ));
@@ -220,7 +220,7 @@ impl Widget<LapceTabData> for SourceControlFileList {
                                         .0
                                         .path()
                                         .clone(),
-                                    "head".to_string(),
+                                    "head".to_owned(),
                                 ),
                                 Target::Auto,
                             ),

--- a/lapce-ui/src/status.rs
+++ b/lapce-ui/src/status.rs
@@ -533,7 +533,7 @@ impl Widget<LapceTabData> for LapceStatus {
                 ),
             ));
 
-            let mut string = "".to_string();
+            let mut string = String::new();
             let editor_content = data.editor_view_content(editor.view_id);
             if let Some(cursor_pos) =
                 editor.cursor.get_line_col_char(editor_content.doc.buffer())

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1752,7 +1752,7 @@ impl LapceTab {
                                     }
                                 }
                             })
-                            .unwrap_or_else(|| "Lapce".to_string());
+                            .unwrap_or_else(|| "Lapce".to_owned());
                         ctx.window().set_title(&dir);
                         ctx.submit_command(Command::new(
                             LAPCE_UI_COMMAND,
@@ -2858,7 +2858,7 @@ impl Widget<LapceTabData> for LapceTabHeader {
                     }
                 }
             })
-            .unwrap_or_else(|| "Lapce".to_string());
+            .unwrap_or_else(|| "Lapce".to_owned());
         let text_layout = ctx
             .text()
             .new_text_layout(dir)

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -410,7 +410,7 @@ impl Title {
                 {
                     format!("Restart to update ({})", latest_version.unwrap())
                 } else {
-                    "No update available".to_string()
+                    "No update available".to_owned()
                 }),
                 command: LapceCommand {
                     kind: CommandKind::Workbench(
@@ -518,14 +518,14 @@ impl Title {
                 .to_string_lossy()
                 .to_string()
         } else {
-            "Open Folder".to_string()
+            "Open Folder".to_owned()
         };
         let remote = match &data.workspace.kind {
-            LapceWorkspaceType::Local => "".to_string(),
+            LapceWorkspaceType::Local => String::new(),
             LapceWorkspaceType::RemoteSSH(ssh) => {
                 format!(" [SSH: {}]", ssh.host)
             }
-            LapceWorkspaceType::RemoteWSL => " [WSL]".to_string(),
+            LapceWorkspaceType::RemoteWSL => " [WSL]".to_owned(),
         };
         let text = format!("{path}{remote}");
         let text_layout = piet_text


### PR DESCRIPTION
This pull request does:
- removes a lot of unnecessary memory allocations. For example, previously, multiple allocations of vectors were performed in a loop to store a single character (function `lapce_core::syntax::Syntax::find_matching_pair`);
- removes many indirect function calls. For example calling `to_string()` on a `&' static str`, using `"".to_string()` instead of `String::new()`.

In addition, a complete rewrite of the `Snippet::extract_text` function was performed while preserving the logic of its work. This was done, firstly, to remove the constant copying of immutable vectors in a loop. Secondly, to exclude a possible crash of the program, since accessing an element by index for a string is not a good idea.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users