### PR TITLE
Use more standardized java indentation

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -496,7 +496,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         highlight: tree_sitter_java::HIGHLIGHT_QUERY,
         injection: None,
         comment: "//",
-        indent: "  ",
+        indent: "    ",
         code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
         sticky_headers: &[],
         extensions: &["java"],


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Java's indentation is almost always 4 spaces, so I think using 4 spaces as the default in Lapce as well makes a lot of sense.