### PR TITLE
Plugin settings shown on right click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features/Changes
+- [#1831](https://github.com/lapce/lapce/pull/1831): Plugin settings shown on right click
 
 ### Bug Fixes
 

--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -600,6 +600,15 @@ impl Widget<LapceTabData> for Plugin {
                         }
                     }
                 }
+                if mouse_event.button.is_right() {
+                    let index = (mouse_event.pos.y
+                        / (self.line_height * 3.0 + self.gap))
+                        as usize;
+
+                    if let Some((_, id, _)) = self.rects.get(&index) {
+                        status_on_click(ctx, data, id, mouse_event.pos);
+                    }
+                }
             }
             _ => (),
         }


### PR DESCRIPTION
__Description__
This pull request allows the user to right click on a plugin to access its settings.

![image](https://user-images.githubusercontent.com/24386960/208287472-4b25bc40-f242-47b2-93e2-d7c05c847124.png)

- [ x] Added an entry to `CHANGELOG.md` if this change could be valuable to users