### PR TITLE
fix: trigger hover when renaming

### DIFF
--- a/lapce-data/src/rename.rs
+++ b/lapce-data/src/rename.rs
@@ -27,6 +27,7 @@ pub struct RenameData {
     pub start: usize,
     pub end: usize,
     pub placeholder: String,
+    pub mouse_within: bool,
 }
 
 impl RenameData {
@@ -43,6 +44,7 @@ impl RenameData {
             start: 0,
             end: 0,
             placeholder: "".to_string(),
+            mouse_within: false,
         }
     }
 
@@ -60,6 +62,7 @@ impl RenameData {
         self.offset = offset;
         self.from_editor = from_editor;
         self.position = position;
+        self.mouse_within = false;
     }
 
     pub fn cancel(&mut self) {

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -2313,7 +2313,10 @@ impl Widget<LapceTabData> for LapceEditor {
                         &editor.view,
                         &data.config,
                     );
-                    editor_data.update_hover(ctx, offset);
+                    if *data.focus == self.view_id {
+                        editor_data.update_hover(ctx, offset);
+                    }
+
                     data.update_from_editor_buffer_data(editor_data, &editor, &doc);
                 } else if self.drag_timer == *id {
                     let doc = data.main_split.editor_doc(self.view_id);

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -196,6 +196,7 @@ impl LapceEditor {
         if !editor_data.check_hover(ctx, offset, is_inside, within_scroll)
             && is_inside
             && within_scroll
+            && !editor_data.rename.mouse_within
         {
             self.mouse_hover_timer = ctx.request_timer(
                 Duration::from_millis(config.editor.hover_delay),
@@ -2313,9 +2314,7 @@ impl Widget<LapceTabData> for LapceEditor {
                         &editor.view,
                         &data.config,
                     );
-                    if *data.focus == self.view_id {
-                        editor_data.update_hover(ctx, offset);
-                    }
+                    editor_data.update_hover(ctx, offset);
 
                     data.update_from_editor_buffer_data(editor_data, &editor, &doc);
                 } else if self.drag_timer == *id {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -621,6 +621,10 @@ impl LapceTab {
         _env: &Env,
     ) {
         match event {
+            Event::MouseMove(mouse) => {
+                Arc::make_mut(&mut data.rename).mouse_within = data.rename.active
+                    && self.rename.layout_rect().contains(mouse.pos);
+            }
             Event::MouseDown(mouse) => {
                 if !ctx.is_handled() && mouse.button.is_left() {
                     if let Some(position) = self.bar_hit_test(mouse.pos) {


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

disable trigger hover when renaming，only trigger hover when focus on editor, fix: https://github.com/lapce/lapce/issues/1951

<img width="302" alt="image" src="https://user-images.githubusercontent.com/4404609/211461246-465d1a51-493d-447b-a8d6-b7319b715157.png">
