### PR TITLE
Completion lens

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -35,6 +35,9 @@ enable-error-lens = true
 error-lens-end-of-line = true
 error-lens-font-family = ""
 error-lens-font-size = 0
+enable-completion-lens = false
+completion-lens-font-family = ""
+completion-lens-font-size = 0
 blink-interval = 500                    # ms
 multicursor-case-sensitive = true
 multicursor-whole-words = true
@@ -165,6 +168,8 @@ magenta = "#C678DD"
 "error_lens.warning.background" = "#E5C07B20"
 "error_lens.other.foreground" = "#5C6370"
 "error_lens.other.background" = "#5C637020"
+
+"completion_lens.foreground" = "#5C6370"
 
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -99,6 +99,8 @@ impl LapceTheme {
     pub const ERROR_LENS_OTHER_FOREGROUND: &str = "error_lens.other.foreground";
     pub const ERROR_LENS_OTHER_BACKGROUND: &str = "error_lens.other.background";
 
+    pub const COMPLETION_LENS_FOREGROUND: &str = "completion_lens.foreground";
+
     pub const SOURCE_CONTROL_ADDED: &str = "source_control.added";
     pub const SOURCE_CONTROL_REMOVED: &str = "source_control.removed";
     pub const SOURCE_CONTROL_MODIFIED: &str = "source_control.modified";
@@ -407,6 +409,18 @@ pub struct EditorConfig {
     )]
     pub error_lens_font_size: usize,
     #[field_names(
+        desc = "If the editor should display the completion item as phantom text"
+    )]
+    pub enable_completion_lens: bool,
+    #[field_names(
+        desc = "Set completion lens font family. If empty, it uses the inlay hint font family."
+    )]
+    pub completion_lens_font_family: String,
+    #[field_names(
+        desc = "Set the completion lens font size. If 0 it uses the inlay hint font size."
+    )]
+    pub completion_lens_font_size: usize,
+    #[field_names(
         desc = "Set the cursor blink interval (in milliseconds). Set to 0 to completely disable."
     )]
     pub blink_interval: u64, // TODO: change to u128 when upgrading config-rs to >0.11
@@ -491,6 +505,22 @@ impl EditorConfig {
             self.inlay_hint_font_size()
         } else {
             self.error_lens_font_size
+        }
+    }
+
+    pub fn completion_lens_font_family(&self) -> FontFamily {
+        if self.completion_lens_font_family.is_empty() {
+            self.inlay_hint_font_family()
+        } else {
+            FontFamily::new_unchecked(self.completion_lens_font_family.clone())
+        }
+    }
+
+    pub fn completion_lens_font_size(&self) -> usize {
+        if self.completion_lens_font_size == 0 {
+            self.inlay_hint_font_size()
+        } else {
+            self.completion_lens_font_size
         }
     }
 }

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -198,21 +198,11 @@ impl BufferContent {
     }
 
     pub fn is_palette(&self) -> bool {
-        match self {
-            BufferContent::File(_) => false,
-            BufferContent::SettingsValue(..) => false,
-            BufferContent::Scratch(..) => false,
-            BufferContent::Local(local) => matches!(local, LocalBufferKind::Palette),
-        }
+        matches!(self, BufferContent::Local(LocalBufferKind::Palette))
     }
 
     pub fn is_search(&self) -> bool {
-        match self {
-            BufferContent::File(_) => false,
-            BufferContent::SettingsValue(..) => false,
-            BufferContent::Scratch(..) => false,
-            BufferContent::Local(local) => matches!(local, LocalBufferKind::Search),
-        }
+        matches!(self, BufferContent::Local(LocalBufferKind::Search))
     }
 
     pub fn is_settings(&self) -> bool {
@@ -768,9 +758,12 @@ impl Document {
 
                             let _ = event_sink.submit_command(
                                 LAPCE_UI_COMMAND,
-                                LapceUICommand::UpdateSemanticStyles(
-                                    buffer_id, path, rev, styles,
-                                ),
+                                LapceUICommand::UpdateSemanticStyles {
+                                    id: buffer_id,
+                                    path,
+                                    rev,
+                                    styles,
+                                },
                                 Target::Widget(tab_id),
                             );
                         });

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1873,7 +1873,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListNext => {
@@ -1888,7 +1894,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListNextPage => {
@@ -1903,7 +1915,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListPrevious => {
@@ -1918,7 +1936,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListPreviousPage => {
@@ -1933,7 +1957,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             JumpToNextSnippetPlaceholder => {

--- a/lapce-data/src/explorer.rs
+++ b/lapce-data/src/explorer.rs
@@ -278,7 +278,11 @@ impl FileExplorerData {
                 let path = path.clone();
                 let _ = event_sink.submit_command(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::UpdateExplorerItems(path, items, expand),
+                    LapceUICommand::UpdateExplorerItems {
+                        path,
+                        items,
+                        expand,
+                    },
                     Target::Widget(tab_id),
                 );
 

--- a/lapce-data/src/history.rs
+++ b/lapce-data/src/history.rs
@@ -169,6 +169,7 @@ impl DocumentHistory {
         self.line_styles.borrow().get(&line).cloned().unwrap()
     }
 
+    /// Retrieve the `head` version of the buffer
     pub fn retrieve(&self, doc: &Document) {
         if let BufferContent::File(path) = &doc.content() {
             let id = doc.id();

--- a/lapce-data/src/hover.rs
+++ b/lapce-data/src/hover.rs
@@ -128,7 +128,7 @@ impl HoverData {
 
                         let _ = event_sink.submit_command(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::UpdateHover(request_id, items),
+                            LapceUICommand::UpdateHover { request_id, items },
                             Target::Widget(hover_widget_id),
                         );
                     }

--- a/lapce-data/src/keypress/mod.rs
+++ b/lapce-data/src/keypress/mod.rs
@@ -578,11 +578,11 @@ impl KeyPressData {
 
             let _ = event_sink.submit_command(
                 LAPCE_UI_COMMAND,
-                LapceUICommand::FilterKeymaps(
+                LapceUICommand::FilterKeymaps {
                     pattern,
-                    Arc::new(filtered_commands_with_keymap),
-                    Arc::new(filtered_commands_without_keymap),
-                ),
+                    keymaps: Arc::new(filtered_commands_with_keymap),
+                    commands: Arc::new(filtered_commands_without_keymap),
+                },
                 Target::Auto,
             );
         });

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -246,14 +246,20 @@ impl PaletteItemContent {
             PaletteItemContent::ColorTheme(theme) => {
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::SetColorTheme(theme.to_string(), preview),
+                    LapceUICommand::SetColorTheme {
+                        theme: theme.to_string(),
+                        preview,
+                    },
                     Target::Auto,
                 ));
             }
             PaletteItemContent::IconTheme(theme) => {
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::SetIconTheme(theme.to_string(), preview),
+                    LapceUICommand::SetIconTheme {
+                        theme: theme.to_string(),
+                        preview,
+                    },
                     Target::Auto,
                 ));
             }
@@ -872,7 +878,7 @@ impl PaletteViewData {
 
                 let _ = event_sink.submit_command(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::UpdatePaletteItems(run_id, items),
+                    LapceUICommand::UpdatePaletteItems { run_id, items },
                     Target::Widget(widget_id),
                 );
             }
@@ -1161,7 +1167,7 @@ impl PaletteViewData {
                         };
                         let _ = event_sink.submit_command(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::UpdatePaletteItems(run_id, items),
+                            LapceUICommand::UpdatePaletteItems { run_id, items },
                             Target::Widget(widget_id),
                         );
                     }
@@ -1221,7 +1227,7 @@ impl PaletteViewData {
                             .collect();
                         let _ = event_sink.submit_command(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::UpdatePaletteItems(run_id, items),
+                            LapceUICommand::UpdatePaletteItems { run_id, items },
                             Target::Widget(widget_id),
                         );
                     }
@@ -1261,11 +1267,11 @@ impl PaletteViewData {
 
                 let _ = event_sink.submit_command(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::FilterPaletteItems(
+                    LapceUICommand::FilterPaletteItems {
                         run_id,
                         input,
                         filtered_items,
-                    ),
+                    },
                     Target::Widget(widget_id),
                 );
             } else {

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -254,9 +254,12 @@ impl CoreHandler for LapceProxy {
             } => {
                 let _ = self.event_sink.submit_command(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::UpdateCompletion(
-                        request_id, input, resp, plugin_id,
-                    ),
+                    LapceUICommand::UpdateCompletion {
+                        request_id,
+                        input,
+                        resp,
+                        plugin_id,
+                    },
                     Target::Widget(self.tab_id),
                 );
             }

--- a/lapce-data/src/source_control.rs
+++ b/lapce-data/src/source_control.rs
@@ -186,14 +186,15 @@ impl KeyPressFocus for SourceControlData {
                     if !self.file_diffs.is_empty() {
                         ctx.submit_command(Command::new(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::OpenFileDiff(
-                                self.file_diffs
+                            LapceUICommand::OpenFileDiff {
+                                path: self
+                                    .file_diffs
                                     .get_index(self.file_list_index)
                                     .unwrap()
                                     .0
                                     .clone(),
-                                "head".to_string(),
-                            ),
+                                history: "head".to_string(),
+                            },
                             Target::Auto,
                         ));
                     }

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -225,8 +225,13 @@ impl LapceEditorView {
             LapceUICommand::EnsureRectVisible(rect) => {
                 self.ensure_rect_visible(ctx, data, *rect, env);
             }
-            LapceUICommand::ResolveCompletion(buffer_id, rev, offset, item) => {
-                if data.doc.id() != *buffer_id {
+            LapceUICommand::ResolveCompletion {
+                id,
+                rev,
+                offset,
+                item,
+            } => {
+                if data.doc.id() != *id {
                     return;
                 }
                 if data.doc.rev() != *rev {
@@ -310,6 +315,7 @@ impl LapceEditorView {
         }
     }
 
+    /// Scroll the editor such that the rect is visible.
     fn ensure_rect_visible(
         &mut self,
         ctx: &mut EventCtx,

--- a/lapce-ui/src/hover.rs
+++ b/lapce-ui/src/hover.rs
@@ -75,7 +75,7 @@ impl Widget<LapceTabData> for HoverContainer {
         match event {
             Event::Command(cmd) if cmd.is(LAPCE_UI_COMMAND) => {
                 let command = cmd.get_unchecked(LAPCE_UI_COMMAND);
-                if let LapceUICommand::UpdateHover(request_id, items) = command {
+                if let LapceUICommand::UpdateHover { request_id, items } = command {
                     let hover = Arc::make_mut(&mut data.hover);
                     hover.receive(*request_id, items.clone());
                     ctx.request_paint();

--- a/lapce-ui/src/palette.rs
+++ b/lapce-ui/src/palette.rs
@@ -53,31 +53,7 @@ impl Widget<LapceTabData> for Palette {
         data: &mut LapceTabData,
         env: &Env,
     ) {
-        // match event {
-        //     Event::MouseDown(_)
-        //     | Event::MouseMove(_)
-        //     | Event::Wheel(_)
-        //     | Event::MouseUp(_) => {
-        //         if data.palette.status == PaletteStatus::Inactive {
-        //             return;
-        //         }
-        //     }
-        //     _ => (),
-        // }
-
         match event {
-            // Event::KeyDown(key_event) => {
-            //     let mut keypress = data.keypress.clone();
-            //     let mut_keypress = Arc::make_mut(&mut keypress);
-            //     let mut palette_data = data.palette_view_data();
-            //     mut_keypress.key_down(ctx, key_event, &mut palette_data, env);
-            //     data.palette = palette_data.palette.clone();
-            //     data.keypress = keypress;
-            //     data.workspace = palette_data.workspace.clone();
-            //     data.main_split = palette_data.main_split.clone();
-            //     data.find = palette_data.find.clone();
-            //     ctx.set_handled();
-            // }
             Event::Command(cmd) if cmd.is(LAPCE_COMMAND) => {
                 let command = cmd.get_unchecked(LAPCE_COMMAND);
                 let mut palette_data = data.palette_view_data();
@@ -88,6 +64,8 @@ impl Widget<LapceTabData> for Palette {
                     Modifiers::default(),
                     env,
                 );
+                // TODO: manually restoring the changed palette data is unfortunate, it would be
+                // better to have a function to do this to avoid accidents where we forget to update
                 data.palette = palette_data.palette.clone();
                 data.workspace = palette_data.workspace.clone();
                 data.main_split = palette_data.main_split.clone();
@@ -123,12 +101,7 @@ impl Widget<LapceTabData> for Palette {
                             Target::Widget(data.palette.input_editor),
                         ));
                     }
-                    LapceUICommand::CancelPalette => {
-                        let mut palette_data = data.palette_view_data();
-                        palette_data.cancel(ctx);
-                        data.palette = palette_data.palette.clone();
-                    }
-                    LapceUICommand::UpdatePaletteItems(run_id, items) => {
+                    LapceUICommand::UpdatePaletteItems { run_id, items } => {
                         let palette = Arc::make_mut(&mut data.palette);
                         if &palette.run_id == run_id {
                             palette.total_items = items.clone();
@@ -145,11 +118,11 @@ impl Widget<LapceTabData> for Palette {
                             }
                         }
                     }
-                    LapceUICommand::FilterPaletteItems(
+                    LapceUICommand::FilterPaletteItems {
                         run_id,
                         input,
                         filtered_items,
-                    ) => {
+                    } => {
                         let palette = Arc::make_mut(&mut data.palette);
                         if &palette.run_id == run_id && palette.get_input() == input
                         {

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -522,14 +522,6 @@ impl Widget<LapceTabData> for LapceSettings {
         data: &LapceTabData,
         env: &Env,
     ) -> Size {
-        if self.children.is_empty() {
-            ctx.submit_command(Command::new(
-                LAPCE_UI_COMMAND,
-                LapceUICommand::InitChildren,
-                Target::Widget(self.widget_id),
-            ));
-        }
-
         let mut y = 0.0;
         for child in self.children.iter_mut() {
             let size = child.layout(ctx, bc, data, env);
@@ -748,11 +740,11 @@ impl SettingsItemInfo {
     ) {
         ctx.submit_command(Command::new(
             LAPCE_UI_COMMAND,
-            LapceUICommand::UpdateSettingsFile(
-                self.kind.clone(),
-                self.key.clone(),
+            LapceUICommand::UpdateSettingsFile {
+                kind: self.kind.clone(),
+                key: self.key.clone(),
                 value,
-            ),
+            },
             Target::Widget(data.id),
         ));
     }
@@ -1568,15 +1560,15 @@ impl ThemeSettingItem {
                     .on_click(move |ctx, data, _env| {
                         ctx.submit_command(Command::new(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::ResetSettingsFile(
-                                kind.to_string(),
-                                local_color.clone(),
-                            ),
+                            LapceUICommand::ResetSettingsFile {
+                                kind: kind.to_string(),
+                                key: local_color.clone(),
+                            },
                             Target::Widget(data.id),
                         ));
                         ctx.submit_command(Command::new(
                             LAPCE_UI_COMMAND,
-                            LapceUICommand::ResetSettings,
+                            LapceUICommand::ResetSettingsItem,
                             Target::Widget(widget_id),
                         ));
                     })
@@ -1671,17 +1663,17 @@ impl Widget<LapceTabData> for ThemeSettingItem {
                 let content = editor_data.doc.buffer().to_string();
                 ctx.submit_command(Command::new(
                     LAPCE_UI_COMMAND,
-                    LapceUICommand::UpdateSettingsFile(
-                        self.kind.to_string(),
-                        self.color.clone(),
-                        serde_json::json!(content),
-                    ),
+                    LapceUICommand::UpdateSettingsFile {
+                        kind: self.kind.to_string(),
+                        key: self.color.clone(),
+                        value: serde_json::json!(content),
+                    },
                     Target::Widget(data.id),
                 ));
             }
             Event::Command(cmd) if cmd.is(LAPCE_UI_COMMAND) => {
                 let command = cmd.get_unchecked(LAPCE_UI_COMMAND);
-                if let LapceUICommand::ResetSettings = command {
+                if let LapceUICommand::ResetSettingsItem = command {
                     let default = self.default(data);
                     let name = format!("{}.{}", self.kind, self.color);
                     let doc = data.main_split.value_docs.get_mut(&name).unwrap();

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -190,15 +190,15 @@ impl Widget<LapceTabData> for SourceControlFileList {
                             } else {
                                 ctx.submit_command(Command::new(
                                     LAPCE_UI_COMMAND,
-                                    LapceUICommand::OpenFileDiff(
-                                        source_control
+                                    LapceUICommand::OpenFileDiff {
+                                        path: source_control
                                             .file_diffs
                                             .get_index(target_line)
                                             .unwrap()
                                             .0
                                             .clone(),
-                                        "head".to_string(),
-                                    ),
+                                        history: "head".to_string(),
+                                    },
                                     Target::Widget(data.id),
                                 ));
                             }
@@ -219,10 +219,10 @@ impl Widget<LapceTabData> for SourceControlFileList {
                         let mut item = druid::MenuItem::new("Open Changes").command(
                             Command::new(
                                 LAPCE_UI_COMMAND,
-                                LapceUICommand::OpenFileDiff(
-                                    target_file_path.clone(),
-                                    "head".to_string(),
-                                ),
+                                LapceUICommand::OpenFileDiff {
+                                    path: target_file_path.clone(),
+                                    history: "head".to_string(),
+                                },
                                 Target::Auto,
                             ),
                         );

--- a/lapce-ui/src/split.rs
+++ b/lapce-ui/src/split.rs
@@ -1143,43 +1143,6 @@ impl Widget<LapceTabData> for LapceSplit {
                     LapceUICommand::SplitTerminalClose(term_id, widget_id) => {
                         self.split_terminal_close(ctx, data, *term_id, *widget_id);
                     }
-                    LapceUICommand::InitTerminalPanel(focus) => {
-                        let terminal_split =
-                            data.terminal.active_terminal_split().unwrap();
-                        if terminal_split.terminals.is_empty() {
-                            let terminal_data = Arc::new(LapceTerminalData::new(
-                                data.workspace.clone(),
-                                terminal_split.split_id,
-                                ctx.get_external_handle(),
-                                data.proxy.clone(),
-                                &data.config,
-                            ));
-                            let terminal = LapceTerminalView::new(&terminal_data);
-                            self.insert_flex_child(
-                                0,
-                                terminal.boxed(),
-                                Some(terminal_data.widget_id),
-                                1.0,
-                                true,
-                            );
-                            if *focus {
-                                ctx.submit_command(Command::new(
-                                    LAPCE_UI_COMMAND,
-                                    LapceUICommand::Focus,
-                                    Target::Widget(terminal_data.widget_id),
-                                ));
-                            }
-                            let terminal_split = Arc::make_mut(&mut data.terminal)
-                                .active_terminal_split_mut()
-                                .unwrap();
-                            terminal_split.active = terminal_data.widget_id;
-                            terminal_split.active_term_id = terminal_data.term_id;
-                            terminal_split
-                                .terminals
-                                .insert(terminal_data.term_id, terminal_data);
-                            ctx.children_changed();
-                        }
-                    }
                     _ => (),
                 }
                 return;

--- a/lapce-ui/src/window.rs
+++ b/lapce-ui/src/window.rs
@@ -365,7 +365,7 @@ impl Widget<LapceWindowData> for LapceWindow {
                         self.new_tab(ctx, data, workspace.clone(), true);
                         return;
                     }
-                    LapceUICommand::SetColorTheme(theme, preview) => {
+                    LapceUICommand::SetColorTheme { theme, preview } => {
                         let config = Arc::make_mut(&mut data.config);
                         config.set_color_theme(
                             &LapceWorkspace::default(),
@@ -381,7 +381,7 @@ impl Widget<LapceWindowData> for LapceWindow {
                         }
                         ctx.set_handled();
                     }
-                    LapceUICommand::SetIconTheme(theme, preview) => {
+                    LapceUICommand::SetIconTheme { theme, preview } => {
                         let config = Arc::make_mut(&mut data.config);
                         config.set_icon_theme(
                             &LapceWorkspace::default(),


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Adds the ability to view the expansion from completion as phantom text where the cursor is.  
(VSCode has this feature as well, under the name 'Suggestion Preview'.)  

![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
![image](https://user-images.githubusercontent.com/13157904/211959348-5c2aa5a4-cb8e-4c93-a39a-751f31022430.png)
(Might be nice to make snippets mark the places in the completion lens)

- This is disabled by default, since VSCode disables it by default. I could imagine enabling it by default, but since it is not typical it may be distracting for most users since they aren't used to it.
- The completion lens would appear in multiple editor views of the same document. I don't think this is really a problem, and making it only appear in the active document would require some modification of the code to have some per-editorview document textlayouts?
- Multiline completion items are cut off at the moment, because we don't have support for 'fake' lines in the document code