### PR TITLE
Only be notified of content changes in file

### DIFF
--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -13,6 +13,7 @@ use lapce_core::directory::Directory;
 use lapce_proxy::plugin::wasi::find_all_volts;
 use lapce_rpc::plugin::VoltID;
 use lsp_types::{CompletionItemKind, SymbolKind};
+use notify::event::{DataChange, ModifyKind};
 use once_cell::sync::Lazy;
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
@@ -985,7 +986,7 @@ impl notify::EventHandler for ConfigWatcher {
         if let Ok(event) = event {
             match event.kind {
                 notify::EventKind::Create(_)
-                | notify::EventKind::Modify(_)
+                | notify::EventKind::Modify(ModifyKind::Data(DataChange::Content))
                 | notify::EventKind::Remove(_) => {
                     *self.delay_handler.lock() = Some(());
                     let delay_handler = self.delay_handler.clone();


### PR DESCRIPTION
This fixes some hanging causes by a feedback loop when listening to config files/folders.
Apparently, we are performing some changes when we listen to a file.
Presumably we are modifying some kind of metadata which triggers another notify causing the feedback loop.

I checked strace and we seem to only be performing `readlink` on `/home/hbina/.local/share/lapce-stable/*`.


```
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/keymaps.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=62, ...}) = 0
openat(AT_FDCWD, "/home/hbina/.config/lapce-stable/keymaps.toml", O_RDONLY|O_CLOEXEC) = 8
statx(8, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=62, ...}) = 0
lseek(8, 0, SEEK_CUR)                   = 0
read(8, "\n[[keymaps]]\ncommand = \"format_d"..., 62) = 62
read(8, "", 32)                         = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
getcwd("/home/hbina/git/lapce", 512)    = 22
openat(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", O_RDONLY|O_CLOEXEC) = 8
statx(8, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
lseek(8, 0, SEEK_CUR)                   = 0
read(8, "\n[editor]\nrender-whitespace = \"n"..., 232) = 232
read(8, "", 32)                         = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/themes", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/themes", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 8
newfstatat(8, "", {st_mode=S_IFDIR|0775, st_size=4096, ...}, AT_EMPTY_PATH) = 0
getdents64(8, 0x55e5bcc77fe0 /* 2 entries */, 32768) = 48
getdents64(8, 0x55e5bcc77fe0 /* 0 entries */, 32768) = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 8
newfstatat(8, "", {st_mode=S_IFDIR|0775, st_size=4096, ...}, AT_EMPTY_PATH) = 0
getdents64(8, 0x55e5bcc77fe0 /* 7 entries */, 32768) = 280
statx(8, "panekj.lapce-cpp-clangd", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=483, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-cpp-clangd\"\nversio"..., 483) = 483
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin/lapce-cpp-clangd.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "dzhou121.lapce-rust", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=780, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-rust\"\nversion = \"0"..., 780) = 780
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/lapce-rust.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-typescript", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=626, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-typescript\"\nversio"..., 626) = 626
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin/lapce-typescript.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-material-icon-theme", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=186, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-material-icon-them"..., 186) = 186
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-go", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=4112, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-go\"\nversion = \"202"..., 4112) = 4112
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/lapce-go.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
getdents64(8, 0x55e5bcc77fe0 /* 0 entries */, 32768) = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 8
newfstatat(8, "", {st_mode=S_IFDIR|0775, st_size=4096, ...}, AT_EMPTY_PATH) = 0
getdents64(8, 0x55e5bcc77fe0 /* 7 entries */, 32768) = 280
statx(8, "panekj.lapce-cpp-clangd", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=483, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-cpp-clangd\"\nversio"..., 483) = 483
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin/lapce-cpp-clangd.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "dzhou121.lapce-rust", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=780, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-rust\"\nversion = \"0"..., 780) = 780
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/lapce-rust.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-typescript", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=626, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-typescript\"\nversio"..., 626) = 626
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin/lapce-typescript.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-material-icon-theme", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=186, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-material-icon-them"..., 186) = 186
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-go", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=4112, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-go\"\nversion = \"202"..., 4112) = 4112
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/lapce-go.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
getdents64(8, 0x55e5bcc77fe0 /* 0 entries */, 32768) = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=2384, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=2384, ...}) = 0
getcwd("/home/hbina/git/lapce", 512)    = 22
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", O_RDONLY|O_CLOEXEC) = 8
statx(8, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=2384, ...}) = 0
lseek(8, 0, SEEK_CUR)                   = 0
read(8, "[icon-theme]\nname = \"Material Ic"..., 2384) = 2384
read(8, "", 32)                         = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
getcwd("/home/hbina/git/lapce", 512)    = 22
openat(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", O_RDONLY|O_CLOEXEC) = 8
statx(8, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
lseek(8, 0, SEEK_CUR)                   = 0
read(8, "\n[editor]\nrender-whitespace = \"n"..., 232) = 232
read(8, "", 32)                         = 0
close(8)                                = 0
clock_gettime(CLOCK_REALTIME, {tv_sec=1673924896, tv_nsec=820106403}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
getcwd("/home/hbina/git/lapce", 512)    = 22
openat(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", O_RDONLY|O_CLOEXEC) = 8
statx(8, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
lseek(8, 0, SEEK_CUR)                   = 0
read(8, "\n[editor]\nrender-whitespace = \"n"..., 232) = 232
read(8, "", 32)                         = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/git/redis/./.lapce/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffe1a38bf00) = -1 ENOENT (No such file or directory)
statx(AT_FDCWD, "/home/hbina/git/redis/./.lapce/settings.toml.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffe1a38bf00) = -1 ENOENT (No such file or directory)
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/themes", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/themes", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 8
newfstatat(8, "", {st_mode=S_IFDIR|0775, st_size=4096, ...}, AT_EMPTY_PATH) = 0
getdents64(8, 0x55e5bcc77fe0 /* 2 entries */, 32768) = 48
getdents64(8, 0x55e5bcc77fe0 /* 0 entries */, 32768) = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 8
newfstatat(8, "", {st_mode=S_IFDIR|0775, st_size=4096, ...}, AT_EMPTY_PATH) = 0
getdents64(8, 0x55e5bcc77fe0 /* 7 entries */, 32768) = 280
statx(8, "panekj.lapce-cpp-clangd", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=483, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-cpp-clangd\"\nversio"..., 483) = 483
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin/lapce-cpp-clangd.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "dzhou121.lapce-rust", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=780, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-rust\"\nversion = \"0"..., 780) = 780
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/lapce-rust.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-typescript", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=626, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-typescript\"\nversio"..., 626) = 626
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin/lapce-typescript.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-material-icon-theme", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=186, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-material-icon-them"..., 186) = 186
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-go", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=4112, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-go\"\nversion = \"202"..., 4112) = 4112
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/lapce-go.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
getdents64(8, 0x55e5bcc77fe0 /* 0 entries */, 32768) = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 8
newfstatat(8, "", {st_mode=S_IFDIR|0775, st_size=4096, ...}, AT_EMPTY_PATH) = 0
getdents64(8, 0x55e5bcc77fe0 /* 7 entries */, 32768) = 280
statx(8, "panekj.lapce-cpp-clangd", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=483, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-cpp-clangd\"\nversio"..., 483) = 483
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-cpp-clangd/bin/lapce-cpp-clangd.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "dzhou121.lapce-rust", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=780, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-rust\"\nversion = \"0"..., 780) = 780
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/dzhou121.lapce-rust/lapce-rust.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-typescript", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=626, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-typescript\"\nversio"..., 626) = 626
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-typescript/bin/lapce-typescript.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-material-icon-theme", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=186, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-material-icon-them"..., 186) = 186
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", 0x7ffe1a38bac0, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
statx(8, "panekj.lapce-go", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/volt.toml", O_RDONLY|O_CLOEXEC) = 9
statx(9, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=4112, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
read(9, "name = \"lapce-go\"\nversion = \"202"..., 4112) = 4112
read(9, "", 32)                         = 0
readlink("/home", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-go/lapce-go.wasm", 0x7ffe1a38bb70, 1023) = -1 EINVAL (Invalid argument)
close(9)                                = 0
getdents64(8, 0x55e5bcc77fe0 /* 0 entries */, 32768) = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=2384, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=2384, ...}) = 0
getcwd("/home/hbina/git/lapce", 512)    = 22
openat(AT_FDCWD, "/home/hbina/.local/share/lapce-stable/plugins/panekj.lapce-material-icon-theme/material.toml", O_RDONLY|O_CLOEXEC) = 8
statx(8, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=2384, ...}) = 0
lseek(8, 0, SEEK_CUR)                   = 0
read(8, "[icon-theme]\nname = \"Material Ic"..., 2384) = 2384
read(8, "", 32)                         = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFDIR|0775, stx_size=4096, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
statx(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
getcwd("/home/hbina/git/lapce", 512)    = 22
openat(AT_FDCWD, "/home/hbina/.config/lapce-stable/settings.toml", O_RDONLY|O_CLOEXEC) = 8
statx(8, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0664, stx_size=232, ...}) = 0
lseek(8, 0, SEEK_CUR)                   = 0
read(8, "\n[editor]\nrender-whitespace = \"n"..., 232) = 232
read(8, "", 32)                         = 0
close(8)                                = 0
statx(AT_FDCWD, "/home/hbina/git/redis/./.lapce/settings.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffe1a3895d0) = -1 ENOENT (No such file or directory)
statx(AT_FDCWD, "/home/hbina/git/redis/./.lapce/settings.toml.toml", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffe1a3895d0) = -1 ENOENT (No such file or directory)
```

Notice how something like `lapce-go.wasm` got read twice?

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users