### PR TITLE
Use bounded channel of 1 when responding to plugin rpc requests

### DIFF
--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -471,7 +471,7 @@ pub fn handle_plugin_server_message(
 ) -> Option<JsonRpc> {
     match JsonRpc::parse(message) {
         Ok(value @ JsonRpc::Request(_)) => {
-            let (tx, rx) = crossbeam_channel::unbounded();
+            let (tx, rx) = crossbeam_channel::bounded(1);
             let id = value.get_id().unwrap();
             let rpc = PluginServerRpc::HostRequest {
                 id: id.clone(),


### PR DESCRIPTION
This will never hang because `rx` dies immediately after. It should have better performance characteristics because unbounded channels have a lot more book keeping that it needs to manage.

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users