### PR TITLE
Remove a lot of small vector allocation in `find_matching_pair`

### DIFF
--- a/lapce-core/src/syntax/mod.rs
+++ b/lapce-core/src/syntax/mod.rs
@@ -31,7 +31,7 @@ use self::{
         HighlightConfiguration, HighlightEvent, HighlightIssue, HighlightIter,
         HighlightIterLayer, IncludedChildren, LocalScope,
     },
-    util::{matching_char, matching_pair_direction, RopeProvider},
+    util::{matching_bracket_general, matching_pair_direction, RopeProvider},
 };
 use crate::{
     language::LapceLanguage,
@@ -687,10 +687,8 @@ impl Syntax {
         let node = tree
             .root_node()
             .descendant_for_byte_range(offset, offset + 1)?;
-        let mut chars = node.kind().chars();
-        let char = chars.next()?;
-        let char = matching_char(char)?;
-        let tag = &char.to_string();
+        let char = node.kind().chars().next()?;
+        let tag: &'static str = matching_bracket_general(char)?;
 
         if let Some(offset) = self.find_tag_in_siblings(node, true, tag) {
             return Some(offset);

--- a/lapce-core/src/syntax/util.rs
+++ b/lapce-core/src/syntax/util.rs
@@ -1,3 +1,4 @@
+use core::str::FromStr;
 use std::collections::HashMap;
 
 use lapce_xi_rope::{rope::ChunkIter, Rope};
@@ -49,6 +50,62 @@ pub fn matching_char(c: char) -> Option<char> {
         ']' => '[',
         _ => return None,
     })
+}
+
+/// If the given character is a parenthesis, returns its matching bracket
+pub fn matching_bracket_general<R: ToStaticTextType>(char: char) -> Option<R>
+where
+    &'static str: ToStaticTextType<R>,
+{
+    let pair = match char {
+        '{' => "}",
+        '}' => "{",
+        '(' => ")",
+        ')' => "(",
+        '[' => "]",
+        ']' => "[",
+        _ => return None,
+    };
+    Some(pair.to_static())
+}
+
+pub trait ToStaticTextType<R: 'static = Self>: 'static {
+    fn to_static(self) -> R;
+}
+
+impl ToStaticTextType for &'static str {
+    #[inline]
+    fn to_static(self) -> &'static str {
+        self
+    }
+}
+
+impl ToStaticTextType<char> for &'static str {
+    #[inline]
+    fn to_static(self) -> char {
+        char::from_str(self).unwrap()
+    }
+}
+
+impl ToStaticTextType<String> for &'static str {
+    #[inline]
+    fn to_static(self) -> String {
+        self.to_string()
+    }
+}
+
+impl ToStaticTextType for char {
+    #[inline]
+    fn to_static(self) -> char {
+        self
+    }
+}
+
+impl ToStaticTextType for String {
+    #[inline]
+    fn to_static(self) -> String {
+        self
+    }
 }
 
 pub fn has_unmatched_pair(line: &str) -> bool {


### PR DESCRIPTION
Splitted from #1796. That (#1796) pull request is so large it looks like it will never be merged, so I decided to break it down into smaller pieces.

This pull request performs one of the most important parts of improving program performance by changing a function that is constantly called in the program:
- removes many unnecessary multiple allocations of vectors (strings) to store one character in `lapce_core::syntax::Syntax::find_matching_pair`.