### PR TITLE
Limit global search to 1 worker thread

### DIFF
--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -802,9 +802,12 @@ impl Dispatcher {
         let (global_search_tx, global_search_rx) = unbounded::<()>();
 
         let local_proxy_rpc = proxy_rpc.clone();
-        thread::spawn(move || {
-            start_global_search_job(local_proxy_rpc, global_search_rx)
-        });
+        let _ = thread::Builder::new()
+            .name("global search worker".into())
+            .spawn(move || {
+                start_global_search_job(local_proxy_rpc, global_search_rx)
+            })
+            .unwrap();
 
         Self {
             workspace: None,

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -341,25 +341,16 @@ impl ProxyHandler for Dispatcher {
                                                 // (such as in minified javascript)
                                                 // Note that the start/end are column based, not absolute from the
                                                 // start of the file.
-                                                let match_start = mymatch
+                                                let display_range = mymatch
                                                     .start()
-                                                    .saturating_sub(100);
-                                                let match_end = line
-                                                    .len()
-                                                    .min(mymatch.end() + 100);
-                                                let display_line = line
-                                                    .get(match_start..match_end)
-                                                    .map(|s| s.to_string())
-                                                    .unwrap_or_else(|| {
-                                                        line.chars()
-                                                            .skip(match_start)
-                                                            .take(100)
-                                                            .collect::<String>()
-                                                    });
+                                                    .saturating_sub(100)
+                                                    ..line
+                                                        .len()
+                                                        .min(mymatch.end() + 100);
                                                 line_matches.push((
                                                     lnum as usize,
                                                     (mymatch.start(), mymatch.end()),
-                                                    display_line,
+                                                    line[display_range].to_string(),
                                                 ));
                                                 Ok(true)
                                             }),


### PR DESCRIPTION
Instead of spawning a new thread for every keystroke.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users