### PR TITLE
Register buffer when saving-as a new file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys
+- [#1939](https://github.com/lapce/lapce/pull/1939): Fix saving/editing newly saved-as files
 
 ## 0.2.5
 

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -709,7 +709,7 @@ impl ProxyHandler for Dispatcher {
                 rev,
                 content,
             } => {
-                let mut buffer = Buffer::new(buffer_id, path);
+                let mut buffer = Buffer::new(buffer_id, path.clone());
                 buffer.rope = Rope::from(content);
                 buffer.rev = rev;
                 let result = buffer
@@ -719,6 +719,7 @@ impl ProxyHandler for Dispatcher {
                         code: 0,
                         message: e.to_string(),
                     });
+                self.buffers.insert(path, buffer);
                 self.respond_rpc(id, result);
             }
             CreateFile { path } => {


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Fixes #1750   
The issue was that the new file was not registered, thus causing future attempts to update the file to error.