### PR TITLE
Don't use the active editor's view id for opening file diff

### DIFF
--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1398,10 +1398,9 @@ impl LapceTab {
                         LapceConfig::reset_setting(parent, key);
                     }
                     LapceUICommand::OpenFileDiff(path, history) => {
-                        let editor_view_id = data.main_split.active.clone();
                         let editor_view_id = data.main_split.jump_to_location(
                             ctx,
-                            *editor_view_id,
+                            None,
                             false,
                             EditorLocation {
                                 path: path.clone(),


### PR DESCRIPTION
~~- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users~~

Currently, clicking on a diff in the source control sidebar will cause it to replace the current editor (even if it is unsaved and/or a scratch file). This PR changes the code to not replace the currently opened file.  
  
(Question: Was the behavior of jump_to or this specific command changed some time ago? I don't remember opening the diff doing this a long while ago, but it started doing it sometime in the last couple months I believe)