### PR TITLE
suppress 'clippy::uninlined_format_args'

### DIFF
--- a/lapce-data/src/lib.rs
+++ b/lapce-data/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::manual_clamp)]
+#![allow(clippy::manual_clamp, clippy::uninlined_format_args)]
 
 pub mod about;
 pub mod alert;

--- a/lapce-proxy/src/lib.rs
+++ b/lapce-proxy/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::manual_clamp)]
+#![allow(clippy::manual_clamp, clippy::uninlined_format_args)]
 
 pub mod buffer;
 pub mod dispatch;

--- a/lapce-ui/src/lib.rs
+++ b/lapce-ui/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::manual_clamp)]
+#![allow(clippy::manual_clamp, clippy::uninlined_format_args)]
 
 pub mod about;
 pub mod alert;


### PR DESCRIPTION
this is a new lint in `clippy::all`, which is `warning` level by default. This repo is using a pinned version of clippy, which suppresses the lint *right now*, but not for a whole lot longer.

https://rust-lang.github.io/rust-clippy/master/#uninlined_format_args

This lint adds a lot of noise when linting with clippy and default settings, so it should be addressed or suppressed to reduce linting noise for downstream users.

#1866 addresses the lint, but this solution was not preferred. This PR suppresses the lint instead.