### PR TITLE
Fix "Open Keyboard Shortcuts" enum.

### DIFF
--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -234,7 +234,7 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
                         ctx.request_focus();
                     }
                     LapceUICommand::ShowKeybindings => {
-                        let kind = LapceSettingsKind::Core;
+                        let kind = LapceSettingsKind::Keymap;
                         self.active = kind.clone();
                         self.switcher
                             .widget_mut()


### PR DESCRIPTION
It currently goes to "Core Settings" rather than "Keybindings".

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users