### PR TITLE
remove mold requirement for fedora package

### DIFF
--- a/lapce.spec
+++ b/lapce.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/lapce/lapce
 VCS:            {{{ git_dir_vcs }}}
 Source:        	{{{ git_dir_pack }}}
 
-BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel perl-lib perl-File-Compare
+BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel perl-lib perl-File-Compare clang
 
 %description
 Lapce is written in pure Rust with a UI in Druid (which is also written in Rust).


### PR DESCRIPTION
Hello! I'm the maintainer of the lapce builds for Fedora.

This PR removes the requirement of mold for compilation and will default to the system compiler. This only applies to builds for packaging on Fedora and related distros. This would allow the package to be build on powerpc as the mold version in the repos don't support powerpc.