### PR TITLE
send user HOME dir from proxy to editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [#1939](https://github.com/lapce/lapce/pull/1939): Fix saving/editing newly saved-as files
 - [#1971](https://github.com/lapce/lapce/pull/1971): Fix up/down movement on first/last line
 - [#2036](https://github.com/lapce/lapce/pull/2036): Fix movement on selections with up/down arrow keys
+- [#2056](https://github.com/lapce/lapce/pull/2056): Fix default directory of remote session file picker
 
 ## 0.2.5
 

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -95,6 +95,13 @@ impl ProxyHandler for Dispatcher {
                     plugin_rpc.mainloop(&mut plugin);
                 });
                 self.core_rpc.proxy_connected();
+
+                // send home directory for initinal filepicker dir
+                let dirs = directories::UserDirs::new();
+
+                if let Some(dirs) = dirs {
+                    self.core_rpc.home_dir(dirs.home_dir().into());
+                }
             }
             OpenPaths { folders, files } => {
                 self.core_rpc.notification(CoreNotification::OpenPaths {

--- a/lapce-rpc/src/core.rs
+++ b/lapce-rpc/src/core.rs
@@ -300,6 +300,10 @@ impl CoreRpcHandler {
     pub fn update_terminal(&self, term_id: TermId, content: Vec<u8>) {
         self.notification(CoreNotification::UpdateTerminal { term_id, content });
     }
+
+    pub fn home_dir(&self, path: PathBuf) {
+        self.notification(CoreNotification::HomeDir { path });
+    }
 }
 
 impl Default for CoreRpcHandler {


### PR DESCRIPTION
For SSH sessions, the remote user's home directory never actually being sent to the editor. This means the file picker defaults to the file system root, which is not ideal.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users