### PR TITLE
Feat increase diff extend lines

### DIFF
--- a/lapce-core/src/buffer/mod.rs
+++ b/lapce-core/src/buffer/mod.rs
@@ -1062,6 +1062,7 @@ pub fn rope_diff(
     right_rope: Rope,
     rev: u64,
     atomic_rev: Arc<AtomicU64>,
+    extend_lines: usize,
 ) -> Option<Vec<DiffLines>> {
     let left_lines = left_rope.lines(..).collect::<Vec<Cow<str>>>();
     let right_lines = right_rope.lines(..).collect::<Vec<Cow<str>>>();
@@ -1198,43 +1199,51 @@ pub fn rope_diff(
             }
             if let DiffLines::Both(l, r) = change {
                 if i == 0 || i == changes_last {
-                    if r.len() > 3 {
+                    if r.len() > extend_lines {
                         if i == 0 {
-                            changes[i] =
-                                DiffLines::Both(l.end - 3..l.end, r.end - 3..r.end);
+                            changes[i] = DiffLines::Both(
+                                l.end - extend_lines..l.end,
+                                r.end - extend_lines..r.end,
+                            );
                             changes.insert(
                                 i,
                                 DiffLines::Skip(
-                                    l.start..l.end - 3,
-                                    r.start..r.end - 3,
+                                    l.start..l.end - extend_lines,
+                                    r.start..r.end - extend_lines,
                                 ),
                             );
                         } else {
                             changes[i] = DiffLines::Skip(
-                                l.start + 3..l.end,
-                                r.start + 3..r.end,
+                                l.start + extend_lines..l.end,
+                                r.start + extend_lines..r.end,
                             );
                             changes.insert(
                                 i,
                                 DiffLines::Both(
-                                    l.start..l.start + 3,
-                                    r.start..r.start + 3,
+                                    l.start..l.start + extend_lines,
+                                    r.start..r.start + extend_lines,
                                 ),
                             );
                         }
                     }
-                } else if r.len() > 6 {
-                    changes[i] = DiffLines::Both(l.end - 3..l.end, r.end - 3..r.end);
+                } else if r.len() > extend_lines * 2 {
+                    changes[i] = DiffLines::Both(
+                        l.end - extend_lines..l.end,
+                        r.end - extend_lines..r.end,
+                    );
                     changes.insert(
                         i,
                         DiffLines::Skip(
-                            l.start + 3..l.end - 3,
-                            r.start + 3..r.end - 3,
+                            l.start + extend_lines..l.end - extend_lines,
+                            r.start + extend_lines..r.end - extend_lines,
                         ),
                     );
                     changes.insert(
                         i,
-                        DiffLines::Both(l.start..l.start + 3, r.start..r.start + 3),
+                        DiffLines::Both(
+                            l.start..l.start + extend_lines,
+                            r.start..r.start + extend_lines,
+                        ),
                     );
                 }
             }

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -843,6 +843,7 @@ pub enum LapceUICommand {
         rev: u64,
         history: String,
         changes: Arc<Vec<DiffLines>>,
+        diff_extend_lines: usize,
     },
     /// Publish diagnostics changes (from the proxy)
     PublishDiagnostics(PublishDiagnosticsParams),

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -55,6 +55,7 @@ use crate::{
     data::{EditorDiagnostic, EditorView},
     editor::{EditorLocation, EditorPosition},
     find::{Find, FindProgress},
+    history,
     history::DocumentHistory,
     proxy::LapceProxy,
     selection_range::{SelectionRangeDirection, SyntaxSelectionRanges},
@@ -747,7 +748,13 @@ impl Document {
 
     fn trigger_head_change(&self) {
         if let Some(head) = self.histories.get("head") {
-            head.trigger_update_change(self);
+            head.trigger_update_change(self, history::DEFAULT_DIFF_EXTEND_LINES);
+        }
+    }
+
+    pub fn trigger_history_change(&self, version: &str, extend_lines: usize) {
+        if let Some(history) = self.histories.get(version) {
+            history.trigger_update_change(self, extend_lines);
         }
     }
 
@@ -756,12 +763,13 @@ impl Document {
         rev: u64,
         version: &str,
         changes: Arc<Vec<DiffLines>>,
+        diff_extend_lines: usize,
     ) {
         if rev != self.rev() {
             return;
         }
         if let Some(history) = self.histories.get_mut(version) {
-            history.update_changes(changes);
+            history.update_changes(changes, diff_extend_lines);
         }
     }
 

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -1813,6 +1813,7 @@ impl LapceTab {
                         rev,
                         history,
                         changes,
+                        diff_extend_lines,
                         ..
                     } => {
                         ctx.set_handled();
@@ -1821,6 +1822,7 @@ impl LapceTab {
                             *rev,
                             history,
                             changes.clone(),
+                            *diff_extend_lines,
                         );
                     }
                     LapceUICommand::UpdateHistoryStyle {


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

feature: support increase diff extend size

<img width="542" alt="image" src="https://user-images.githubusercontent.com/4404609/212015697-35a77430-c050-4adc-91c0-a2e04209abc0.png">


click the area will increase the diff extend size, now wil plus 5 lines.

<img width="725" alt="image" src="https://user-images.githubusercontent.com/4404609/212015981-77fb21e7-2d3f-46a8-8814-b619fca82136.png">
