### PR TITLE
Highlight git/VCS modified files in explorer, palette, and buffer tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - [#1835](https://github.com/lapce/lapce/pull/1835): Add mouse keybinds
 
+- [#1856](https://github.com/lapce/lapce/pull/1856): Highlight git/VCS modified files in explorer, palette, and buffer tabs
+
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "im",
  "image",
  "include_dir",
+ "indexmap",
  "itertools",
  "lapce-core",
  "lapce-data",

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1658,14 +1658,15 @@ impl LapceTabData {
                     .file_diffs
                     .iter()
                     .filter_map(
-                        |(diff, checked)| {
+                        |(_, (diff, checked))| {
                             if *checked {
-                                Some(diff.clone())
+                                Some(diff)
                             } else {
                                 None
                             }
                         },
                     )
+                    .cloned()
                     .collect();
                 if diffs.is_empty() {
                     return;

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1243,6 +1243,7 @@ impl LapceTabData {
             db: self.db.clone(),
             focus_area: self.focus_area.clone(),
             terminal: self.terminal.clone(),
+            source_control: self.source_control.clone(),
         }
     }
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -997,8 +997,7 @@ impl LapceEditorBufferData {
                 .source_control
                 .file_diffs
                 .iter()
-                .map(|(diff, _)| {
-                    let path = diff.path();
+                .map(|(path, _)| {
                     let mut positions = Vec::new();
                     if let Some(doc) = self.main_split.open_docs.get(path) {
                         if let Some(history) = doc.get_history("head") {

--- a/lapce-data/src/source_control.rs
+++ b/lapce-data/src/source_control.rs
@@ -1,4 +1,7 @@
+use std::path::PathBuf;
+
 use druid::{Command, Env, EventCtx, Modifiers, Target, WidgetId};
+use indexmap::IndexMap;
 use lapce_core::{
     command::{FocusCommand, MoveCommand},
     mode::Mode,
@@ -25,7 +28,8 @@ pub struct SourceControlData {
     pub file_list_index: usize,
     pub editor_view_id: WidgetId,
     pub commit_button_id: WidgetId,
-    pub file_diffs: Vec<(FileDiff, bool)>,
+    // VCS modified files & whether they should be included in the next commit
+    pub file_diffs: IndexMap<PathBuf, (FileDiff, bool)>,
     pub branch: String,
     pub branches: im::Vector<String>,
 }
@@ -43,7 +47,7 @@ impl SourceControlData {
             commit_button_id: WidgetId::next(),
             split_id: WidgetId::next(),
             split_direction: SplitDirection::Horizontal,
-            file_diffs: Vec::new(),
+            file_diffs: IndexMap::new(),
             branch: "".to_string(),
             branches: im::Vector::new(),
         }
@@ -183,9 +187,10 @@ impl KeyPressFocus for SourceControlData {
                         ctx.submit_command(Command::new(
                             LAPCE_UI_COMMAND,
                             LapceUICommand::OpenFileDiff(
-                                self.file_diffs[self.file_list_index]
+                                self.file_diffs
+                                    .get_index(self.file_list_index)
+                                    .unwrap()
                                     .0
-                                    .path()
                                     .clone(),
                                 "head".to_string(),
                             ),

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -1120,13 +1120,13 @@ fn git_diff_new(workspace_path: &Path) -> Option<DiffInfo> {
     let mut renames = Vec::new();
     let mut renamed_deltas = HashSet::new();
 
-    for (i, delta) in deltas.iter().enumerate() {
+    for (added_index, delta) in deltas.iter().enumerate() {
         if delta.0 == git2::Delta::Added {
-            for (j, d) in deltas.iter().enumerate() {
+            for (deleted_index, d) in deltas.iter().enumerate() {
                 if d.0 == git2::Delta::Deleted && d.1 == delta.1 {
-                    renames.push((i, j));
-                    renamed_deltas.insert(i);
-                    renamed_deltas.insert(j);
+                    renames.push((added_index, deleted_index));
+                    renamed_deltas.insert(added_index);
+                    renamed_deltas.insert(deleted_index);
                     break;
                 }
             }
@@ -1134,10 +1134,10 @@ fn git_diff_new(workspace_path: &Path) -> Option<DiffInfo> {
     }
 
     let mut file_diffs = Vec::new();
-    for (i, j) in renames.iter() {
+    for (added_index, deleted_index) in renames.iter() {
         file_diffs.push(FileDiff::Renamed(
-            deltas[*i].2.clone(),
-            deltas[*j].2.clone(),
+            deltas[*added_index].2.clone(),
+            deltas[*deleted_index].2.clone(),
         ));
     }
     for (i, delta) in deltas.iter().enumerate() {

--- a/lapce-ui/Cargo.toml
+++ b/lapce-ui/Cargo.toml
@@ -29,6 +29,7 @@ lsp-types = { version = "0.93", features = ["proposed"] }
 toml_edit = { version = "0.14.4", features = ["easy"] }
 open = "3.0.2"
 hashbrown = { version = "0.13.1", features = ["serde"] }
+indexmap = "1.7.0"
 
 # lapce deps
 druid = { git = "https://github.com/lapce/druid", branch = "shell_opengl", features = ["svg", "im", "serde"] }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1190,10 +1190,9 @@ impl LapceTab {
                             .map(|diff| {
                                 let checked = source_control
                                     .file_diffs
-                                    .iter()
-                                    .find_map(|(p, c)| (p == &diff).then_some(*c))
-                                    .unwrap_or(true);
-                                (diff, checked)
+                                    .get(diff.path())
+                                    .map_or(true, |(_, c)| *c);
+                                (diff.path().clone(), (diff, checked))
                             })
                             .collect();
 


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Hi there! I'm enjoying using Lapce and excited to contribute to the project. This PR upates the styling of file names in the file explorer, file palette, and editor tab headers to reflect their curreng git/VCS status. I found this feature really useful in Atom (RIP). I've been using this locally for several days, and it has been accurate and stable so far.

Screenshot showing updated styling:  
![Screen Shot 2023-01-03 at 10 56 01 PM](https://user-images.githubusercontent.com/1420419/210482507-1f44a29c-ab6f-480f-8ac8-7b1c3253a8f0.jpg)

Notes:
- no new system calls were needed; the data was already present on `LapceTabData.file_diffs`, it just needed to be tweaked a little to be accessible where needed
- `LapceTabData.file_diffs` is currently a `Vec<(FileDiff, bool)>`; this changes it to a `HashMap<PathBuf, FileDiff>` (for easy lookup by path) and adds a new `file_list: Vec<(PathBuf, bool)>` to support the `int` based indexing that's happening on the `Vec`
- modified, added, deleted are highlighted, along with their containing directories 
	- note that directories are only displayed as modified, not added or deleted

Specific things to look for during review:
- I don't expect a performance hit, but perhaps a limited memory usage increase. I'm not able to quantify that at this time, though. Any insight you have here would be great.
- I think I picked the right theme colors, but this should definitely be confirmed.
- I've only been working w/ Lapce for a week or so, so I likely did something very wrong somewhere in here. All suggestions are very welcome!

References:
- https://github.com/lapce/lapce/issues/793#issuecomment-1190473279
- https://github.com/lapce/lapce/issues/532#issuecomment-1163523157