### PR TITLE
fix: align width and tab separator correctly + refactor

### DIFF
--- a/lapce-ui/src/editor/tab_header_content.rs
+++ b/lapce-ui/src/editor/tab_header_content.rs
@@ -542,7 +542,8 @@ impl Widget<LapceTabData> for LapceEditorTabHeaderContent {
                 + path_layout.as_ref().map(|p| p.size()).unwrap_or(Size::ZERO);
             let width =
                 (text_size.width + height + (height - font_size) / 2.0 + font_size)
-                    .max(data.config.ui.tab_min_width() as f64);
+                    .max(data.config.ui.tab_min_width() as f64)
+                    + 1.; // +1. for tab separator
             let close_size = 24.0;
             let inflate = (height - close_size) / 2.0;
             let tab_rect = TabRect {


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

- Tab separators are drawn outside the tab
- Active tab underline is properly aligned to have padding of 2px from both sides
![image](https://user-images.githubusercontent.com/50457605/212586395-9dd7fee2-0983-4c53-98a7-399989d85c8e.png)
