### PR TITLE
Add serde feature req to indexmap dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ flate2 = "1.0"
 hashbrown = { version = "0.12.3", features = ["serde"] }
 im = { version = "15.0.0", features = ["serde"] }
 include_dir = "0.6.2"
-indexmap = "1.9"
+indexmap = { version = "1.9", features = ["serde"] }
 interprocess = "1.1.1"
 itertools = "0.10.1"
 log = "0.4"


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

#1940 forgot to include the `serde` feature requirement. Lapce would still compile, but running `lapce-core`/`lapce-rpc` in isolation (via tests) would fail to compile due to the missing feature.