### PR TITLE
Implement rendering of images in markdown views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#1968](https://github.com/lapce/lapce/pull/1968): Completion lens (disabled by default)
   - ![image](https://user-images.githubusercontent.com/13157904/211959283-c3229cfc-28d7-4676-a50d-aec7d47cde9f.png)
 - [#1972](https://github.com/lapce/lapce/pull/1972): Add file duplication option in fs tree context menu
+- [#1991](https://github.com/lapce/lapce/pull/1991): Implement rendering of images in markdown views
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "tar",
  "thiserror",
  "toml_edit",
+ "url",
  "uuid",
  "zip",
 ]

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -260,6 +260,9 @@ name = ""
 "file_explorer" = "files.svg"
 "file_picker_up" = "arrow-up.svg"
 
+"image_loading" = "refresh.svg"
+"image_error" = "error.svg"
+
 "scm.icon" = "source-control.svg"
 "scm.diff.modified" = "diff-modified.svg"
 "scm.diff.added" = "diff-added.svg"

--- a/icons/codicons/refresh.svg
+++ b/icons/codicons/refresh.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/></svg>

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -54,6 +54,7 @@ structdesc = { git = "https://github.com/lapce/structdesc" }
 bytemuck = "1.8.0"
 # For parsing markdown data, such as in hovers
 pulldown-cmark = "0.9.1"
+url = "2.3.1"
 
 [target.'cfg(target_os="macos")'.dependencies]
 dmg = "0.1.1"

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -221,6 +221,9 @@ impl LapceIcons {
     pub const FILE_EXPLORER: &str = "file_explorer";
     pub const FILE_PICKER_UP: &str = "file_picker_up";
 
+    pub const IMAGE_LOADING: &str = "image_loading";
+    pub const IMAGE_ERROR: &str = "image_error";
+
     pub const SCM: &str = "scm.icon";
     pub const SCM_DIFF_MODIFIED: &str = "scm.diff.modified";
     pub const SCM_DIFF_ADDED: &str = "scm.diff.added";

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -65,6 +65,7 @@ use crate::{
     explorer::FileExplorerData,
     find::Find,
     hover::HoverData,
+    images::ImageCache,
     keypress::KeyPressData,
     palette::{PaletteData, PaletteType, PaletteViewData},
     panel::{
@@ -644,6 +645,7 @@ pub struct LapceTabData {
     pub window_origin: Rc<RefCell<Point>>,
     pub panel: Arc<PanelData>,
     pub config: Arc<LapceConfig>,
+    pub images: Arc<ImageCache>,
     pub focus: Arc<WidgetId>,
     pub focus_area: FocusArea,
     #[data(ignore)]
@@ -868,6 +870,7 @@ impl LapceTabData {
             window_origin: Rc::new(RefCell::new(Point::ZERO)),
             panel: Arc::new(panel),
             config,
+            images: Arc::new(ImageCache::default()),
             focus_area: FocusArea::Editor,
             db,
             progresses: Arc::new(Vec::new()),

--- a/lapce-data/src/hover.rs
+++ b/lapce-data/src/hover.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{LapceConfig, LapceTheme},
     data::EditorDiagnostic,
     document::{BufferContent, Document},
-    markdown::{from_marked_string, parse_markdown},
+    markdown::{from_marked_string, parse_markdown, Content},
     proxy::LapceProxy,
     rich_text::{RichText, RichTextBuilder},
 };
@@ -40,7 +40,7 @@ pub struct HoverData {
     /// Stores the actual size of the hover content
     pub content_size: Rc<RefCell<Size>>,
     /// The hover items that are currently loaded
-    pub items: Arc<Vec<RichText>>,
+    pub items: Arc<Vec<Content>>,
     /// The text for the diagnostic(s) at the position
     pub diagnostic_content: Option<RichText>,
 }
@@ -64,7 +64,7 @@ impl HoverData {
         }
     }
 
-    pub fn get_current_items(&self) -> Option<&[RichText]> {
+    pub fn get_current_items(&self) -> Option<&[Content]> {
         if self.items.is_empty() {
             None
         } else {
@@ -117,14 +117,7 @@ impl HoverData {
                         result
                     {
                         let items = parse_hover_resp(hover, &p_config);
-
-                        let items = Arc::new(
-                            items
-                                .into_iter()
-                                .filter(|i| !i.is_empty())
-                                .rev()
-                                .collect(),
-                        );
+                        let items = Arc::new(items);
 
                         let _ = event_sink.submit_command(
                             LAPCE_UI_COMMAND,
@@ -139,7 +132,7 @@ impl HoverData {
     }
 
     /// Receive the result of a hover request
-    pub fn receive(&mut self, request_id: usize, items: Arc<Vec<RichText>>) {
+    pub fn receive(&mut self, request_id: usize, items: Arc<Vec<Content>>) {
         // If we've moved to inactive between the time the request started and now
         // or we've moved to a different request
         // then don't bother processing the received data
@@ -226,32 +219,35 @@ impl Default for HoverData {
     }
 }
 
-fn parse_hover_resp(hover: lsp_types::Hover, config: &LapceConfig) -> Vec<RichText> {
+fn parse_hover_resp(hover: lsp_types::Hover, config: &LapceConfig) -> Vec<Content> {
     match hover.contents {
         HoverContents::Scalar(text) => match text {
-            MarkedString::String(text) => {
-                vec![parse_markdown(&text, 1.5, config)]
-            }
-            MarkedString::LanguageString(code) => vec![parse_markdown(
+            MarkedString::String(text) => parse_markdown(&text, 1.5, config),
+            MarkedString::LanguageString(code) => parse_markdown(
                 &format!("```{}\n{}\n```", code.language, code.value),
                 1.5,
                 config,
-            )],
+            ),
         },
-        HoverContents::Array(array) => array
-            .into_iter()
-            .map(|t| from_marked_string(t, config))
-            .collect(),
+        HoverContents::Array(array) => {
+            let entries = array
+                .into_iter()
+                .map(|t| from_marked_string(t, config))
+                .rev();
+
+            // TODO: It'd be nice to avoid this vec
+            itertools::Itertools::intersperse(entries, vec![Content::Separator])
+                .flatten()
+                .collect()
+        }
         HoverContents::Markup(content) => match content.kind {
             MarkupKind::PlainText => {
                 let mut builder = RichTextBuilder::new();
                 builder.set_line_height(1.5);
                 builder.push(&content.value);
-                vec![builder.build()]
+                vec![Content::Text(builder.build())]
             }
-            MarkupKind::Markdown => {
-                vec![parse_markdown(&content.value, 1.5, config)]
-            }
+            MarkupKind::Markdown => parse_markdown(&content.value, 1.5, config),
         },
     }
 }

--- a/lapce-data/src/images.rs
+++ b/lapce-data/src/images.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+
+use druid::{piet::PietImage, ExtEventSink, Target};
+use lapce_core::directory::Directory;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::command::{LapceUICommand, LAPCE_UI_COMMAND};
+
+#[derive(Clone)]
+pub enum Image {
+    Image(Arc<PietImage>),
+}
+impl std::fmt::Debug for Image {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Image::Image(_) => f.debug_tuple("Image").finish(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ImageStatus {
+    /// The image is being requested
+    Loading,
+    // TODO: Give this some error string to display? Maybe use thiserror or whatever?
+    /// There was some error in loading the image
+    Error,
+    /// The image has been loaded
+    Loaded(Image),
+}
+
+#[derive(Clone)]
+struct ImageCacheEntry {
+    /// The number of active entries for this image, used for reference counting
+    pub count: usize,
+    pub image: ImageStatus,
+}
+
+#[derive(Clone, Default)]
+pub struct ImageCache {
+    images: im::HashMap<Url, ImageCacheEntry>,
+}
+impl ImageCache {
+    /// Loads the given url, and submits the `ImageLoaded` event to the event sink when it's done.  
+    /// You can use [`ImageCache::get`] to get the image's status, and content once it is finished.
+    pub fn load_url_cmd(&mut self, url: Url, event_sink: ExtEventSink) {
+        self.load_url_cb(url.clone(), move |image| {
+            let _ = event_sink.submit_command(
+                LAPCE_UI_COMMAND,
+                LapceUICommand::ImageLoaded { url, image },
+                Target::Auto,
+            );
+        });
+    }
+
+    fn load_url_cb(
+        &mut self,
+        url: Url,
+        cb: impl FnOnce(anyhow::Result<Image>) + Send + 'static,
+    ) {
+        let has_img = self.images.contains_key(&url);
+        let img =
+            self.images
+                .entry(url.clone())
+                .or_insert_with(|| ImageCacheEntry {
+                    count: 0,
+                    image: ImageStatus::Loading,
+                });
+        img.count += 1;
+
+        // If we've already started loading the image, then assume that we don't need to load it
+        // again. If this is incorrect, then that's a sign of some bug in the code which uses
+        // the cache. Either forgetting to call `load_finished` or accidentally unregistering
+        // an image too many times.
+        if has_img {
+            return;
+        }
+
+        std::thread::spawn(move || cb(get_image(url)));
+    }
+
+    pub fn load_finished(
+        &mut self,
+        url: &Url,
+        image: &Result<Image, anyhow::Error>,
+    ) {
+        let image = match image {
+            Ok(image) => ImageStatus::Loaded(image.clone()),
+            Err(_) => ImageStatus::Error,
+        };
+
+        if let Some(img) = self.images.get_mut(url) {
+            img.image = image;
+        } else {
+            log::warn!("Image loading for '{url}' finished, but it was not present in the cache.");
+            self.images
+                .insert(url.clone(), ImageCacheEntry { count: 1, image });
+        }
+    }
+
+    pub fn done_with_image(&mut self, url: &Url) {
+        if let Some(img) = self.images.get_mut(url) {
+            img.count = img.count.saturating_sub(1);
+        } else {
+            log::warn!("Image '{url}' was not present in the cache.");
+        }
+    }
+
+    pub fn get(&self, url: &Url) -> Option<&ImageStatus> {
+        self.images.get(url).map(|x| &x.image)
+    }
+}
+
+fn get_image(url: Url) -> Result<Image, anyhow::Error> {
+    // Load the image's raw bytes
+    let content = if url.scheme() == "file" {
+        // If it's a file, then we can just load it directly rather than
+        // storing it in a cache directory.
+        let path = url.to_file_path().unwrap();
+        std::fs::read(path)?
+    } else {
+        // Hash the url to get a safe and basically-unique filename
+        let cache_file_path = Directory::cache_directory().map(|cache_dir| {
+            let mut hasher = Sha256::new();
+            hasher.update(url.as_str().as_bytes());
+            let filename = format!("{:x}", hasher.finalize());
+            cache_dir.join(filename)
+        });
+
+        let cache_content =
+            cache_file_path.as_ref().and_then(|p| std::fs::read(p).ok());
+
+        match cache_content {
+            Some(content) => content,
+            None => {
+                let resp = reqwest::blocking::get(url.clone())?;
+                if !resp.status().is_success() {
+                    return Err(anyhow::anyhow!("can't download icon"));
+                }
+                let buf = resp.bytes()?.to_vec();
+
+                if let Some(path) = cache_file_path.as_ref() {
+                    let _ = std::fs::write(path, &buf);
+                }
+
+                buf
+            }
+        }
+    };
+
+    let image = PietImage::from_bytes(&content)
+        .map_err(|_| anyhow::anyhow!("can't resolve image from '{url}'"))?;
+    Ok(Image::Image(Arc::new(image)))
+}

--- a/lapce-data/src/lib.rs
+++ b/lapce-data/src/lib.rs
@@ -16,6 +16,7 @@ pub mod explorer;
 pub mod find;
 pub mod history;
 pub mod hover;
+pub mod images;
 pub mod keypress;
 pub mod list;
 pub mod markdown;

--- a/lapce-data/src/markdown/layout_content.rs
+++ b/lapce-data/src/markdown/layout_content.rs
@@ -1,0 +1,281 @@
+use std::sync::Arc;
+
+use druid::{
+    kurbo::Line,
+    piet::{InterpolationMode, PietText},
+    ArcStr, Color, Env, EventCtx, ExtEventSink, FontDescriptor, PaintCtx, Point,
+    Rect, RenderContext, Size, TextLayout, UpdateCtx, Vec2,
+};
+use lsp_types::Url;
+
+use crate::{
+    config::{LapceConfig, LapceIcons, LapceTheme},
+    data::LapceTabData,
+    images::{Image, ImageCache, ImageStatus},
+    rich_text::RichText,
+};
+
+use super::Content;
+
+#[derive(Clone)]
+pub enum LayoutContent {
+    Text(TextLayout<RichText>),
+    // TODO: keep title with it to inform the user on hover
+    Image { url: Url, size: Size },
+    BrokenImage { text: TextLayout<RichText> },
+    Separator { width: f64 },
+}
+impl LayoutContent {
+    // TODO: Add configuration for whether it should allow loading local file urls
+    // (And it would be desirable to have them be fine-grained enough to allow previewing
+    // local markdown files to load local images, but not allow loading local images in hover)
+
+    /// Transform a `MarkdownContent` instance into one which can be rendered.  
+    /// This loads images as needed. Specify a `base_url` for the root of relative urls, typically
+    /// the current workspace.  
+    pub fn from_content(
+        event_sink: ExtEventSink,
+        images: &mut ImageCache,
+        base_url: Option<&Url>,
+        content: &Content,
+    ) -> LayoutContent {
+        match content {
+            Content::Text(text) => {
+                let mut layout = TextLayout::new();
+                layout.set_text(text.clone());
+                LayoutContent::Text(layout)
+            }
+            Content::Image { url, .. } => {
+                if let Ok(url) = Url::options().base_url(base_url).parse(url) {
+                    images.load_url_cmd(url.clone(), event_sink);
+
+                    LayoutContent::Image {
+                        url,
+                        size: Size::ZERO,
+                    }
+                } else {
+                    // TODO: highlight this with red text and make it italics or something?
+                    let mut layout = TextLayout::new();
+                    layout.set_text(RichText::new(ArcStr::from(format!(
+                        "Bad Image URL: {}",
+                        url
+                    ))));
+                    LayoutContent::BrokenImage { text: layout }
+                }
+            }
+            Content::Separator => LayoutContent::Separator { width: 0.0 },
+        }
+    }
+
+    pub fn set_font(&mut self, font: FontDescriptor) {
+        match self {
+            LayoutContent::Text(layout) => {
+                layout.set_font(font);
+            }
+            LayoutContent::BrokenImage { text } => {
+                text.set_font(font);
+            }
+            LayoutContent::Image { .. } | LayoutContent::Separator { .. } => {}
+        }
+    }
+
+    pub fn set_text_color(&mut self, color: Color) {
+        match self {
+            LayoutContent::Text(layout) => {
+                layout.set_text_color(color);
+            }
+            LayoutContent::BrokenImage { text } => {
+                text.set_text_color(color);
+            }
+            LayoutContent::Image { .. } | LayoutContent::Separator { .. } => {}
+        }
+    }
+
+    pub fn set_max_width(&mut self, images: &ImageCache, max_width: f64) {
+        match self {
+            LayoutContent::Text(layout) => {
+                layout.set_wrap_width(max_width);
+            }
+            LayoutContent::BrokenImage { text } => {
+                text.set_wrap_width(max_width);
+            }
+            LayoutContent::Image { url, size } => {
+                if let Some(ImageStatus::Loaded(image)) = images.get(url) {
+                    *size = get_image_size(image, max_width);
+                }
+            }
+            LayoutContent::Separator { width } => {
+                *width = max_width - 2.0;
+            }
+        }
+    }
+
+    pub fn needs_rebuild_after_update(&mut self, ctx: &mut UpdateCtx) -> bool {
+        match self {
+            LayoutContent::Text(layout) => layout.needs_rebuild_after_update(ctx),
+            LayoutContent::BrokenImage { text } => {
+                text.needs_rebuild_after_update(ctx)
+            }
+            LayoutContent::Image { .. } | LayoutContent::Separator { .. } => false,
+        }
+    }
+
+    pub fn rebuild_if_needed(&mut self, factory: &mut PietText, env: &Env) {
+        match self {
+            LayoutContent::Text(layout) => {
+                layout.rebuild_if_needed(factory, env);
+            }
+            LayoutContent::BrokenImage { text } => {
+                text.rebuild_if_needed(factory, env);
+            }
+            LayoutContent::Image { .. } | LayoutContent::Separator { .. } => {}
+        }
+    }
+
+    /// `width` is only used for images currently, and should probably be the same as
+    /// `set_wrap_width`'s call
+    pub fn size(&self, images: &ImageCache, config: &LapceConfig) -> Size {
+        match self {
+            LayoutContent::Text(layout) => layout.size(),
+            LayoutContent::Image { url, size } => match images.get(url) {
+                Some(ImageStatus::Loading | ImageStatus::Error) | None => {
+                    get_svg_size(config)
+                }
+                Some(ImageStatus::Loaded(_)) => *size,
+            },
+            LayoutContent::BrokenImage { text } => text.size(),
+            // TODO: Separator side margin should perhaps be supplied by some margin setting??
+            LayoutContent::Separator { width } => Size::new(*width, 1.0),
+        }
+    }
+
+    /// `width` is only used for images currently, and should probably be the same as
+    /// `set_wrap_width`'s call
+    pub fn draw(
+        &self,
+        ctx: &mut PaintCtx,
+        images: &ImageCache,
+        config: &LapceConfig,
+        origin: Point,
+    ) {
+        match self {
+            LayoutContent::Text(layout) => {
+                layout.draw(ctx, origin);
+            }
+            LayoutContent::Image { url, size } => {
+                match images.get(url) {
+                    Some(ImageStatus::Loading) => {
+                        // TODO: Animating this as spinning would be nice, but would be easier
+                        // to do once we have some general textview widget to hold renderalbe
+                        // content
+                        ctx.draw_svg(
+                            &config.ui_svg(LapceIcons::IMAGE_LOADING),
+                            get_svg_size(config).to_rect().with_origin(origin),
+                            Some(
+                                config.get_color_unchecked(
+                                    LapceTheme::LAPCE_ICON_ACTIVE,
+                                ),
+                            ),
+                        );
+                    }
+                    Some(ImageStatus::Error) | None => {
+                        // TODO: On hover, give the user the information about image that
+                        // failed to load
+                        ctx.draw_svg(
+                            &config.ui_svg(LapceIcons::IMAGE_ERROR),
+                            get_svg_size(config).to_rect().with_origin(origin),
+                            Some(
+                                config.get_color_unchecked(
+                                    LapceTheme::LAPCE_ICON_ACTIVE,
+                                ),
+                            ),
+                        );
+                    }
+                    Some(ImageStatus::Loaded(image)) => match image {
+                        Image::Image(image) => {
+                            ctx.draw_image(
+                                image,
+                                Rect::from_origin_size(origin, *size),
+                                InterpolationMode::Bilinear,
+                            );
+                        }
+                    },
+                }
+            }
+            LayoutContent::BrokenImage { text } => {
+                text.draw(ctx, origin);
+            }
+            LayoutContent::Separator { width } => {
+                let line = Line::new(
+                    origin + Vec2::new(1.0, 0.0),
+                    origin + Vec2::new(1.0 + *width, 0.0),
+                );
+                ctx.stroke(
+                    line,
+                    config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
+                    1.0,
+                );
+            }
+        }
+    }
+}
+
+fn get_svg_size(config: &LapceConfig) -> Size {
+    let svg_size = config.ui.icon_size() as f64;
+    Size::new(svg_size, svg_size)
+}
+
+fn get_image_size(image: &Image, max_width: f64) -> Size {
+    match image {
+        Image::Image(image) => {
+            // This needs piet-wgpu updated with the size implementation for WgpuImage
+            // let size = image.size();
+            let (width, height) = image.img.dimensions();
+            let size = Size::new(width as f64, height as f64);
+            let aspect_ratio = size.width / size.height;
+            let height = max_width / aspect_ratio;
+            Size::new(max_width, height)
+        }
+    }
+}
+
+/// Utility function to make constructing a vector of `LayoutContent` from a vector of `Content`
+pub fn layouts_from_contents<'a>(
+    ctx: &mut EventCtx,
+    data: &mut LapceTabData,
+    items: impl Iterator<Item = &'a Content>,
+) -> Vec<LayoutContent> {
+    let event_sink = ctx.get_external_handle();
+    let images = Arc::make_mut(&mut data.images);
+    let base_url = data
+        .workspace
+        .path
+        .as_deref()
+        .and_then(|p| Url::from_directory_path(p).ok());
+    let base_url = base_url.as_ref();
+    let mut layouts = Vec::new();
+
+    for content in items {
+        layouts.push(LayoutContent::from_content(
+            event_sink.clone(),
+            images,
+            base_url,
+            content,
+        ));
+    }
+
+    layouts
+}
+
+/// Mark that you're done with the layout content, so that they can be cleaned up
+pub fn layout_content_clean_up(
+    layouts: &mut Vec<LayoutContent>,
+    data: &mut LapceTabData,
+) {
+    let images = Arc::make_mut(&mut data.images);
+    for item in layouts.drain(..) {
+        if let LayoutContent::Image { url, .. } = item {
+            images.done_with_image(&url);
+        }
+    }
+}

--- a/lapce-data/src/plugin.rs
+++ b/lapce-data/src/plugin.rs
@@ -345,7 +345,7 @@ impl PluginData {
             let text = parse_markdown("Plugin doesn't have a README", 2.0, config);
             let _ = event_sink.submit_command(
                 LAPCE_UI_COMMAND,
-                LapceUICommand::UpdateVoltReadme(text),
+                LapceUICommand::UpdateVoltReadme(Arc::new(text)),
                 Target::Widget(widget_id),
             );
             return Ok(());
@@ -354,7 +354,7 @@ impl PluginData {
         let text = parse_markdown(&text, 2.0, config);
         let _ = event_sink.submit_command(
             LAPCE_UI_COMMAND,
-            LapceUICommand::UpdateVoltReadme(text),
+            LapceUICommand::UpdateVoltReadme(Arc::new(text)),
             Target::Widget(widget_id),
         );
         Ok(())

--- a/lapce-ui/src/hover.rs
+++ b/lapce-ui/src/hover.rs
@@ -10,6 +10,9 @@ use lapce_data::{
     config::LapceTheme,
     data::LapceTabData,
     hover::{HoverData, HoverStatus},
+    markdown::layout_content::{
+        layout_content_clean_up, layouts_from_contents, LayoutContent,
+    },
     rich_text::RichText,
 };
 
@@ -76,8 +79,16 @@ impl Widget<LapceTabData> for HoverContainer {
             Event::Command(cmd) if cmd.is(LAPCE_UI_COMMAND) => {
                 let command = cmd.get_unchecked(LAPCE_UI_COMMAND);
                 if let LapceUICommand::UpdateHover { request_id, items } = command {
+                    // TODO: Should we check whether it has actually changed?
                     let hover = Arc::make_mut(&mut data.hover);
                     hover.receive(*request_id, items.clone());
+
+                    self.hover
+                        .widget_mut()
+                        .inner_mut()
+                        .child_mut()
+                        .update_layouts(ctx, data);
+
                     ctx.request_paint();
                 }
             }
@@ -185,7 +196,7 @@ impl Widget<LapceTabData> for HoverContainer {
 
 #[derive(Default)]
 struct Hover {
-    active_layout: Vec<TextLayout<RichText>>,
+    active_layout: Vec<LayoutContent>,
     active_diagnostic_layout: TextLayout<RichText>,
 }
 
@@ -202,6 +213,38 @@ impl Hover {
                 layout
             },
         }
+    }
+
+    fn update_layouts(&mut self, ctx: &mut EventCtx, data: &mut LapceTabData) {
+        let items = data.hover.items.clone();
+
+        layout_content_clean_up(&mut self.active_layout, data);
+        self.active_layout = layouts_from_contents(ctx, data, items.iter());
+
+        if let Some(diagnostic_content) = &data.hover.diagnostic_content {
+            self.active_diagnostic_layout
+                .set_text(diagnostic_content.clone());
+        } else {
+            self.active_diagnostic_layout
+                .set_text(RichText::new(ArcStr::from("")));
+        }
+
+        let font = FontDescriptor::new(data.config.ui.hover_font_family())
+            .with_size(data.config.ui.hover_font_size() as f64);
+        let text_color = data
+            .config
+            .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
+            .clone();
+
+        for layout in self.active_layout.iter_mut() {
+            layout.set_font(font.clone());
+            layout.set_text_color(text_color.clone());
+        }
+
+        self.active_diagnostic_layout.set_font(font);
+        self.active_diagnostic_layout.set_text_color(text_color);
+
+        ctx.request_layout();
     }
 }
 impl Widget<LapceTabData> for Hover {
@@ -228,58 +271,11 @@ impl Widget<LapceTabData> for Hover {
 
     fn update(
         &mut self,
-        ctx: &mut UpdateCtx,
-        old_data: &LapceTabData,
-        data: &LapceTabData,
+        _ctx: &mut UpdateCtx,
+        _old_data: &LapceTabData,
+        _data: &LapceTabData,
         _env: &Env,
     ) {
-        // or we've gotten new diagnostic text
-        // then update the layout
-        if old_data.hover.request_id != data.hover.request_id
-            || old_data.hover.get_current_items().is_some()
-                != data.hover.get_current_items().is_some()
-            || old_data.hover.len() != data.hover.len()
-            || !old_data
-                .hover
-                .diagnostic_content
-                .same(&data.hover.diagnostic_content)
-        {
-            self.active_layout = data
-                .hover
-                .items
-                .iter()
-                .map(|item| {
-                    let mut layout = TextLayout::new();
-                    layout.set_text(item.clone());
-                    layout
-                })
-                .collect();
-
-            if let Some(diagnostic_content) = &data.hover.diagnostic_content {
-                self.active_diagnostic_layout
-                    .set_text(diagnostic_content.clone());
-            } else {
-                self.active_diagnostic_layout
-                    .set_text(RichText::new(ArcStr::from("")));
-            }
-
-            let font = FontDescriptor::new(data.config.ui.hover_font_family())
-                .with_size(data.config.ui.hover_font_size() as f64);
-            let text_color = data
-                .config
-                .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
-                .clone();
-
-            for layout in self.active_layout.iter_mut() {
-                layout.set_font(font.clone());
-                layout.set_text_color(text_color.clone());
-            }
-
-            self.active_diagnostic_layout.set_font(font);
-            self.active_diagnostic_layout.set_text_color(text_color);
-
-            ctx.request_layout();
-        }
     }
 
     fn layout(
@@ -297,9 +293,9 @@ impl Widget<LapceTabData> for Hover {
 
         let mut max_layout_width = 0.0;
         for layout in self.active_layout.iter_mut() {
-            layout.set_wrap_width(max_width);
+            layout.set_max_width(&data.images, max_width);
             layout.rebuild_if_needed(ctx.text(), env);
-            let layout_width = layout.size().width;
+            let layout_width = layout.size(&data.images, &data.config).width;
             if layout_width > max_layout_width {
                 max_layout_width = layout_width;
             }
@@ -314,7 +310,7 @@ impl Widget<LapceTabData> for Hover {
         } else {
             let mut height = 0.0;
             for layout in self.active_layout.iter() {
-                height += layout.layout_metrics().size.height;
+                height += layout.size(&data.images, &data.config).height;
             }
 
             if self.active_layout.len() > 1 {
@@ -360,7 +356,6 @@ impl Widget<LapceTabData> for Hover {
 
         let side_margin =
             env.get(theme::SCROLLBAR_WIDTH) + env.get(theme::SCROLLBAR_PAD);
-        let line_height = data.config.editor.line_height() as f64;
 
         let rect = ctx.region().bounding_box();
         let diagnostic_origin = Point::new(Self::STARTING_X, Self::STARTING_Y);
@@ -401,31 +396,16 @@ impl Widget<LapceTabData> for Hover {
 
         let mut start_height = 0.0;
 
-        let active_items_len = data.hover.items.len();
+        for layout in self.active_layout.iter_mut() {
+            layout.draw(
+                ctx,
+                &data.images,
+                &data.config,
+                doc_origin + (0.0, start_height),
+            );
 
-        for (i, layout) in self.active_layout.iter_mut().enumerate() {
-            layout.draw(ctx, doc_origin + (0.0, start_height));
-
-            if i < active_items_len - 1 {
-                let layout_metrics = layout.layout_metrics();
-                start_height += layout_metrics.size.height;
-
-                let line = {
-                    let x0 = rect.x0 + side_margin;
-                    let y =
-                        (doc_origin + (0.0, start_height)).y + (line_height / 2.0);
-                    let x1 = rect.x1 - side_margin;
-                    Line::new(Point::new(x0, y), Point::new(x1, y))
-                };
-
-                start_height += line_height;
-
-                ctx.stroke(
-                    line,
-                    data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
-                    1.0,
-                );
-            }
+            let layout_size = layout.size(&data.images, &data.config);
+            start_height += layout_size.height;
         }
     }
 }

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -2048,6 +2048,11 @@ impl LapceTab {
                         ctx.set_handled();
                         let _ = process::Command::new(cmd).args(args).spawn();
                     }
+                    LapceUICommand::ImageLoaded { url, image } => {
+                        ctx.set_handled();
+                        let images = Arc::make_mut(&mut data.images);
+                        images.load_finished(url, image)
+                    }
                     _ => (),
                 }
             }


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR implements rendering of images in markdown views (hover, completion documentation, signature, and plugin readmes).  
  
- The loading icon it shows is a bit weird, because typically you see them spinning  
- Sometimes the images don't load??? 
  - I had this most often with the plugin readme (I put an image in my Aleph theme plugin's readme for testing). 
  - I note that I have the same issue with plugin icons sometimes not loading, despite that they should be in the local cache folder by now. I'd think this was some github throttling (are those icons even hosted on github pages?), but it also happened for a local image (if less often??). I'm very confused. 
- The positioning of images is off. This is mostly due to the code not paying attention to whether the user did a hard line break before the image or not. That'll have to be fixed for having links work in markdown views too.
- This provides an `ImageCache`.
  - Does not currently load SVGs, so it doesn't swap out the volt icon loading code to use image cache. (Though that should be possible, but I'm somewhat confused as to the best way to decide the size of an svg if it isn't literally given to us?)
  - *Does not actually clear the cache yet*. It keeps track of the data, but when I had it immediately remove with zero references I got failures to load an image a lot more often?