### PR TITLE
Support hiding open editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features/Changes
 
+- [#1114](https://github.com/lapce/lapce/issues/1114): Add option to hide open editors
+
 ### Bug Fixes
 
 ## 0.2.5

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -13,6 +13,7 @@ code-lens-font-size = 2
 line-height = 1.5
 tab-width = 4
 show-tab = true
+show-open-editors = true
 show-bread-crumbs = true
 scroll-beyond-last-line = true
 cursor-surrounding-lines = 1

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -332,6 +332,8 @@ pub struct EditorConfig {
     pub tab_width: usize,
     #[field_names(desc = "If opened editors are shown in a tab")]
     pub show_tab: bool,
+    #[field_names(desc = "If opened editors are shown above the file explorer")]
+    pub show_open_editors: bool,
     #[field_names(desc = "If navigation breadcrumbs are shown for the file")]
     pub show_bread_crumbs: bool,
     #[field_names(desc = "If the editor can scroll beyond the last line")]

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -335,35 +335,40 @@ impl FileExplorer {
         }
     }
 
-    pub fn new_panel(data: &mut LapceTabData) -> LapcePanel {
+    pub fn new_panel(data: &mut LapceTabData, open_editors: bool) -> LapcePanel {
         let split_id = WidgetId::next();
+
+        let mut sections = Vec::new();
+        if open_editors {
+            sections.push((
+                WidgetId::next(),
+                PanelHeaderKind::Simple("Open Editors".into()),
+                LapceScroll::new(OpenEditorList::new()).boxed(),
+                PanelSizing::Flex(true),
+            ));
+        }
+
+        sections.push((
+            split_id,
+            PanelHeaderKind::Simple(
+                data.workspace
+                    .path
+                    .as_ref()
+                    .and_then(|p| p.file_name())
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "No Folder Open".to_string())
+                    .into(),
+            ),
+            Self::new(data).boxed(),
+            PanelSizing::Flex(true),
+        ));
+
         LapcePanel::new(
             PanelKind::FileExplorer,
             data.file_explorer.widget_id,
             split_id,
-            vec![
-                (
-                    WidgetId::next(),
-                    PanelHeaderKind::Simple("Open Editors".into()),
-                    LapceScroll::new(OpenEditorList::new()).boxed(),
-                    PanelSizing::Size(200.0),
-                ),
-                (
-                    split_id,
-                    PanelHeaderKind::Simple(
-                        data.workspace
-                            .path
-                            .as_ref()
-                            .and_then(|p| p.file_name())
-                            .and_then(|s| s.to_str())
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|| "No Folder Open".to_string())
-                            .into(),
-                    ),
-                    Self::new(data).boxed(),
-                    PanelSizing::Flex(true),
-                ),
-            ],
+            sections,
         )
     }
 }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -146,7 +146,13 @@ impl LapceTab {
                     PanelKind::FileExplorer => {
                         panel.insert_panel(
                             *kind,
-                            WidgetPod::new(FileExplorer::new_panel(data).boxed()),
+                            WidgetPod::new(
+                                FileExplorer::new_panel(
+                                    data,
+                                    data.config.editor.show_open_editors,
+                                )
+                                .boxed(),
+                            ),
                         );
                     }
                     PanelKind::SourceControl => {


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This works, but requires a restart for changes to take effect, which isn't great. I think I'm going about this the wrong way, since it seems that once the panel is created, it's sections aren't expected to change. Is there a better way to do this?

Resolves #1114