### PR TITLE
Fix crash in lapce-proxy when doing bad ranges on string

### DIFF
--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -330,16 +330,17 @@ impl ProxyHandler for Dispatcher {
                                                 // (such as in minified javascript)
                                                 // Note that the start/end are column based, not absolute from the
                                                 // start of the file.
-                                                let display_range = mymatch
-                                                    .start()
-                                                    .saturating_sub(100)
-                                                    ..line
-                                                        .len()
-                                                        .min(mymatch.end() + 100);
                                                 line_matches.push((
                                                     lnum as usize,
                                                     (mymatch.start(), mymatch.end()),
-                                                    line[display_range].to_string(),
+                                                    line.chars()
+                                                        .skip(
+                                                            mymatch
+                                                                .start()
+                                                                .saturating_sub(100),
+                                                        )
+                                                        .take(100)
+                                                        .collect::<String>(),
                                                 ));
                                                 Ok(true)
                                             }),


### PR DESCRIPTION
```
[2023-01-16][15:52:36][panic][ERROR] thread '<unnamed>' panicked at 'byte index 107 is not a char boundary; it is inside 'ο' (bytes 106..108) of `    This is some text. Это некоторый текст. Αυτό είναι κάποιο κείμενο. 這是一些文字。"
`': lapce-proxy/src/dispatch.rs:342
   0: <backtrace::capture::Backtrace as core::default::Default>::default
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.66/src/capture.rs:410:9
   1: log_panics::Config::install_panic_hook::{{closure}}
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/log-panics-2.1.0/src/lib.rs:115:29
   2: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/alloc/src/boxed.rs:2001:9
      std::panicking::rust_panic_with_hook
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:692:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:579:13
   4: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/sys_common/backtrace.rs:137:18
   5: rust_begin_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:575:5
   6: core::panicking::panic_fmt
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panicking.rs:65:14
   7: core::str::slice_error_fail_rt
   8: core::str::slice_error_fail
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/str/mod.rs:86:9
   9: core::str::traits::<impl core::slice::index::SliceIndex<str> for core::ops::range::Range<usize>>::index
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/str/traits.rs:218:21
  10: core::str::traits::<impl core::ops::index::Index<I> for str>::index
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/str/traits.rs:65:9
  11: <lapce_proxy::dispatch::Dispatcher as lapce_rpc::proxy::ProxyHandler>::handle_request::{{closure}}::{{closure}}
             at lapce-proxy/src/dispatch.rs:342:53
  12: <grep_searcher::sink::sinks::UTF8<F> as grep_searcher::sink::Sink>::matched
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/sink.rs:562:13
  13: grep_searcher::searcher::core::Core<M,S>::sink_matched
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/searcher/core.rs:437:25
      grep_searcher::searcher::core::Core<M,S>::match_by_line_fast
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/searcher/core.rs:311:21
  14: grep_searcher::searcher::core::Core<M,S>::match_by_line
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/searcher/core.rs:112:13
  15: grep_searcher::searcher::glue::ReadByLine<M,R,S>::run
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/searcher/glue.rs:42:35
  16: grep_searcher::searcher::Searcher::search_reader
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/searcher/mod.rs:735:13
  17: grep_searcher::searcher::Searcher::search_file_maybe_path
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/searcher/mod.rs:684:13
  18: grep_searcher::searcher::Searcher::search_path
             at /home/hbina/.cargo/registry/src/github.com-1ecc6299db9ec823/grep-searcher-0.1.10/src/searcher/mod.rs:628:9
  19: <lapce_proxy::dispatch::Dispatcher as lapce_rpc::proxy::ProxyHandler>::handle_request::{{closure}}
             at lapce-proxy/src/dispatch.rs:322:49
  20: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/sys_common/backtrace.rs:121:18
  21: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/thread/mod.rs:551:17
  22: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panic/unwind_safe.rs:271:9
  23: std::panicking::try::do_call
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:483:40
  24: __rust_try
  25: std::panicking::try
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:447:19
  26: std::panic::catch_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panic.rs:137:14
  27: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/thread/mod.rs:550:30
  28: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/ops/function.rs:251:5
  29: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/alloc/src/boxed.rs:1987:9
      <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/alloc/src/boxed.rs:1987:9
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/sys/unix/thread.rs:108:17
  30: start_thread
             at ./nptl/./nptl/pthread_create.c:442:8
  31: clone3
             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users