### PR TITLE
fix: ToggleHistory command

### DIFF
--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -2281,9 +2281,12 @@ impl LapceEditorBufferData {
             }
             ToggleHistory => {
                 let editor = Arc::make_mut(&mut self.editor);
-                editor.view = match editor.view {
-                    EditorView::Normal => EditorView::Diff(String::from("head")),
-                    EditorView::Diff(_) => EditorView::Normal,
+                (editor.view, editor.compare) = match editor.view {
+                    EditorView::Normal => (
+                        EditorView::Diff(String::from("head")),
+                        Some(String::from("head")),
+                    ),
+                    EditorView::Diff(_) => (EditorView::Normal, None),
                     EditorView::Lens => return CommandExecuted::Yes,
                 };
             }


### PR DESCRIPTION
`editor.compare` needs to be set in addition to `editor.view`. Otherwise, the size of the editor (the scroll area) is computed wrong.