### PR TITLE
Add borders to SourceControlBranches

### DIFF
--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -1194,6 +1194,11 @@ impl Widget<LapceTabData> for SourceControlBranches {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &LapceTabData, env: &Env) {
         let rect = ctx.size().to_rect();
+        ctx.stroke(
+            rect,
+            data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
+            1.0,
+        );
         ctx.fill(
             rect,
             data.config


### PR DESCRIPTION
Optimize the UI: add borders to SourceControlBranches.

Before:
<img width="419" alt="before-light" src="https://user-images.githubusercontent.com/4404609/210312138-e3eb42a4-05eb-4eb6-aa39-6e20ce9f1ebb.png">
<img width="413" alt="before-dark" src="https://user-images.githubusercontent.com/4404609/210312155-704c1f4e-9633-453c-9930-0600d3827eb0.png">

After:
<img width="411" alt="after-light" src="https://user-images.githubusercontent.com/4404609/210312179-e170b008-a1d9-4efe-977b-c118c872da01.png">
<img width="437" alt="after-dark" src="https://user-images.githubusercontent.com/4404609/210312187-6b977611-61b6-44b1-b66e-35f56c32cf0f.png">
