### PR TITLE
fix: redundant context menus in input box

### DIFF
--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -292,7 +292,7 @@ impl LapceEditor {
         }
 
         let menu_items = if let BufferContent::File(_) = editor_data.doc.content() {
-             vec![
+            vec![
                 MenuKind::Item(MenuItem {
                     desc: None,
                     command: LapceCommand {

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -291,60 +291,100 @@ impl LapceEditor {
             editor_data.single_click(ctx, mouse_event, config);
         }
 
-        let menu_items = vec![
-            MenuKind::Item(MenuItem {
-                desc: None,
-                command: LapceCommand {
-                    kind: CommandKind::Focus(FocusCommand::GotoDefinition),
-                    data: None,
-                },
-                enabled: true,
-            }),
-            MenuKind::Item(MenuItem {
-                desc: None,
-                command: LapceCommand {
-                    kind: CommandKind::Focus(FocusCommand::GotoTypeDefinition),
-                    data: None,
-                },
-                enabled: true,
-            }),
-            MenuKind::Separator,
-            MenuKind::Item(MenuItem {
-                desc: None,
-                command: LapceCommand {
-                    kind: CommandKind::Edit(EditCommand::ClipboardCut),
-                    data: None,
-                },
-                enabled: true,
-            }),
-            MenuKind::Item(MenuItem {
-                desc: None,
-                command: LapceCommand {
-                    kind: CommandKind::Edit(EditCommand::ClipboardCopy),
-                    data: None,
-                },
-                enabled: true,
-            }),
-            MenuKind::Item(MenuItem {
-                desc: None,
-                command: LapceCommand {
-                    kind: CommandKind::Edit(EditCommand::ClipboardPaste),
-                    data: None,
-                },
-                enabled: true,
-            }),
-            MenuKind::Separator,
-            MenuKind::Item(MenuItem {
-                desc: None,
-                command: LapceCommand {
-                    kind: CommandKind::Workbench(
-                        LapceWorkbenchCommand::PaletteCommand,
-                    ),
-                    data: None,
-                },
-                enabled: true,
-            }),
-        ];
+        let menu_items = if let BufferContent::File(_) = editor_data.doc.content() {
+             vec![
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Focus(FocusCommand::GotoDefinition),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Focus(FocusCommand::GotoTypeDefinition),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Separator,
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Edit(EditCommand::ClipboardCut),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Edit(EditCommand::ClipboardCopy),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Edit(EditCommand::ClipboardPaste),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Separator,
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Workbench(
+                            LapceWorkbenchCommand::PaletteCommand,
+                        ),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+            ]
+        } else {
+            vec![
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Edit(EditCommand::ClipboardCut),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Edit(EditCommand::ClipboardCopy),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Edit(EditCommand::ClipboardPaste),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Separator,
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
+                        kind: CommandKind::Workbench(
+                            LapceWorkbenchCommand::PaletteCommand,
+                        ),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+            ]
+        };
 
         ctx.submit_command(Command::new(
             LAPCE_UI_COMMAND,


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

remove redundant context menus in input box, fix: https://github.com/lapce/lapce/issues/1952

file editor:
<img width="447" alt="image" src="https://user-images.githubusercontent.com/4404609/211457759-fcc46455-e364-4c17-a7a5-7bba45e1bef3.png">

input box:
<img width="256" alt="image" src="https://user-images.githubusercontent.com/4404609/211457849-7d4090d4-629e-46e8-9750-24bc82f8bc21.png">
<img width="256" alt="image" src="https://user-images.githubusercontent.com/4404609/211457885-20fe9528-05de-4553-9eac-40720dcb4dad.png">
