### PR TITLE
Added primary buffer support to the editor when compiled for linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,6 +2649,7 @@ dependencies = [
  "directories",
  "dmg",
  "druid",
+ "druid-shell",
  "flate2",
  "fs_extra",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ branch = "shell_opengl"
 # path = "../../druid/druid"
 features = ["svg", "im", "serde"]
 
+[workspace.dependencies.druid-shell]
+git = "https://github.com/lapce/druid"
+branch = "shell_opengl"
 
 [profile.release-lto]
 inherits = "release"

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -75,6 +75,12 @@ pub enum EditCommand {
     Paste,
     #[strum(serialize = "paste_before")]
     PasteBefore,
+    #[cfg(target_os = "linux")]
+    #[strum(serialize = "clipboard_primary_copy")]
+    ClipboardPrimaryCopy,
+    #[cfg(target_os = "linux")]
+    #[strum(serialize = "clipboard_primary_paste")]
+    ClipboardPrimaryPaste,
 
     #[strum(serialize = "normal_mode")]
     NormalMode,

--- a/lapce-core/src/register.rs
+++ b/lapce-core/src/register.rs
@@ -3,6 +3,10 @@ use crate::mode::VisualMode;
 pub trait Clipboard {
     fn get_string(&self) -> Option<String>;
     fn put_string(&mut self, s: impl AsRef<str>);
+    #[cfg(target_os = "linux")]
+    fn get_string_primary(&self) -> Option<String>;
+    #[cfg(target_os = "linux")]
+    fn put_string_primary(&mut self, s: impl AsRef<str>);
 }
 
 #[derive(Clone, Default)]

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -43,6 +43,7 @@ lapce-rpc.workspace = true
 lapce-proxy.workspace = true
 
 druid.workspace = true
+druid-shell.workspace = true
 
 sha2 = "0.10.6"
 fs_extra = "1.2.0"

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -12,6 +12,7 @@ use druid::{
     },
     Color, ExtEventSink, FontFamily, Point, Size, Target, Vec2, WidgetId,
 };
+#[cfg(target_os = "linux")]
 use druid_shell::platform::linux::ApplicationExt;
 use itertools::Itertools;
 use lapce_core::{

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -12,6 +12,7 @@ use druid::{
     },
     Color, ExtEventSink, FontFamily, Point, Size, Target, Vec2, WidgetId,
 };
+use druid_shell::platform::linux::ApplicationExt;
 use itertools::Itertools;
 use lapce_core::{
     buffer::{Buffer, DiffLines, InvalLines},
@@ -66,6 +67,11 @@ impl SystemClipboard {
     fn clipboard() -> druid::Clipboard {
         druid::Application::global().clipboard()
     }
+
+    #[cfg(target_os = "linux")]
+    fn primary_clipboard() -> druid::Clipboard {
+        druid::Application::global().primary_clipboard()
+    }
 }
 
 impl Clipboard for SystemClipboard {
@@ -75,6 +81,16 @@ impl Clipboard for SystemClipboard {
 
     fn put_string(&mut self, s: impl AsRef<str>) {
         Self::clipboard().put_string(s)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn get_string_primary(&self) -> Option<String> {
+        Self::primary_clipboard().get_string()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn put_string_primary(&mut self, s: impl AsRef<str>) {
+        Self::primary_clipboard().put_string(s)
     }
 }
 

--- a/lapce-ui/src/editor/container.rs
+++ b/lapce-ui/src/editor/container.rs
@@ -1,9 +1,15 @@
 use druid::{
-    kurbo::Line, BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget, WidgetId,
-    WidgetPod,
+    kurbo::Line, BoxConstraints, Command, Env, Event, EventCtx, LayoutCtx,
+    LifeCycle, LifeCycleCtx, PaintCtx, Point, RenderContext, Size, Target,
+    UpdateCtx, Widget, WidgetId, WidgetPod,
 };
-use lapce_data::{config::LapceTheme, data::LapceTabData};
+use lapce_data::{
+    command::{CommandKind, LapceCommand, LAPCE_COMMAND},
+    config::LapceTheme,
+    data::LapceTabData,
+};
+
+use lapce_core::command::EditCommand;
 
 use super::bread_crumb::LapceEditorBreadCrumb;
 use crate::{
@@ -83,6 +89,21 @@ impl Widget<LapceTabData> for LapceEditorContainer {
                 let doc = editor_data.doc.clone();
                 editor_data
                     .sync_buffer_position(self.editor.widget().inner().offset());
+                if let Event::MouseUp(_) = event {
+                    #[cfg(target_os = "linux")]
+                    {
+                        ctx.submit_command(Command::new(
+                            LAPCE_COMMAND,
+                            LapceCommand {
+                                kind: CommandKind::Edit(
+                                    EditCommand::ClipboardPrimaryCopy,
+                                ),
+                                data: None,
+                            },
+                            Target::Widget(*editor_data.main_split.tab_id),
+                        ));
+                    }
+                }
                 data.update_from_editor_buffer_data(editor_data, &editor, &doc);
             }
             _ => (),

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -720,6 +720,20 @@ impl Widget<LapceTabData> for LapceEditorView {
                     );
                     editor_data.get_code_actions(ctx);
 
+                    #[cfg(target_os = "linux")]
+                    {
+                        ctx.submit_command(Command::new(
+                            LAPCE_COMMAND,
+                            LapceCommand {
+                                kind: CommandKind::Edit(
+                                    EditCommand::ClipboardPrimaryCopy,
+                                ),
+                                data: None,
+                            },
+                            Target::Widget(*editor_data.main_split.tab_id),
+                        ));
+                    }
+
                     data.keypress = keypress.clone();
                 }
             }


### PR DESCRIPTION
This pr adds support for the primary clipboard which is present in most linux systems. This allows for pasting text selected in any application using the middle mouse button. This fixes #834.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users