### PR TITLE
feat: select name only when renaming a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 - [#1835](https://github.com/lapce/lapce/pull/1835): Add mouse keybinds
 
+- [#1895](https://github.com/lapce/lapce/pull/1895): Adds setting to only select the name, when renaming a file
+
 ### Bug Fixes
 
 ## 0.2.5

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -5,6 +5,8 @@ modal = false
 color-theme = "Lapce Dark"
 icon-theme = "Lapce Codicons"
 custom-titlebar = true
+select-name-only= true
+
 
 [editor]
 font-family = "Cascadia Code"

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -314,6 +314,10 @@ pub struct CoreConfig {
         desc = "Enable customised titlebar and disable OS native one (Linux, BSD, Windows)"
     )]
     pub custom_titlebar: bool,
+    #[field_names(
+        desc = "When renaming a file only the name gets selected, without the extension"
+    )]
+    pub select_name_only: bool,
 }
 
 #[derive(FieldNames, Debug, Clone, Deserialize, Serialize, Default)]

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1978,6 +1978,7 @@ impl LapceTab {
                             *list_index,
                             *indent_level,
                             text.clone(),
+                            &data.config,
                         );
                         ctx.set_handled();
                     }


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Adds a settings under the core section that makes it possible to only select the name of a file when renaming. I am not completely sure if "core" is the right section for it, but the others fit even worse. 
The option is on by default.