### PR TITLE
Fix GotoTypeDefinition that contains percent-encoded characters

### DIFF
--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -919,22 +919,7 @@ impl Remote for WslRemote {
 // This function strips the additional / from the beginning, if the first segment is a drive letter.
 #[cfg(windows)]
 pub fn path_from_url(url: &Url) -> PathBuf {
-    let path = url.path();
-    if let Some(path) = path.strip_prefix('/') {
-        if let Some((maybe_drive_letter, _)) = path.split_once(['/', '\\']) {
-            let b = maybe_drive_letter.as_bytes();
-            if b.len() == 2
-                && matches!(
-                    b[0],
-                    b'a'..=b'z' | b'A'..=b'Z'
-                )
-                && b[1] == b':'
-            {
-                return PathBuf::from(path);
-            }
-        }
-    }
-    PathBuf::from(path)
+    return url.to_file_path().expect("Path must be a file scheme");
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Simply use the provided function by Url. Do you want to propagate this upwards?

Solves: https://github.com/lapce/lapce/issues/1910

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users