### PR TITLE
Improve `get_file_node[_mut]` efficiency

### DIFF
--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -63,17 +63,27 @@ impl FileNodeItem {
     /// (ignored because the function is private but I promise this passes)
     /// ```rust,ignore
     /// # use lapce_rpc::file::FileNodeItem;
-    /// # use std::path::Path;
+    /// # use std::path::{Path, PathBuf};
+    /// # use std::collections::HashMap;
     /// #
-    /// let mut iter = FileNodeItem::ancestors_rev(Path::new("/pre/fix"), Path::new("/pre/fix/foo/bar"));
+    /// let node_item = FileNodeItem {
+    ///     path_buf: PathBuf::from("/pre/fix"),
+    ///     // ...
+    /// #    is_dir: true,
+    /// #    read: false,
+    /// #    open: false,
+    /// #    children: HashMap::new(),
+    /// #    children_open_count: 0,
+    ///};
+    /// let mut iter = node_item.ancestors_rev(Path::new("/pre/fix/foo/bar"));
     /// assert_eq!(Some(Path::new("/pre/fix/foo")), iter.next());
     /// assert_eq!(Some(Path::new("/pre/fix/foo/bar")), iter.next());
     /// ```
     fn ancestors_rev<'a>(
-        prefix: &Path,
+        &self,
         path: &'a Path,
     ) -> impl Iterator<Item = &'a Path> {
-        let skip = prefix.components().count();
+        let skip = self.path_buf.components().count();
         let take = path.components().count() - skip;
 
         let ancestors = path.ancestors().take(take).collect::<Vec<&Path>>();
@@ -82,14 +92,14 @@ impl FileNodeItem {
 
     pub fn get_file_node(&self, path: &Path) -> Option<&FileNodeItem> {
         let mut node = self;
-        for p in Self::ancestors_rev(&self.path_buf, path) {
+        for p in self.ancestors_rev(path) {
             node = node.children.get(p)?;
         }
         Some(node)
     }
 
     pub fn get_file_node_mut(&mut self, path: &Path) -> Option<&mut FileNodeItem> {
-        let iterator = Self::ancestors_rev(&self.path_buf, path);
+        let iterator = self.ancestors_rev(path);
 
         let mut node = self;
         for p in iterator {

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -89,6 +89,7 @@ impl FileNodeItem {
             return None;
         };
 
+        #[allow(clippy::needless_collect)] // Ancestors is not reversible
         let ancestors = path.ancestors().take(take).collect::<Vec<&Path>>();
         Some(ancestors.into_iter().rev())
     }

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -75,31 +75,34 @@ impl FileNodeItem {
     /// #    children: HashMap::new(),
     /// #    children_open_count: 0,
     ///};
-    /// let mut iter = node_item.ancestors_rev(Path::new("/pre/fix/foo/bar"));
+    /// let mut iter = node_item.ancestors_rev(Path::new("/pre/fix/foo/bar")).unwrap();
     /// assert_eq!(Some(Path::new("/pre/fix/foo")), iter.next());
     /// assert_eq!(Some(Path::new("/pre/fix/foo/bar")), iter.next());
     /// ```
     fn ancestors_rev<'a>(
         &self,
         path: &'a Path,
-    ) -> impl Iterator<Item = &'a Path> {
+    ) -> Option<impl Iterator<Item = &'a Path>> {
+        if !path.starts_with(&self.path_buf) {
+            return None;
+        }
         let skip = self.path_buf.components().count();
         let take = path.components().count() - skip;
 
         let ancestors = path.ancestors().take(take).collect::<Vec<&Path>>();
-        ancestors.into_iter().rev()
+        Some(ancestors.into_iter().rev())
     }
 
     pub fn get_file_node(&self, path: &Path) -> Option<&FileNodeItem> {
         let mut node = self;
-        for p in self.ancestors_rev(path) {
+        for p in self.ancestors_rev(path)? {
             node = node.children.get(p)?;
         }
         Some(node)
     }
 
     pub fn get_file_node_mut(&mut self, path: &Path) -> Option<&mut FileNodeItem> {
-        let iterator = self.ancestors_rev(path);
+        let iterator = self.ancestors_rev(path)?;
 
         let mut node = self;
         for p in iterator {

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -89,9 +89,10 @@ impl FileNodeItem {
     }
 
     pub fn get_file_node_mut(&mut self, path: &Path) -> Option<&mut FileNodeItem> {
-        let prefix = self.path_buf.clone();
+        let iterator = Self::ancestors_rev(&self.path_buf, path);
+
         let mut node = self;
-        for p in Self::ancestors_rev(&prefix, path) {
+        for p in iterator {
             node = node.children.get_mut(p)?;
         }
         Some(node)

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -95,21 +95,13 @@ impl FileNodeItem {
     }
 
     pub fn get_file_node(&self, path: &Path) -> Option<&FileNodeItem> {
-        let mut node = self;
-        for p in self.ancestors_rev(path)? {
-            node = node.children.get(p)?;
-        }
-        Some(node)
+        self.ancestors_rev(path)?
+            .try_fold(self, |node, path| node.children.get(path))
     }
 
     pub fn get_file_node_mut(&mut self, path: &Path) -> Option<&mut FileNodeItem> {
-        let iterator = self.ancestors_rev(path)?;
-
-        let mut node = self;
-        for p in iterator {
-            node = node.children.get_mut(p)?;
-        }
-        Some(node)
+        self.ancestors_rev(path)?
+            .try_fold(self, |node, path| node.children.get_mut(path))
     }
 
     pub fn remove_child(&mut self, path: &Path) -> Option<FileNodeItem> {

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -83,11 +83,11 @@ impl FileNodeItem {
         &self,
         path: &'a Path,
     ) -> Option<impl Iterator<Item = &'a Path>> {
-        if !path.starts_with(&self.path_buf) {
+        let take = if let Ok(suffix) = path.strip_prefix(&self.path_buf) {
+            suffix.components().count()
+        } else {
             return None;
-        }
-        let skip = self.path_buf.components().count();
-        let take = path.components().count() - skip;
+        };
 
         let ancestors = path.ancestors().take(take).collect::<Vec<&Path>>();
         Some(ancestors.into_iter().rev())

--- a/lapce-ui/src/picker.rs
+++ b/lapce-ui/src/picker.rs
@@ -440,7 +440,7 @@ impl Widget<LapceTabData> for FilePickerExplorer {
                 let index = ((mouse_event.pos.y + self.line_height)
                     / self.line_height) as usize;
                 ctx.request_paint();
-                if let Some(item) = picker.root.get_file_node_mut(&pwd) {
+                if let Some(item) = picker.root.get_file_node(&pwd) {
                     let (_, node) = get_item_children(0, index, item);
                     if let Some(_node) = node {
                         ctx.set_cursor(&druid::Cursor::Pointer);


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This is absolutely unnecessary as I don't think the code is very hot, but I was rather confused by how it works and I also didn't like the duplication.

This PR now avoids allocations previously used when re-joining the stripped prefix, at the cost of counting path components. Also, I think the resulting implementation is cleaner and the added (although, by default, disabled) tests are also a bonus.