### PR TITLE
Fix some LSP bugs causing code actions to not show up correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#1737](https://github.com/lapce/lapce/pull/1726): Fix an issue that plugins can't be upgraded
 - [#1724](https://github.com/lapce/lapce/pull/1724): Files and hidden folders no longer will be considered when trying to open a plugin base folder
 - [#1753](https://github.com/lapce/lapce/pull/1753): Limit proxy search response size in order to avoid issues with absurdly long lines
+- [#1805](https://github.com/lapce/lapce/pull/1805): Fix some LSP bugs causing code actions to not show up correctly
 
 ## 0.2.4
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -303,7 +303,14 @@ impl LapceEditorBufferData {
             self.proxy.proxy_rpc.get_code_actions(
                 path.clone(),
                 position,
-                diagnostics.into_iter().map(|x| x.diagnostic).collect(),
+                diagnostics
+                    .into_iter()
+                    .map(|x| x.diagnostic)
+                    .filter(|x| {
+                        x.range.start.line <= position.line
+                            && x.range.end.line >= position.line
+                    })
+                    .collect(),
                 move |result| {
                     if let Ok(ProxyResponse::GetCodeActionsResponse {
                         plugin_id,

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -289,13 +289,21 @@ impl LapceEditorBufferData {
             let offset = self.editor.cursor.offset();
             let prev_offset = self.doc.buffer().prev_code_boundary(offset);
             // REMOVED(if) this prevents some code actions from showing up correctly, and there is almost no performance penalty for this
-            //if self.doc.code_actions.get(&prev_offset).is_none() { 
+            //if self.doc.code_actions.get(&prev_offset).is_none() {
             let position = self.doc.buffer().offset_to_position(prev_offset);
             let rev = self.doc.rev();
             let event_sink = ctx.get_external_handle();
+            let diagnostics: &Vec<EditorDiagnostic> = &*(self
+                .doc
+                .diagnostics
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| Arc::new(Vec::new())));
+            let diagnostics = diagnostics.clone();
             self.proxy.proxy_rpc.get_code_actions(
                 path.clone(),
                 position,
+                diagnostics.into_iter().map(|x| x.diagnostic).collect(),
                 move |result| {
                     if let Ok(ProxyResponse::GetCodeActionsResponse {
                         plugin_id,

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -293,7 +293,7 @@ impl LapceEditorBufferData {
             let position = self.doc.buffer().offset_to_position(prev_offset);
             let rev = self.doc.rev();
             let event_sink = ctx.get_external_handle();
-            let diagnostics: &Vec<EditorDiagnostic> = &*(self
+            let diagnostics: &Vec<EditorDiagnostic> = &(self
                 .doc
                 .diagnostics
                 .as_ref()

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -288,34 +288,35 @@ impl LapceEditorBufferData {
             let path = path.clone();
             let offset = self.editor.cursor.offset();
             let prev_offset = self.doc.buffer().prev_code_boundary(offset);
-            if self.doc.code_actions.get(&prev_offset).is_none() {
-                let position = self.doc.buffer().offset_to_position(prev_offset);
-                let rev = self.doc.rev();
-                let event_sink = ctx.get_external_handle();
-                self.proxy.proxy_rpc.get_code_actions(
-                    path.clone(),
-                    position,
-                    move |result| {
-                        if let Ok(ProxyResponse::GetCodeActionsResponse {
-                            plugin_id,
-                            resp,
-                        }) = result
-                        {
-                            let _ = event_sink.submit_command(
-                                LAPCE_UI_COMMAND,
-                                LapceUICommand::UpdateCodeActions {
-                                    path,
-                                    plugin_id,
-                                    rev,
-                                    offset: prev_offset,
-                                    resp,
-                                },
-                                Target::Auto,
-                            );
-                        }
-                    },
-                );
-            }
+            // REMOVED(if) this prevents some code actions from showing up correctly, and there is almost no performance penalty for this
+            //if self.doc.code_actions.get(&prev_offset).is_none() { 
+            let position = self.doc.buffer().offset_to_position(prev_offset);
+            let rev = self.doc.rev();
+            let event_sink = ctx.get_external_handle();
+            self.proxy.proxy_rpc.get_code_actions(
+                path.clone(),
+                position,
+                move |result| {
+                    if let Ok(ProxyResponse::GetCodeActionsResponse {
+                        plugin_id,
+                        resp,
+                    }) = result
+                    {
+                        let _ = event_sink.submit_command(
+                            LAPCE_UI_COMMAND,
+                            LapceUICommand::UpdateCodeActions {
+                                path,
+                                plugin_id,
+                                rev,
+                                offset: prev_offset,
+                                resp,
+                            },
+                            Target::Auto,
+                        );
+                    }
+                },
+            );
+            //}
         }
     }
 

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -520,11 +520,16 @@ impl ProxyHandler for Dispatcher {
                     },
                 );
             }
-            GetCodeActions { path, position } => {
+            GetCodeActions {
+                path,
+                position,
+                diagnostics,
+            } => {
                 let proxy_rpc = self.proxy_rpc.clone();
                 self.catalog_rpc.get_code_actions(
                     &path,
                     position,
+                    diagnostics,
                     move |plugin_id, result| {
                         let result = result.map(|resp| {
                             ProxyResponse::GetCodeActionsResponse { plugin_id, resp }

--- a/lapce-proxy/src/plugin/lsp.rs
+++ b/lapce-proxy/src/plugin/lsp.rs
@@ -11,6 +11,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use crossbeam_channel::Sender;
 use jsonrpc_lite::{Id, Params};
+use lapce_core::meta;
 use lapce_rpc::{style::LineStyle, RpcError};
 use lapce_xi_rope::Rope;
 use lsp_types::{
@@ -362,6 +363,8 @@ impl LspClient {
                                 CodeActionKind::SOURCE_ORGANIZE_IMPORTS
                                     .as_str()
                                     .to_string(),
+                                "quickassist".to_string(),
+                                "source.fixAll".to_string(),
                             ],
                         },
                     }),
@@ -417,7 +420,10 @@ impl LspClient {
                     uri,
                 }]
             }),
-            client_info: None,
+            client_info: Some(ClientInfo {
+                name: meta::NAME.to_owned(),
+                version: Some(meta::VERSION.to_owned()),
+            }),
             locale: None,
             root_path: None,
         };

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -490,13 +490,7 @@ impl PluginCatalogRpcHandler {
                 end: position,
             },
             context: CodeActionContext {
-                diagnostics: diagnostics
-                    .into_iter()
-                    .filter(|x| {
-                        x.range.start.line <= position.line
-                            && x.range.end.line >= position.line
-                    })
-                    .collect(),
+                diagnostics,
                 only: None,
             },
             work_done_progress_params: WorkDoneProgressParams::default(),

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -37,15 +37,15 @@ use lsp_types::{
         SignatureHelpRequest, WorkspaceSymbol,
     },
     CodeAction, CodeActionContext, CodeActionParams, CodeActionResponse,
-    CompletionItem, CompletionParams, CompletionResponse, DocumentFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, FormattingOptions,
-    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InlayHint,
-    InlayHintParams, Location, PartialResultParams, Position, PrepareRenameResponse,
-    Range, ReferenceContext, ReferenceParams, RenameParams, SelectionRange,
-    SelectionRangeParams, SemanticTokens, SemanticTokensParams, SignatureHelp,
-    SignatureHelpParams, SymbolInformation, TextDocumentIdentifier,
-    TextDocumentItem, TextDocumentPositionParams, TextEdit, Url,
-    VersionedTextDocumentIdentifier, WorkDoneProgressParams, WorkspaceEdit,
+    CompletionItem, CompletionParams, CompletionResponse, Diagnostic,
+    DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
+    FormattingOptions, GotoDefinitionParams, GotoDefinitionResponse, Hover,
+    HoverParams, InlayHint, InlayHintParams, Location, PartialResultParams,
+    Position, PrepareRenameResponse, Range, ReferenceContext, ReferenceParams,
+    RenameParams, SelectionRange, SelectionRangeParams, SemanticTokens,
+    SemanticTokensParams, SignatureHelp, SignatureHelpParams, SymbolInformation,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, TextEdit,
+    Url, VersionedTextDocumentIdentifier, WorkDoneProgressParams, WorkspaceEdit,
     WorkspaceSymbolParams,
 };
 use parking_lot::Mutex;
@@ -475,6 +475,7 @@ impl PluginCatalogRpcHandler {
         &self,
         path: &Path,
         position: Position,
+        diagnostics: Vec<Diagnostic>,
         cb: impl FnOnce(PluginId, Result<CodeActionResponse, RpcError>)
             + Clone
             + Send
@@ -488,7 +489,16 @@ impl PluginCatalogRpcHandler {
                 start: position,
                 end: position,
             },
-            context: CodeActionContext::default(),
+            context: CodeActionContext {
+                diagnostics: diagnostics
+                    .into_iter()
+                    .filter(|x| {
+                        x.range.start.line <= position.line
+                            && x.range.end.line >= position.line
+                    })
+                    .collect(),
+                only: None,
+            },
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
         };

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -12,8 +12,8 @@ use indexmap::IndexMap;
 use lapce_xi_rope::RopeDelta;
 use lsp_types::{
     request::GotoTypeDefinitionResponse, CodeAction, CodeActionResponse,
-    CompletionItem, DocumentSymbolResponse, GotoDefinitionResponse, Hover,
-    InlayHint, Location, Position, PrepareRenameResponse, SelectionRange,
+    CompletionItem, Diagnostic, DocumentSymbolResponse, GotoDefinitionResponse,
+    Hover, InlayHint, Location, Position, PrepareRenameResponse, SelectionRange,
     SymbolInformation, TextDocumentItem, TextEdit, WorkspaceEdit,
 };
 use parking_lot::Mutex;
@@ -107,6 +107,7 @@ pub enum ProxyRequest {
     GetCodeActions {
         path: PathBuf,
         position: Position,
+        diagnostics: Vec<Diagnostic>,
     },
     GetDocumentSymbols {
         path: PathBuf,
@@ -732,9 +733,17 @@ impl ProxyRpcHandler {
         &self,
         path: PathBuf,
         position: Position,
+        diagnostics: Vec<Diagnostic>,
         f: impl ProxyCallback + 'static,
     ) {
-        self.request_async(ProxyRequest::GetCodeActions { path, position }, f);
+        self.request_async(
+            ProxyRequest::GetCodeActions {
+                path,
+                position,
+                diagnostics,
+            },
+            f,
+        );
     }
 
     pub fn get_document_formatting(


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This will fix the following LSP-related issues: 
- Java LS does not show "Surround with try/catch" and similar issue-related actions
- All language servers don't always update code actions when the document was changed
- Rust LS sometimes highlights a line with a fix suggestion, but is unable to actually provide it in code actions

This PR updates the capabilities and code action requests to fully match LSP spec.