### PR TITLE
Implement completion lens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [#1574](https://github.com/lapce/lapce/pull/1574): Panel sections can be expanded/collapsed
 - [#1938](https://github.com/lapce/lapce/pull/1938): Use dropdown for theme selection in settings
 - [#1960](https://github.com/lapce/lapce/pull/1960): Add sticky headers and code lens for PHP
+- [#1968](https://github.com/lapce/lapce/pull/1968): Completion lens (disabled by default)
+  - ![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -35,6 +35,9 @@ enable-error-lens = true
 error-lens-end-of-line = true
 error-lens-font-family = ""
 error-lens-font-size = 0
+enable-completion-lens = false
+completion-lens-font-family = ""
+completion-lens-font-size = 0
 blink-interval = 500                    # ms
 multicursor-case-sensitive = true
 multicursor-whole-words = true
@@ -166,6 +169,8 @@ magenta = "#C678DD"
 "error_lens.warning.background" = "#E5C07B20"
 "error_lens.other.foreground" = "#5C6370"
 "error_lens.other.background" = "#5C637020"
+
+"completion_lens.foreground" = "#5C6370"
 
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"

--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, path::PathBuf, str::FromStr, sync::Arc};
+use std::{borrow::Cow, fmt::Display, path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::Error;
 use core::fmt;
@@ -6,11 +6,14 @@ use druid::{EventCtx, Size, WidgetId};
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use lapce_core::command::FocusCommand;
 use lapce_rpc::{buffer::BufferId, plugin::PluginId};
-use lsp_types::{CompletionItem, CompletionResponse, Position};
+use lsp_types::{CompletionItem, CompletionResponse, CompletionTextEdit, Position};
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::{config::LapceConfig, list::ListData, proxy::LapceProxy};
+use crate::{
+    config::LapceConfig, data::LapceEditorData, document::Document, list::ListData,
+    proxy::LapceProxy,
+};
 
 #[derive(Debug, PartialEq)]
 pub struct Snippet {
@@ -487,8 +490,126 @@ impl CompletionData {
         self.completion_list.items = items;
     }
 
-    pub fn run_focus_command(&mut self, ctx: &mut EventCtx, command: &FocusCommand) {
+    pub fn run_focus_command(
+        &mut self,
+        editor: &LapceEditorData,
+        doc: &mut Arc<Document>,
+        config: &LapceConfig,
+        ctx: &mut EventCtx,
+        command: &FocusCommand,
+    ) {
+        let prev_index = self.completion_list.selected_index;
         self.completion_list.run_focus_command(ctx, command);
+
+        if prev_index != self.completion_list.selected_index {
+            self.update_document_completion(editor, doc, config);
+        }
+    }
+
+    /// Update the active document's completion phantomtext, if it is enabled and needed.
+    pub fn update_document_completion(
+        &self,
+        editor: &LapceEditorData,
+        doc: &mut Arc<Document>,
+        config: &LapceConfig,
+    ) {
+        if editor.content.is_file() {
+            let doc = Arc::make_mut(doc);
+
+            // It isn't enabled at all, so we just clear it (in case it was
+            // enabled, and then disalbled) which is cheap with no existing completion lens
+            if !config.editor.enable_completion_lens {
+                doc.clear_completion();
+                return;
+            }
+
+            let item = if let Some(item) = self.current_item() {
+                if let Some(edit) = &item.item.text_edit {
+                    // There's a text edit, which is used rather than the label
+
+                    let text_format = item
+                        .item
+                        .insert_text_format
+                        .unwrap_or(lsp_types::InsertTextFormat::PLAIN_TEXT);
+
+                    match edit {
+                        CompletionTextEdit::Edit(edit) => {
+                            // The completion offset can be different from the current
+                            // cursor offset
+                            let completion_offset = self.offset;
+
+                            let offset = editor.cursor.offset();
+                            let start_offset =
+                                doc.buffer().prev_code_boundary(offset);
+                            let edit_start =
+                                doc.buffer().offset_of_position(&edit.range.start);
+
+                            // If the start of the edit isn't where the cursor currently is
+                            // and it isn't at the start of the completion, then we ignore
+                            // it. This captures most cases that we want, even if it
+                            // skips over some easily displayeable edits.
+                            if start_offset != edit_start
+                                && completion_offset != edit_start
+                            {
+                                None
+                            } else {
+                                match text_format {
+                                    lsp_types::InsertTextFormat::PLAIN_TEXT => {
+                                        // This isn't entirely correcty because it assumes that the position is `{start,end}_offset` when it may not necessarily be.
+                                        let text = &edit.new_text;
+
+                                        Some(Cow::Borrowed(text))
+                                    }
+                                    lsp_types::InsertTextFormat::SNIPPET => {
+                                        // TODO: Don't unwrap
+                                        let snippet =
+                                            Snippet::from_str(&edit.new_text)
+                                                .unwrap();
+
+                                        let text = snippet.text();
+                                        Some(Cow::Owned(text))
+                                    }
+                                    _ => None,
+                                }
+                            }
+                        }
+                        CompletionTextEdit::InsertAndReplace(_) => None,
+                    }
+                } else {
+                    // There's no specific text edit, so we just use the label displayed in
+                    // the completion list
+                    let label = &item.item.label;
+
+                    Some(Cow::Borrowed(label))
+                }
+            } else {
+                None
+            };
+
+            // We strip the prefix of the currently inputted text off of it, so that
+            // 'p' with a completion of `println` only sets the completion to 'rintln'.
+            // If it does not include the prefix in the right position, then we don't
+            // display it. There's probably nicer ways to do this, but that's how it works
+            // in other editors that impl it atm and it is simpler to implement.
+            let item = item.as_ref().and_then(|x| x.strip_prefix(&self.input));
+            // Get only the first line of text, because Lapce does not currently support
+            // multi-line phantom-text.
+            // TODO: Once Lapce supports multi-line phantom text, then this can be
+            // removed/modified to support it.
+            let item = item.map(|x| x.lines().next().unwrap_or(x));
+
+            // If the item we got is different from the one stored, either in content or
+            // existence, then we update the document's stored completion text.
+            if doc.completion() != item {
+                if let Some(item) = item {
+                    let offset = self.offset + self.input.len();
+                    let (line, col) = doc.buffer().offset_to_line_col(offset);
+                    doc.set_completion(item.to_string(), line, col);
+                } else {
+                    doc.clear_completion();
+                }
+            }
+        }
     }
 }
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -99,6 +99,8 @@ impl LapceTheme {
     pub const ERROR_LENS_OTHER_FOREGROUND: &str = "error_lens.other.foreground";
     pub const ERROR_LENS_OTHER_BACKGROUND: &str = "error_lens.other.background";
 
+    pub const COMPLETION_LENS_FOREGROUND: &str = "completion_lens.foreground";
+
     pub const SOURCE_CONTROL_ADDED: &str = "source_control.added";
     pub const SOURCE_CONTROL_REMOVED: &str = "source_control.removed";
     pub const SOURCE_CONTROL_MODIFIED: &str = "source_control.modified";
@@ -409,6 +411,18 @@ pub struct EditorConfig {
     )]
     pub error_lens_font_size: usize,
     #[field_names(
+        desc = "If the editor should display the completion item as phantom text"
+    )]
+    pub enable_completion_lens: bool,
+    #[field_names(
+        desc = "Set completion lens font family. If empty, it uses the inlay hint font family."
+    )]
+    pub completion_lens_font_family: String,
+    #[field_names(
+        desc = "Set the completion lens font size. If 0 it uses the inlay hint font size."
+    )]
+    pub completion_lens_font_size: usize,
+    #[field_names(
         desc = "Set the cursor blink interval (in milliseconds). Set to 0 to completely disable."
     )]
     pub blink_interval: u64, // TODO: change to u128 when upgrading config-rs to >0.11
@@ -493,6 +507,22 @@ impl EditorConfig {
             self.inlay_hint_font_size()
         } else {
             self.error_lens_font_size
+        }
+    }
+
+    pub fn completion_lens_font_family(&self) -> FontFamily {
+        if self.completion_lens_font_family.is_empty() {
+            self.inlay_hint_font_family()
+        } else {
+            FontFamily::new_unchecked(self.completion_lens_font_family.clone())
+        }
+    }
+
+    pub fn completion_lens_font_size(&self) -> usize {
+        if self.completion_lens_font_size == 0 {
+            self.inlay_hint_font_size()
+        } else {
+            self.completion_lens_font_size
         }
     }
 }

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -242,6 +242,7 @@ pub struct PhantomText {
 #[derive(Ord, Eq, PartialEq, PartialOrd)]
 pub enum PhantomTextKind {
     Ime,
+    Completion,
     InlayHint,
     Diagnostic,
 }
@@ -355,6 +356,10 @@ pub struct Document {
     pub code_actions: im::HashMap<usize, (PluginId, CodeActionResponse)>,
     pub inlay_hints: Option<Spans<InlayHint>>,
     pub diagnostics: Option<Arc<Vec<EditorDiagnostic>>>,
+    /// Current completion text which should be rendered at the `completion_pos`, as phantom text
+    completion: Option<Arc<String>>,
+    /// (line, col) position that the completion text should be displayed at.
+    completion_pos: (usize, usize),
     ime_text: Option<Arc<str>>,
     ime_pos: (usize, usize, usize),
     pub syntax_selection_range: Option<SyntaxSelectionRanges>,
@@ -402,6 +407,8 @@ impl Document {
             code_actions: im::HashMap::new(),
             inlay_hints: None,
             diagnostics: None,
+            completion: None,
+            completion_pos: (0, 0),
             ime_text: None,
             ime_pos: (0, 0, 0),
             find: Rc::new(RefCell::new(Find::new(0))),
@@ -512,6 +519,62 @@ impl Document {
                 diagnostic.diagnostic.range.end = new_end_pos;
             }
             self.diagnostics = Some(diagnostics);
+        }
+    }
+
+    /// Get the current completion phantomtext
+    pub fn completion(&self) -> Option<&str> {
+        self.completion.as_deref().map(String::as_str)
+    }
+
+    pub fn set_completion(&mut self, completion: String, line: usize, col: usize) {
+        self.clear_text_layout_cache();
+        self.completion = Some(Arc::new(completion));
+        self.completion_pos = (line, col);
+    }
+
+    pub fn clear_completion(&mut self) {
+        if self.completion.is_some() {
+            self.clear_text_layout_cache();
+        }
+        self.completion = None;
+    }
+
+    /// Update the completion phantomtext with the new edit
+    fn update_completion(&mut self, delta: &RopeDelta) {
+        if let Some(completion) = self.completion.clone() {
+            let (line, col) = self.completion_pos;
+            let offset = self.buffer().offset_of_line_col(line, col);
+
+            // If the edit is easily checkable & updateable from, then we change
+            // the completion's text. Because, in normal typing (if we didn't do this)
+            // then the text would jitter forward and then backwards as the completion widget
+            // updates it.
+            // TODO: this could also handle simple deletion, but we don't currently keep track of
+            // the past completion string content.
+            if delta.as_simple_insert().is_some() {
+                let (iv, new_len) = delta.summary();
+                if iv.start() == iv.end()
+                    && iv.start() == offset
+                    && new_len <= completion.len()
+                {
+                    // Remove the # of newly inserted characters
+                    // These aren't necessarily the same as the characters literally in the
+                    // text, but the completion will be updated when the completion widget
+                    // receives the update event, and it will fix this if needed.
+                    // TODO: this could be smarter and use the insert's content
+                    self.completion =
+                        Some(Arc::new(completion[new_len..].to_string()))
+                }
+            }
+
+            // Shift the position by the rope delta
+            let mut transformer = Transformer::new(delta);
+
+            let new_offset = transformer.transform(offset, true);
+            let new_pos = self.buffer().offset_to_line_col(new_offset);
+
+            self.completion_pos = new_pos;
         }
     }
 
@@ -1117,6 +1180,33 @@ impl Document {
 
         text.append(&mut diag_text);
 
+        let (completion_line, completion_col) = self.completion_pos;
+        let completion_text = config
+            .editor
+            .enable_completion_lens
+            .then_some(())
+            .and(self.completion.as_ref())
+            // TODO: We're probably missing on various useful completion things to include here!
+            .filter(|_| line == completion_line)
+            .map(|completion| PhantomText {
+                kind: PhantomTextKind::Completion,
+                col: completion_col,
+                text: completion.to_string(),
+                fg: Some(
+                    config
+                        .get_color_unchecked(LapceTheme::COMPLETION_LENS_FOREGROUND)
+                        .clone(),
+                ),
+                font_size: Some(config.editor.completion_lens_font_size()),
+                font_family: Some(config.editor.completion_lens_font_family()),
+                bg: None,
+                under_line: None,
+                // TODO: italics?
+            });
+        if let Some(completion_text) = completion_text {
+            text.push(completion_text);
+        }
+
         if let Some(ime_text) = self.ime_text.as_ref() {
             let (ime_line, col, _) = self.ime_pos;
             if line == ime_line {
@@ -1154,6 +1244,7 @@ impl Document {
             self.update_styles(delta);
             self.update_inlay_hints(delta);
             self.update_diagnostics(delta);
+            self.update_completion(delta);
             if let BufferContent::File(path) = &self.content {
                 self.proxy.proxy_rpc.update(
                     path.clone(),

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1873,7 +1873,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListNext => {
@@ -1888,7 +1894,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListNextPage => {
@@ -1903,7 +1915,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListPrevious => {
@@ -1918,7 +1936,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListPreviousPage => {
@@ -1933,7 +1957,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             JumpToNextSnippetPlaceholder => {

--- a/lapce-ui/src/completion.rs
+++ b/lapce-ui/src/completion.rs
@@ -12,6 +12,7 @@ use lapce_data::{
     completion::{CompletionData, CompletionStatus, ScoredCompletionItem},
     config::LapceTheme,
     data::LapceTabData,
+    document::BufferContent,
     list::ListData,
     markdown::parse_documentation,
     rich_text::RichText,
@@ -170,6 +171,24 @@ impl Widget<LapceTabData> for CompletionContainer {
         completion.completion_list.update_data(data.config.clone());
         self.completion
             .event(ctx, event, &mut completion.completion_list, env);
+
+        if let Some(editor) = data
+            .main_split
+            .active
+            .and_then(|active| data.main_split.editors.get(&active))
+            .cloned()
+        {
+            if let BufferContent::File(path) = &editor.content {
+                if let Some(doc) = data.main_split.open_docs.get_mut(path) {
+                    completion.update_document_completion(
+                        &editor,
+                        doc,
+                        &data.config,
+                    );
+                }
+            }
+        }
+
         self.documentation.event(ctx, event, data, env);
     }
 


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Adds the ability to view the expansion from completion as phantom text where the cursor is.  
(VSCode has this feature as well, under the name 'Suggestion Preview'.)  

![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
![image](https://user-images.githubusercontent.com/13157904/211959348-5c2aa5a4-cb8e-4c93-a39a-751f31022430.png)
(Might be nice to make snippets mark the places in the completion lens)

- This is disabled by default, since VSCode disables it by default. I could imagine enabling it by default, but since it is not typical it may be distracting for most users since they aren't used to it.
- The completion lens would appear in multiple editor views of the same document. I don't think this is really a problem, and making it only appear in the active document would require some modification of the code to have some per-editorview document textlayouts?
- Multiline completion items are cut off at the moment, because we don't have support for 'fake' lines in the document code