### PR TITLE
Remove cloning of the `colors` vector in `lapce_ui::settings::ThemeSection::update_items`

### DIFF
--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -1370,15 +1370,14 @@ impl ThemeSection {
         let event_sink = ctx.get_external_handle();
         self.items = self
             .colors
-            .clone()
-            .into_iter()
+            .iter()
             .map(|color| {
                 WidgetPod::new(LapcePadding::new(
                     5.0,
                     ThemeSettingItem::new(
                         data,
                         self.kind,
-                        color,
+                        color.clone(),
                         event_sink.clone(),
                     ),
                 ))


### PR DESCRIPTION
We only need to clone the contents of the vector, not the vector itself.