### PR TITLE
Fix bug in `lapce_proxy::plugin::wasi::start_volt`

### DIFF
--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -394,7 +394,7 @@ pub fn start_volt(
     let mut store = wasmtime::Store::new(&engine, wasi);
 
     let (io_tx, io_rx) = crossbeam_channel::unbounded();
-    let rpc = PluginServerRpcHandler::new(meta.name.clone(), io_tx);
+    let rpc = PluginServerRpcHandler::new(meta.id(), io_tx);
 
     let local_rpc = rpc.clone();
     let local_stdin = stdin.clone();


### PR DESCRIPTION
I think there is a mistake in this place. This structure is created directly from the passed `volt_id: String` (https://github.com/lapce/lapce/blob/master/lapce-proxy/src/plugin/psp.rs#L215). It is further included in the [`PluginCatalog`](https://github.com/lapce/lapce/blob/master/lapce-proxy/src/plugin/catalog.rs#L36) structure. Finally, the `PluginCatalog` structure actively uses `volt_id` comparisons among themselves, for example [`here`](https://github.com/lapce/lapce/blob/master/lapce-proxy/src/plugin/catalog.rs#L366 ). However, the comparison is not made with the `VoltMetadata.name` field, but with the result of calling the [`VoltMetadata::id`](https://github.com/lapce/lapce/blob/master/lapce-rpc/src/plugin.rs#L76) function that are not equivalent.

This was discovered while working on #1879.