### PR TITLE
Rewrite some parts of `LapceSettingsPanel::update_plugins`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,7 +2071,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -2069,7 +2080,17 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash 0.8.2",
+ "serde",
 ]
 
 [[package]]
@@ -2754,6 +2775,7 @@ dependencies = [
  "clap",
  "druid",
  "fern",
+ "hashbrown 0.13.1",
  "im",
  "image",
  "include_dir",

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -28,6 +28,7 @@ lapce-xi-rope = { version = "0.3.1", features = ["serde"] }
 lsp-types = { version = "0.93", features = ["proposed"] }
 toml_edit = { version = "0.14.4", features = ["easy"] }
 open = "3.0.2"
+hashbrown = { version = "0.13.1", features = ["serde"] }
 
 # lapce deps
 druid = { git = "https://github.com/lapce/druid", branch = "shell_opengl", features = ["svg", "im", "serde"] }


### PR DESCRIPTION
This pull request does the following:
- Changes the structure of `LapceSettingsPanel::children` to use `hashbrown::HashMap`. This was done because the `std::collections::HashMap::drain_filter` method is not yet stable. Also, this should make things a lot faster with `LapceSettingsPanel::children`, since `hashbrown::HashMap` uses [`aHash`](https://github.com/tkaitchuck/ahash) by default, which is much faster than `SipHash 1-3` hash function [`used`](https://doc.rust-lang.org/src/std/collections/hash/map.rs.html#3142) in the default library (https://github.com/tkaitchuck/aHash/blob/master/FAQ.md#how-is-ahash-so-fast).

- Removes unnecessary creation of an intermediate vector `Vec<LapceSettingsKind>` (for which we have to go through all the keys and clone them).

- Corrects the search for a key in `HashMap` and `IndexMap`, since previously the search for a key in a hash table was performed by a **linear search through an iterator**:
  ``` rust
  data.plugin.installed.keys().contains(&volt_id)
  //...
  self.children.keys().contains(&kind)
  ```
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users