### PR TITLE
Fix cursor movement on selections with arrow keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#1835](https://github.com/lapce/lapce/pull/1835): Add mouse keybinds
 
 ### Bug Fixes
+- [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys
 
 ## 0.2.5
 


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Fixes #1908   

(Where `|` is the cursor and `|H|` is a selection)  
Before: `|H|ello` -> right arrow key -> `He|llo`
`|H|ello` -> right arrow key -> `H|ello`  
This matches other applications better.  

It would be nice to have tests for this, but I didn't see testing code for the document movement commands?