### PR TITLE
Add 'Rename Symbol' option on right-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#1991](https://github.com/lapce/lapce/pull/1991): Implement rendering of images in markdown views
 - [#2004](https://github.com/lapce/lapce/pull/2004): Add ToggleHistory command
 - [#2033](https://github.com/lapce/lapce/pull/2033): Add setting for double click delay (Currently only works for opening file from the explorer)
+- [#2045](https://github.com/lapce/lapce/pull/2045): Add 'Rename Symbol' option on right-click
 
 ### Bug Fixes
 - [#1911](https://github.com/lapce/lapce/pull/1911): Fix movement on selections with left/right arrow keys

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -314,6 +314,15 @@ impl LapceEditor {
                 MenuKind::Item(MenuItem {
                     desc: None,
                     command: LapceCommand {
+                        kind: CommandKind::Focus(FocusCommand::Rename),
+                        data: None,
+                    },
+                    enabled: true,
+                }),
+                MenuKind::Separator,
+                MenuKind::Item(MenuItem {
+                    desc: None,
+                    command: LapceCommand {
                         kind: CommandKind::Edit(EditCommand::ClipboardCut),
                         data: None,
                     },


### PR DESCRIPTION
Fixes https://github.com/lapce/lapce/issues/1949

Implementation suggested by https://github.com/lapce/lapce/issues/1949#issuecomment-1376658407. I have confirmed that with this patch I can right click to rename a symbol.