### PR TITLE
Fix cursor movement on selections with arrow up/down keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys
 - [#1939](https://github.com/lapce/lapce/pull/1939): Fix saving/editing newly saved-as files
 - [#1971](https://github.com/lapce/lapce/pull/1971): Fix up/down movement on first/last line
+- [#2036](https://github.com/lapce/lapce/pull/2036): Fix movement on selections with up/down arrow keys
 
 ## 0.2.5
 

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -2415,17 +2415,17 @@ impl Document {
         config: &LapceConfig,
     ) -> SelRegion {
         let (count, region) = if count >= 1 && !modify && !region.is_caret() {
-            // If we're not a caret, and we are moving left or right, we want to move
+            // If we're not a caret, and we are moving left/up or right/down, we want to move
             // the cursor to the left or right side of the selection.
-            // Ex: `|abc|` -> left arrow key -> `|abc`
-            // Ex: `|abc|` -> right arrow key -> `abc|`
+            // Ex: `|abc|` -> left/up arrow key -> `|abc`
+            // Ex: `|abc|` -> right/down arrow key -> `abc|`
             // and it doesn't matter which direction the selection os going, so we use min/max
             match movement {
-                Movement::Left => {
+                Movement::Left | Movement::Up => {
                     let leftmost = region.min();
                     (count - 1, SelRegion::new(leftmost, leftmost, region.horiz))
                 }
-                Movement::Right => {
+                Movement::Right | Movement::Down => {
                     let rightmost = region.max();
                     (
                         count - 1,


### PR DESCRIPTION
This follows up on #1911: the up/down keys should also move relative to the selection.