### PR TITLE
（Draft）feat: support increase diff extend size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,12 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        
+      - name: Fetch dependencies
+        run: cargo fetch --locked
 
       - name: Build
-        run: cargo build
+        run: cargo build --frozen
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -91,6 +94,9 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        
+      - name: Fetch dependencies
+        run: cargo fetch --locked
 
       - name: Run clippy
         run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,12 @@ jobs:
 
       - name: Update rust
         run: rustup update
+        
+      - name: Fetch dependencies
+        run: cargo fetch --locked
 
       - name: Build
-        run: cargo build --profile release-lto
+        run: cargo build --frozen --profile release-lto
 
       - name: Install WiX
         run: nuget install WiX
@@ -119,9 +122,12 @@ jobs:
           toolchain: stable
           target: x86_64-unknown-linux-gnu
           profile: minimal
-          
+
+      - name: Fetch dependencies
+        run: cargo fetch --locked
+
       - name: Build
-        run: cargo build --profile release-lto --bin lapce
+        run: cargo build --frozen --profile release-lto --bin lapce
 
       - name: Gzip
         run: |
@@ -205,8 +211,9 @@ jobs:
           echo -e '#!/bin/sh\nPKG_CONFIG_SYSROOT_DIR=${{ env.CROSS_SYSROOT }} exec pkgconf "$@"' \
               | install -m755 /dev/stdin pkg-config
           export PKG_CONFIG="$(pwd)/pkg-config"
+          cargo fetch --locked
           cargo build \
-            --locked \
+            --frozen \
             --verbose \
             --release \
             --bin lapce-proxy \
@@ -243,6 +250,9 @@ jobs:
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
           p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+
+      - name: Fetch dependencies
+        run: cargo fetch --locked
 
       - name: Make DMG
         run: make dmg-universal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#1968](https://github.com/lapce/lapce/pull/1968): Completion lens (disabled by default)
   - ![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
 - [#1972](https://github.com/lapce/lapce/pull/1972): Add file duplication option in fs tree context menu
+- [#19670](https://github.com/lapce/lapce/pull/1970): Support increase diff extend size(5 lines).
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@
 - [#1574](https://github.com/lapce/lapce/pull/1574): Panel sections can be expanded/collapsed
 - [#1938](https://github.com/lapce/lapce/pull/1938): Use dropdown for theme selection in settings
 - [#1960](https://github.com/lapce/lapce/pull/1960): Add sticky headers and code lens for PHP
+- [#1968](https://github.com/lapce/lapce/pull/1968): Completion lens (disabled by default)
+  - ![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
+- [#1972](https://github.com/lapce/lapce/pull/1972): Add file duplication option in fs tree context menu
 - [#19670](https://github.com/lapce/lapce/pull/1970): Support increase diff extend size(5 lines).
-
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys
 - [#1939](https://github.com/lapce/lapce/pull/1939): Fix saving/editing newly saved-as files
+- [#1971](https://github.com/lapce/lapce/pull/1971): Fix up/down movement on first/last line
 
 ## 0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#1960](https://github.com/lapce/lapce/pull/1960): Add sticky headers and code lens for PHP
 - [#1968](https://github.com/lapce/lapce/pull/1968): Completion lens (disabled by default)
   - ![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
+- [#1972](https://github.com/lapce/lapce/pull/1972): Add file duplication option in fs tree context menu
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys
 - [#1939](https://github.com/lapce/lapce/pull/1939): Fix saving/editing newly saved-as files
+- [#1971](https://github.com/lapce/lapce/pull/1971): Fix up/down movement on first/last line
 
 ## 0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [#1574](https://github.com/lapce/lapce/pull/1574): Panel sections can be expanded/collapsed
 - [#1938](https://github.com/lapce/lapce/pull/1938): Use dropdown for theme selection in settings
 - [#1960](https://github.com/lapce/lapce/pull/1960): Add sticky headers and code lens for PHP
+- [#1968](https://github.com/lapce/lapce/pull/1968): Completion lens (disabled by default)
+  - ![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -35,6 +35,9 @@ enable-error-lens = true
 error-lens-end-of-line = true
 error-lens-font-family = ""
 error-lens-font-size = 0
+enable-completion-lens = false
+completion-lens-font-family = ""
+completion-lens-font-size = 0
 blink-interval = 500                    # ms
 multicursor-case-sensitive = true
 multicursor-whole-words = true
@@ -166,6 +169,8 @@ magenta = "#C678DD"
 "error_lens.warning.background" = "#E5C07B20"
 "error_lens.other.foreground" = "#5C6370"
 "error_lens.other.background" = "#5C637020"
+
+"completion_lens.foreground" = "#5C6370"
 
 "source_control.added" = "#50A14F32"
 "source_control.removed" = "#FF526632"

--- a/lapce-core/src/buffer/mod.rs
+++ b/lapce-core/src/buffer/mod.rs
@@ -1062,6 +1062,7 @@ pub fn rope_diff(
     right_rope: Rope,
     rev: u64,
     atomic_rev: Arc<AtomicU64>,
+    extend_lines: usize,
 ) -> Option<Vec<DiffLines>> {
     let left_lines = left_rope.lines(..).collect::<Vec<Cow<str>>>();
     let right_lines = right_rope.lines(..).collect::<Vec<Cow<str>>>();
@@ -1198,43 +1199,51 @@ pub fn rope_diff(
             }
             if let DiffLines::Both(l, r) = change {
                 if i == 0 || i == changes_last {
-                    if r.len() > 3 {
+                    if r.len() > extend_lines {
                         if i == 0 {
-                            changes[i] =
-                                DiffLines::Both(l.end - 3..l.end, r.end - 3..r.end);
+                            changes[i] = DiffLines::Both(
+                                l.end - extend_lines..l.end,
+                                r.end - extend_lines..r.end,
+                            );
                             changes.insert(
                                 i,
                                 DiffLines::Skip(
-                                    l.start..l.end - 3,
-                                    r.start..r.end - 3,
+                                    l.start..l.end - extend_lines,
+                                    r.start..r.end - extend_lines,
                                 ),
                             );
                         } else {
                             changes[i] = DiffLines::Skip(
-                                l.start + 3..l.end,
-                                r.start + 3..r.end,
+                                l.start + extend_lines..l.end,
+                                r.start + extend_lines..r.end,
                             );
                             changes.insert(
                                 i,
                                 DiffLines::Both(
-                                    l.start..l.start + 3,
-                                    r.start..r.start + 3,
+                                    l.start..l.start + extend_lines,
+                                    r.start..r.start + extend_lines,
                                 ),
                             );
                         }
                     }
-                } else if r.len() > 6 {
-                    changes[i] = DiffLines::Both(l.end - 3..l.end, r.end - 3..r.end);
+                } else if r.len() > extend_lines * 2 {
+                    changes[i] = DiffLines::Both(
+                        l.end - extend_lines..l.end,
+                        r.end - extend_lines..r.end,
+                    );
                     changes.insert(
                         i,
                         DiffLines::Skip(
-                            l.start + 3..l.end - 3,
-                            r.start + 3..r.end - 3,
+                            l.start + extend_lines..l.end - extend_lines,
+                            r.start + extend_lines..r.end - extend_lines,
                         ),
                     );
                     changes.insert(
                         i,
-                        DiffLines::Both(l.start..l.start + 3, r.start..r.start + 3),
+                        DiffLines::Both(
+                            l.start..l.start + extend_lines,
+                            r.start..r.start + extend_lines,
+                        ),
                     );
                 }
             }

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -843,6 +843,7 @@ pub enum LapceUICommand {
         rev: u64,
         history: String,
         changes: Arc<Vec<DiffLines>>,
+        diff_extend_lines: usize,
     },
     /// Publish diagnostics changes (from the proxy)
     PublishDiagnostics(PublishDiagnosticsParams),

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -936,6 +936,11 @@ pub enum LapceUICommand {
     CreateDirectory {
         path: PathBuf,
     },
+    /// Copy an existing file to the given name and then open it
+    DuplicateFileOpen {
+        existing_path: PathBuf,
+        new_path: PathBuf,
+    },
     RenamePath {
         from: PathBuf,
         to: PathBuf,
@@ -943,6 +948,17 @@ pub enum LapceUICommand {
     /// Move a file/directory to the os-specific trash
     TrashPath {
         path: PathBuf,
+    },
+    /// Start duplicating a specific file in view at the given index
+    ExplorerStartDuplicate {
+        /// The index into the explorer's file listing
+        list_index: usize,
+        /// The level that it should be indented to
+        indent_level: usize,
+        /// The folder that the file/directory is being created within
+        base_path: PathBuf,
+        /// The name of the file being duplicated
+        name: String,
     },
     /// Start renaming a specific file in view at the given index
     ExplorerStartRename {

--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, path::PathBuf, str::FromStr, sync::Arc};
+use std::{borrow::Cow, fmt::Display, path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::Error;
 use core::fmt;
@@ -6,11 +6,14 @@ use druid::{EventCtx, Size, WidgetId};
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use lapce_core::command::FocusCommand;
 use lapce_rpc::{buffer::BufferId, plugin::PluginId};
-use lsp_types::{CompletionItem, CompletionResponse, Position};
+use lsp_types::{CompletionItem, CompletionResponse, CompletionTextEdit, Position};
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::{config::LapceConfig, list::ListData, proxy::LapceProxy};
+use crate::{
+    config::LapceConfig, data::LapceEditorData, document::Document, list::ListData,
+    proxy::LapceProxy,
+};
 
 #[derive(Debug, PartialEq)]
 pub struct Snippet {
@@ -487,8 +490,126 @@ impl CompletionData {
         self.completion_list.items = items;
     }
 
-    pub fn run_focus_command(&mut self, ctx: &mut EventCtx, command: &FocusCommand) {
+    pub fn run_focus_command(
+        &mut self,
+        editor: &LapceEditorData,
+        doc: &mut Arc<Document>,
+        config: &LapceConfig,
+        ctx: &mut EventCtx,
+        command: &FocusCommand,
+    ) {
+        let prev_index = self.completion_list.selected_index;
         self.completion_list.run_focus_command(ctx, command);
+
+        if prev_index != self.completion_list.selected_index {
+            self.update_document_completion(editor, doc, config);
+        }
+    }
+
+    /// Update the active document's completion phantomtext, if it is enabled and needed.
+    pub fn update_document_completion(
+        &self,
+        editor: &LapceEditorData,
+        doc: &mut Arc<Document>,
+        config: &LapceConfig,
+    ) {
+        if editor.content.is_file() {
+            let doc = Arc::make_mut(doc);
+
+            // It isn't enabled at all, so we just clear it (in case it was
+            // enabled, and then disalbled) which is cheap with no existing completion lens
+            if !config.editor.enable_completion_lens {
+                doc.clear_completion();
+                return;
+            }
+
+            let item = if let Some(item) = self.current_item() {
+                if let Some(edit) = &item.item.text_edit {
+                    // There's a text edit, which is used rather than the label
+
+                    let text_format = item
+                        .item
+                        .insert_text_format
+                        .unwrap_or(lsp_types::InsertTextFormat::PLAIN_TEXT);
+
+                    match edit {
+                        CompletionTextEdit::Edit(edit) => {
+                            // The completion offset can be different from the current
+                            // cursor offset
+                            let completion_offset = self.offset;
+
+                            let offset = editor.cursor.offset();
+                            let start_offset =
+                                doc.buffer().prev_code_boundary(offset);
+                            let edit_start =
+                                doc.buffer().offset_of_position(&edit.range.start);
+
+                            // If the start of the edit isn't where the cursor currently is
+                            // and it isn't at the start of the completion, then we ignore
+                            // it. This captures most cases that we want, even if it
+                            // skips over some easily displayeable edits.
+                            if start_offset != edit_start
+                                && completion_offset != edit_start
+                            {
+                                None
+                            } else {
+                                match text_format {
+                                    lsp_types::InsertTextFormat::PLAIN_TEXT => {
+                                        // This isn't entirely correcty because it assumes that the position is `{start,end}_offset` when it may not necessarily be.
+                                        let text = &edit.new_text;
+
+                                        Some(Cow::Borrowed(text))
+                                    }
+                                    lsp_types::InsertTextFormat::SNIPPET => {
+                                        // TODO: Don't unwrap
+                                        let snippet =
+                                            Snippet::from_str(&edit.new_text)
+                                                .unwrap();
+
+                                        let text = snippet.text();
+                                        Some(Cow::Owned(text))
+                                    }
+                                    _ => None,
+                                }
+                            }
+                        }
+                        CompletionTextEdit::InsertAndReplace(_) => None,
+                    }
+                } else {
+                    // There's no specific text edit, so we just use the label displayed in
+                    // the completion list
+                    let label = &item.item.label;
+
+                    Some(Cow::Borrowed(label))
+                }
+            } else {
+                None
+            };
+
+            // We strip the prefix of the currently inputted text off of it, so that
+            // 'p' with a completion of `println` only sets the completion to 'rintln'.
+            // If it does not include the prefix in the right position, then we don't
+            // display it. There's probably nicer ways to do this, but that's how it works
+            // in other editors that impl it atm and it is simpler to implement.
+            let item = item.as_ref().and_then(|x| x.strip_prefix(&self.input));
+            // Get only the first line of text, because Lapce does not currently support
+            // multi-line phantom-text.
+            // TODO: Once Lapce supports multi-line phantom text, then this can be
+            // removed/modified to support it.
+            let item = item.map(|x| x.lines().next().unwrap_or(x));
+
+            // If the item we got is different from the one stored, either in content or
+            // existence, then we update the document's stored completion text.
+            if doc.completion() != item {
+                if let Some(item) = item {
+                    let offset = self.offset + self.input.len();
+                    let (line, col) = doc.buffer().offset_to_line_col(offset);
+                    doc.set_completion(item.to_string(), line, col);
+                } else {
+                    doc.clear_completion();
+                }
+            }
+        }
     }
 }
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -99,6 +99,8 @@ impl LapceTheme {
     pub const ERROR_LENS_OTHER_FOREGROUND: &str = "error_lens.other.foreground";
     pub const ERROR_LENS_OTHER_BACKGROUND: &str = "error_lens.other.background";
 
+    pub const COMPLETION_LENS_FOREGROUND: &str = "completion_lens.foreground";
+
     pub const SOURCE_CONTROL_ADDED: &str = "source_control.added";
     pub const SOURCE_CONTROL_REMOVED: &str = "source_control.removed";
     pub const SOURCE_CONTROL_MODIFIED: &str = "source_control.modified";
@@ -409,6 +411,18 @@ pub struct EditorConfig {
     )]
     pub error_lens_font_size: usize,
     #[field_names(
+        desc = "If the editor should display the completion item as phantom text"
+    )]
+    pub enable_completion_lens: bool,
+    #[field_names(
+        desc = "Set completion lens font family. If empty, it uses the inlay hint font family."
+    )]
+    pub completion_lens_font_family: String,
+    #[field_names(
+        desc = "Set the completion lens font size. If 0 it uses the inlay hint font size."
+    )]
+    pub completion_lens_font_size: usize,
+    #[field_names(
         desc = "Set the cursor blink interval (in milliseconds). Set to 0 to completely disable."
     )]
     pub blink_interval: u64, // TODO: change to u128 when upgrading config-rs to >0.11
@@ -493,6 +507,22 @@ impl EditorConfig {
             self.inlay_hint_font_size()
         } else {
             self.error_lens_font_size
+        }
+    }
+
+    pub fn completion_lens_font_family(&self) -> FontFamily {
+        if self.completion_lens_font_family.is_empty() {
+            self.inlay_hint_font_family()
+        } else {
+            FontFamily::new_unchecked(self.completion_lens_font_family.clone())
+        }
+    }
+
+    pub fn completion_lens_font_size(&self) -> usize {
+        if self.completion_lens_font_size == 0 {
+            self.inlay_hint_font_size()
+        } else {
+            self.completion_lens_font_size
         }
     }
 }

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -2461,7 +2461,9 @@ impl Document {
             Movement::Up => {
                 let line = self.buffer.line_of_offset(offset);
                 if line == 0 {
-                    return (offset, horiz.cloned());
+                    let line = self.buffer.line_of_offset(offset);
+                    let new_offset = self.buffer.offset_of_line(line);
+                    return (new_offset, Some(ColPosition::Start));
                 }
 
                 let (line, font_size) = match view {
@@ -2536,6 +2538,11 @@ impl Document {
             Movement::Down => {
                 let last_line = self.buffer.last_line();
                 let line = self.buffer.line_of_offset(offset);
+                if line == last_line {
+                    let new_offset =
+                        self.buffer.offset_line_end(offset, mode != Mode::Normal);
+                    return (new_offset, Some(ColPosition::End));
+                }
 
                 let (line, font_size) = match view {
                     EditorView::Lens => {

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -242,6 +242,7 @@ pub struct PhantomText {
 #[derive(Ord, Eq, PartialEq, PartialOrd)]
 pub enum PhantomTextKind {
     Ime,
+    Completion,
     InlayHint,
     Diagnostic,
 }
@@ -355,6 +356,10 @@ pub struct Document {
     pub code_actions: im::HashMap<usize, (PluginId, CodeActionResponse)>,
     pub inlay_hints: Option<Spans<InlayHint>>,
     pub diagnostics: Option<Arc<Vec<EditorDiagnostic>>>,
+    /// Current completion text which should be rendered at the `completion_pos`, as phantom text
+    completion: Option<Arc<String>>,
+    /// (line, col) position that the completion text should be displayed at.
+    completion_pos: (usize, usize),
     ime_text: Option<Arc<str>>,
     ime_pos: (usize, usize, usize),
     pub syntax_selection_range: Option<SyntaxSelectionRanges>,
@@ -402,6 +407,8 @@ impl Document {
             code_actions: im::HashMap::new(),
             inlay_hints: None,
             diagnostics: None,
+            completion: None,
+            completion_pos: (0, 0),
             ime_text: None,
             ime_pos: (0, 0, 0),
             find: Rc::new(RefCell::new(Find::new(0))),
@@ -512,6 +519,62 @@ impl Document {
                 diagnostic.diagnostic.range.end = new_end_pos;
             }
             self.diagnostics = Some(diagnostics);
+        }
+    }
+
+    /// Get the current completion phantomtext
+    pub fn completion(&self) -> Option<&str> {
+        self.completion.as_deref().map(String::as_str)
+    }
+
+    pub fn set_completion(&mut self, completion: String, line: usize, col: usize) {
+        self.clear_text_layout_cache();
+        self.completion = Some(Arc::new(completion));
+        self.completion_pos = (line, col);
+    }
+
+    pub fn clear_completion(&mut self) {
+        if self.completion.is_some() {
+            self.clear_text_layout_cache();
+        }
+        self.completion = None;
+    }
+
+    /// Update the completion phantomtext with the new edit
+    fn update_completion(&mut self, delta: &RopeDelta) {
+        if let Some(completion) = self.completion.clone() {
+            let (line, col) = self.completion_pos;
+            let offset = self.buffer().offset_of_line_col(line, col);
+
+            // If the edit is easily checkable & updateable from, then we change
+            // the completion's text. Because, in normal typing (if we didn't do this)
+            // then the text would jitter forward and then backwards as the completion widget
+            // updates it.
+            // TODO: this could also handle simple deletion, but we don't currently keep track of
+            // the past completion string content.
+            if delta.as_simple_insert().is_some() {
+                let (iv, new_len) = delta.summary();
+                if iv.start() == iv.end()
+                    && iv.start() == offset
+                    && new_len <= completion.len()
+                {
+                    // Remove the # of newly inserted characters
+                    // These aren't necessarily the same as the characters literally in the
+                    // text, but the completion will be updated when the completion widget
+                    // receives the update event, and it will fix this if needed.
+                    // TODO: this could be smarter and use the insert's content
+                    self.completion =
+                        Some(Arc::new(completion[new_len..].to_string()))
+                }
+            }
+
+            // Shift the position by the rope delta
+            let mut transformer = Transformer::new(delta);
+
+            let new_offset = transformer.transform(offset, true);
+            let new_pos = self.buffer().offset_to_line_col(new_offset);
+
+            self.completion_pos = new_pos;
         }
     }
 
@@ -1117,6 +1180,33 @@ impl Document {
 
         text.append(&mut diag_text);
 
+        let (completion_line, completion_col) = self.completion_pos;
+        let completion_text = config
+            .editor
+            .enable_completion_lens
+            .then_some(())
+            .and(self.completion.as_ref())
+            // TODO: We're probably missing on various useful completion things to include here!
+            .filter(|_| line == completion_line)
+            .map(|completion| PhantomText {
+                kind: PhantomTextKind::Completion,
+                col: completion_col,
+                text: completion.to_string(),
+                fg: Some(
+                    config
+                        .get_color_unchecked(LapceTheme::COMPLETION_LENS_FOREGROUND)
+                        .clone(),
+                ),
+                font_size: Some(config.editor.completion_lens_font_size()),
+                font_family: Some(config.editor.completion_lens_font_family()),
+                bg: None,
+                under_line: None,
+                // TODO: italics?
+            });
+        if let Some(completion_text) = completion_text {
+            text.push(completion_text);
+        }
+
         if let Some(ime_text) = self.ime_text.as_ref() {
             let (ime_line, col, _) = self.ime_pos;
             if line == ime_line {
@@ -1154,6 +1244,7 @@ impl Document {
             self.update_styles(delta);
             self.update_inlay_hints(delta);
             self.update_diagnostics(delta);
+            self.update_completion(delta);
             if let BufferContent::File(path) = &self.content {
                 self.proxy.proxy_rpc.update(
                     path.clone(),

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -55,6 +55,7 @@ use crate::{
     data::{EditorDiagnostic, EditorView},
     editor::{EditorLocation, EditorPosition},
     find::{Find, FindProgress},
+    history,
     history::DocumentHistory,
     proxy::LapceProxy,
     selection_range::{SelectionRangeDirection, SyntaxSelectionRanges},
@@ -747,7 +748,13 @@ impl Document {
 
     fn trigger_head_change(&self) {
         if let Some(head) = self.histories.get("head") {
-            head.trigger_update_change(self);
+            head.trigger_update_change(self, history::DEFAULT_DIFF_EXTEND_LINES);
+        }
+    }
+
+    pub fn trigger_history_change(&self, version: &str, extend_lines: usize) {
+        if let Some(history) = self.histories.get(version) {
+            history.trigger_update_change(self, extend_lines);
         }
     }
 
@@ -756,12 +763,13 @@ impl Document {
         rev: u64,
         version: &str,
         changes: Arc<Vec<DiffLines>>,
+        diff_extend_lines: usize,
     ) {
         if rev != self.rev() {
             return;
         }
         if let Some(history) = self.histories.get_mut(version) {
-            history.update_changes(changes);
+            history.update_changes(changes, diff_extend_lines);
         }
     }
 

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -1873,7 +1873,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListNext => {
@@ -1888,7 +1894,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListNextPage => {
@@ -1903,7 +1915,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListPrevious => {
@@ -1918,7 +1936,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             ListPreviousPage => {
@@ -1933,7 +1957,13 @@ impl LapceEditorBufferData {
                     ));
                 } else {
                     let completion = Arc::make_mut(&mut self.completion);
-                    completion.run_focus_command(ctx, cmd);
+                    completion.run_focus_command(
+                        &self.editor,
+                        &mut self.doc,
+                        &self.config,
+                        ctx,
+                        cmd,
+                    );
                 }
             }
             JumpToNextSnippetPlaceholder => {

--- a/lapce-data/src/explorer.rs
+++ b/lapce-data/src/explorer.rs
@@ -38,12 +38,25 @@ pub enum Naming {
         /// The folder that the file/directory is being created within
         base_path: PathBuf,
     },
+    /// Duplicating an existing file
+    Duplicating {
+        /// The index that the file being created should appear at
+        /// Note that when duplicating, it is not yet actually created.
+        list_index: usize,
+        /// Indentation level
+        indent_level: usize,
+        /// The folder that the file/directory is being created within
+        base_path: PathBuf,
+        /// The name of the file being duplicated
+        name: String,
+    },
 }
 impl Naming {
     pub fn list_index(&self) -> usize {
         match self {
             Naming::Renaming { list_index, .. }
-            | Naming::Naming { list_index, .. } => *list_index,
+            | Naming::Naming { list_index, .. }
+            | Naming::Duplicating { list_index, .. } => *list_index,
         }
     }
 }
@@ -366,6 +379,21 @@ impl FileExplorerData {
                     Target::Auto,
                 ));
             }
+            Naming::Duplicating {
+                base_path, name, ..
+            } => {
+                let new_path = base_path.join(target_name);
+
+                let cmd = LapceUICommand::DuplicateFileOpen {
+                    existing_path: base_path.join(name),
+                    new_path,
+                };
+                ctx.submit_command(Command::new(
+                    LAPCE_UI_COMMAND,
+                    cmd,
+                    Target::Auto,
+                ));
+            }
         }
 
         self.cancel_naming();
@@ -401,6 +429,54 @@ impl FileExplorerData {
             .get_mut(&self.renaming_editor_view_id)
             .unwrap();
         Arc::make_mut(editor).cursor.mode = CursorMode::Insert(Selection::caret(0));
+
+        // Focus on the input
+        ctx.submit_command(Command::new(
+            LAPCE_UI_COMMAND,
+            LapceUICommand::Focus,
+            Target::Widget(editor.view_id),
+        ));
+    }
+
+    /// Show the naming input for the given file at the index
+    /// Requires `main_split` for getting the input to set its content
+    /// Requires `ctx` to switch focus to the input
+    pub fn start_duplicating(
+        &mut self,
+        ctx: &mut EventCtx,
+        main_split: &mut LapceMainSplitData,
+        list_index: usize,
+        indent_level: usize,
+        base_path: PathBuf,
+        name: String,
+    ) {
+        self.cancel_naming();
+        self.naming = Some(Naming::Duplicating {
+            list_index,
+            indent_level,
+            base_path,
+            name: name.clone(),
+        });
+
+        // Set the text of the input
+        let doc = main_split
+            .local_docs
+            .get_mut(&LocalBufferKind::PathName)
+            .unwrap();
+        Arc::make_mut(doc).reload(Rope::from(name), true);
+
+        // TODO: We could provide a configuration option to only select the filename at first,
+        // which would fit a common case of just wanting to change the filename and not the ext
+        // (or that could be the default)
+
+        // Select all of the text, allowing them to quickly completely change the name if they wish
+        let editor = main_split
+            .editors
+            .get_mut(&self.renaming_editor_view_id)
+            .unwrap();
+        let offset = doc.buffer().line_end_offset(0, true);
+        Arc::make_mut(editor).cursor.mode =
+            CursorMode::Insert(Selection::region(0, offset));
 
         // Focus on the input
         ctx.submit_command(Command::new(

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -757,6 +757,37 @@ impl ProxyHandler for Dispatcher {
                     });
                 self.respond_rpc(id, result);
             }
+            DuplicatePath {
+                existing_path,
+                new_path,
+            } => {
+                // We first check if the destination already exists, because copy can overwrite it
+                // and that's not the default behavior we want for when a user duplicates a document.
+                let result = if new_path.exists() {
+                    Err(RpcError {
+                        code: 0,
+                        message: format!("{:?} already exists", new_path),
+                    })
+                } else {
+                    if let Some(parent) = new_path.parent() {
+                        if let Err(error) = std::fs::create_dir_all(parent) {
+                            let result = Err(RpcError {
+                                code: 0,
+                                message: error.to_string(),
+                            });
+                            self.respond_rpc(id, result);
+                            return;
+                        }
+                    }
+                    std::fs::copy(existing_path, new_path)
+                        .map(|_| ProxyResponse::Success {})
+                        .map_err(|e| RpcError {
+                            code: 0,
+                            message: e.to_string(),
+                        })
+                };
+                self.respond_rpc(id, result);
+            }
             RenamePath { from, to } => {
                 // We first check if the destination already exists, because rename can overwrite it
                 // and that's not the default behavior we want for when a user renames a document.

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -146,6 +146,10 @@ pub enum ProxyRequest {
     TrashPath {
         path: PathBuf,
     },
+    DuplicatePath {
+        existing_path: PathBuf,
+        new_path: PathBuf,
+    },
     RenamePath {
         from: PathBuf,
         to: PathBuf,
@@ -574,6 +578,21 @@ impl ProxyRpcHandler {
 
     pub fn trash_path(&self, path: PathBuf, f: impl ProxyCallback + 'static) {
         self.request_async(ProxyRequest::TrashPath { path }, f);
+    }
+
+    pub fn duplicate_path(
+        &self,
+        existing_path: PathBuf,
+        new_path: PathBuf,
+        f: impl ProxyCallback + 'static,
+    ) {
+        self.request_async(
+            ProxyRequest::DuplicatePath {
+                existing_path,
+                new_path,
+            },
+            f,
+        );
     }
 
     pub fn rename_path(

--- a/lapce-ui/src/completion.rs
+++ b/lapce-ui/src/completion.rs
@@ -12,6 +12,7 @@ use lapce_data::{
     completion::{CompletionData, CompletionStatus, ScoredCompletionItem},
     config::LapceTheme,
     data::LapceTabData,
+    document::BufferContent,
     list::ListData,
     markdown::parse_documentation,
     rich_text::RichText,
@@ -170,6 +171,24 @@ impl Widget<LapceTabData> for CompletionContainer {
         completion.completion_list.update_data(data.config.clone());
         self.completion
             .event(ctx, event, &mut completion.completion_list, env);
+
+        if let Some(editor) = data
+            .main_split
+            .active
+            .and_then(|active| data.main_split.editors.get(&active))
+            .cloned()
+        {
+            if let BufferContent::File(path) = &editor.content {
+                if let Some(doc) = data.main_split.open_docs.get_mut(path) {
+                    completion.update_document_completion(
+                        &editor,
+                        doc,
+                        &data.config,
+                    );
+                }
+            }
+        }
+
         self.documentation.event(ctx, event, data, env);
     }
 

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -249,7 +249,7 @@ fn draw_name_input(
         Naming::Renaming { .. } => {
             name_edit_input.paint(ctx, data, env);
         }
-        Naming::Naming { .. } => {
+        Naming::Naming { .. } | Naming::Duplicating { .. } => {
             name_edit_input.paint(ctx, data, env);
             // Skip forward by an entry
             // This is fine since we aren't using i as an index, but as an offset-multiple in painting
@@ -831,6 +831,30 @@ impl Widget<LapceTabData> for FileExplorerFileList {
                             );
                             menu = menu.entry(item);
 
+                            if !node.is_dir {
+                                let item = druid::MenuItem::new("Duplicate")
+                                    .command(Command::new(
+                                        LAPCE_UI_COMMAND,
+                                        LapceUICommand::ExplorerStartDuplicate {
+                                            list_index: index,
+                                            indent_level,
+                                            base_path: node
+                                                .path_buf
+                                                .parent()
+                                                .expect("file without parent")
+                                                .to_owned(),
+                                            name: node
+                                                .path_buf
+                                                .file_name()
+                                                .expect("file without name")
+                                                .to_string_lossy()
+                                                .into_owned(),
+                                        },
+                                        Target::Auto,
+                                    ));
+                                menu = menu.entry(item);
+                            }
+
                             let trash_text = if node.is_dir {
                                 "Move Directory to Trash"
                             } else {
@@ -949,6 +973,11 @@ impl Widget<LapceTabData> for FileExplorerFileList {
                     indent_level,
                 }
                 | Naming::Naming {
+                    list_index,
+                    indent_level,
+                    ..
+                }
+                | Naming::Duplicating {
                     list_index,
                     indent_level,
                     ..

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1813,6 +1813,7 @@ impl LapceTab {
                         rev,
                         history,
                         changes,
+                        diff_extend_lines,
                         ..
                     } => {
                         ctx.set_handled();
@@ -1821,6 +1822,7 @@ impl LapceTab {
                             *rev,
                             history,
                             changes.clone(),
+                            *diff_extend_lines,
                         );
                     }
                     LapceUICommand::UpdateHistoryStyle {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1904,6 +1904,41 @@ impl LapceTab {
                         );
                         ctx.set_handled();
                     }
+                    LapceUICommand::DuplicateFileOpen {
+                        existing_path,
+                        new_path,
+                    } => {
+                        let new_path_clone = new_path.clone();
+                        let event_sink = ctx.get_external_handle();
+                        let tab_id = data.id;
+                        let explorer = data.file_explorer.clone();
+                        data.proxy.proxy_rpc.duplicate_path(
+                            existing_path.clone(),
+                            new_path.clone(),
+                            Box::new(move |res| {
+                                match res {
+                                    Ok(_) => {
+                                        let _ = event_sink.submit_command(
+                                            LAPCE_UI_COMMAND,
+                                            LapceUICommand::OpenFile(
+                                                new_path_clone,
+                                                false,
+                                            ),
+                                            Target::Widget(tab_id),
+                                        );
+                                    }
+                                    Err(err) => {
+                                        // TODO: Inform the user through a corner-notif
+                                        log::warn!(
+                                            "Failed to duplicate file: {:?}",
+                                            err,
+                                        );
+                                    }
+                                }
+                                explorer.reload();
+                            }),
+                        );
+                    }
                     LapceUICommand::RenamePath { from, to } => {
                         let explorer = data.file_explorer.clone();
                         data.proxy.proxy_rpc.rename_path(
@@ -1946,6 +1981,23 @@ impl LapceTab {
                             *indent_level,
                             *is_dir,
                             base_path.clone(),
+                        );
+                        ctx.set_handled();
+                    }
+                    LapceUICommand::ExplorerStartDuplicate {
+                        list_index,
+                        indent_level,
+                        base_path,
+                        name,
+                    } => {
+                        let file_explorer = Arc::make_mut(&mut data.file_explorer);
+                        file_explorer.start_duplicating(
+                            ctx,
+                            &mut data.main_split,
+                            *list_index,
+                            *indent_level,
+                            base_path.clone(),
+                            name.clone(),
                         );
                         ctx.set_handled();
                     }


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

feature: support increase diff extend size

<img width="542" alt="image" src="https://user-images.githubusercontent.com/4404609/212015697-35a77430-c050-4adc-91c0-a2e04209abc0.png">


click the area will increase the diff extend size, now wil plus 5 lines.

<img width="725" alt="image" src="https://user-images.githubusercontent.com/4404609/212015981-77fb21e7-2d3f-46a8-8814-b619fca82136.png">
