### PR TITLE
minor fixes to scope and bracket highlight

### DIFF
--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -824,8 +824,8 @@ impl LapceEditor {
         Self::paint_text(ctx, data, &screen_lines);
         Self::paint_diagnostics(ctx, data, &screen_lines);
         Self::paint_snippet(ctx, data, &screen_lines);
-        Self::paint_sticky_headers(ctx, data, env);
         Self::highlight_scope_and_brackets(ctx, data, &screen_lines);
+        Self::paint_sticky_headers(ctx, data, env);
 
         if data.doc.buffer().is_empty() {
             if let Some(placeholder) = self.placeholder.as_ref() {
@@ -2046,6 +2046,10 @@ impl LapceEditor {
         end_offset: usize,
         color: &Color,
     ) {
+        if data.editor.is_code_lens() {
+            return;
+        }
+
         const LINE_WIDTH: f64 = 1.0;
 
         let (start_line, start_col) =


### PR DESCRIPTION
This PR fixes small annoyances with scope and bracket highlighting, like drawing over sticky headers and drawing the scope highlights in code lens mode.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users