### PR TITLE
Encode language_id as usize instead of String

### DIFF
--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -274,7 +274,7 @@ impl ProxyHandler for Dispatcher {
                 let content = buffer.rope.to_string();
                 self.catalog_rpc.did_open_document(
                     &path,
-                    buffer.language_id.to_string(),
+                    buffer.language_id,
                     buffer.rev as i32,
                     content.clone(),
                 );
@@ -628,7 +628,7 @@ impl ProxyHandler for Dispatcher {
                     .iter()
                     .map(|(path, buffer)| TextDocumentItem {
                         uri: Url::from_file_path(path).unwrap(),
-                        language_id: buffer.language_id.to_string(),
+                        language_id: buffer.language_id.as_str().to_string(),
                         version: buffer.rev as i32,
                         text: buffer.get_document(),
                     })

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -16,6 +16,7 @@ use crossbeam_channel::Sender;
 use jsonrpc_lite::{Id, Params};
 use lapce_core::directory::Directory;
 use lapce_rpc::{
+    language_id::LanguageId,
     plugin::{PluginId, VoltID, VoltInfo, VoltMetadata},
     style::LineStyle,
     RpcError,
@@ -94,8 +95,8 @@ impl PluginServerHandler for Plugin {
     }
 
     fn document_supported(
-        &mut self,
-        language_id: Option<&str>,
+        &self,
+        language_id: LanguageId,
         path: Option<&Path>,
     ) -> bool {
         self.host.document_supported(language_id, path)
@@ -132,7 +133,7 @@ impl PluginServerHandler for Plugin {
 
     fn handle_did_save_text_document(
         &self,
-        language_id: String,
+        language_id: LanguageId,
         path: PathBuf,
         text_document: TextDocumentIdentifier,
         text: Rope,
@@ -147,7 +148,7 @@ impl PluginServerHandler for Plugin {
 
     fn handle_did_change_text_document(
         &mut self,
-        language_id: String,
+        language_id: LanguageId,
         document: VersionedTextDocumentIdentifier,
         delta: RopeDelta,
         text: Rope,
@@ -200,7 +201,7 @@ impl Plugin {
                     initialization_options: configurations,
                     workspace_folders: None,
                 },
-                None,
+                LanguageId::Unknown,
                 None,
                 false,
             );

--- a/lapce-rpc/src/language_id.rs
+++ b/lapce-rpc/src/language_id.rs
@@ -1,0 +1,236 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Copy, Clone, Debug, Serialize, PartialEq, Eq)]
+pub enum LanguageId {
+    Cpp,
+    ObjectiveC,
+    Bat,
+    Clojure,
+    C,
+    CoffeeScript,
+    Csharp,
+    Css,
+    Dlang,
+    Diff,
+    Dart,
+    Dockerfile,
+    Elm,
+    Elixir,
+    Erlang,
+    Fsharp,
+    Git,
+    Go,
+    Groovy,
+    Handlebars,
+    Html,
+    Ini,
+    Java,
+    JavaScript,
+    JavaScriptReact,
+    Json,
+    Julia,
+    Kotlin,
+    Less,
+    Lua,
+    Makefile,
+    Markdown,
+    ObjectiveCpp,
+    Perl,
+    Perl6,
+    Php,
+    Proto,
+    Powershell,
+    Python,
+    R,
+    Ruby,
+    Rust,
+    Scss,
+    Scala,
+    ShellScript,
+    Sql,
+    Swift,
+    Svelte,
+    Toml,
+    TypeScript,
+    TypeScriptReact,
+    Tex,
+    Vb,
+    Xml,
+    Xsl,
+    Yaml,
+    Zig,
+    Vue,
+
+    ///
+    Unknown,
+}
+
+impl LanguageId {
+    pub fn from_path(path: &Path) -> LanguageId {
+        LanguageId::impl_from_path(path).unwrap_or(LanguageId::Unknown)
+    }
+
+    fn impl_from_path(path: &Path) -> Option<LanguageId> {
+        // recommended language_id values
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+        Some(match path.extension() {
+            Some(ext) => {
+                match ext.to_str()? {
+                    "C" | "H" => LanguageId::Cpp,
+                    "M" => LanguageId::ObjectiveC,
+                    // stop case-sensitive matching
+                    ext => {
+                        return Some(LanguageId::from_str(
+                            ext.to_lowercase().as_str(),
+                        ))
+                    }
+                }
+            }
+            // Handle paths without extension
+            #[allow(clippy::match_single_binding)]
+            None => match path.file_name()?.to_str()? {
+                // case-insensitive matching
+                filename => match filename.to_lowercase().as_str() {
+                    "dockerfile" => LanguageId::Dockerfile,
+                    "makefile" | "gnumakefile" => LanguageId::Makefile,
+                    _ => return None,
+                },
+            },
+        })
+    }
+
+    pub fn from_str(str: &str) -> LanguageId {
+        match str {
+            "bat" => LanguageId::Bat,
+            "clj" | "cljs" | "cljc" | "edn" => LanguageId::Clojure,
+            "coffee" => LanguageId::CoffeeScript,
+            "c" | "h" => LanguageId::C,
+            "cpp" | "hpp" | "cxx" | "hxx" | "c++" | "h++" | "cc" | "hh" => {
+                LanguageId::Cpp
+            }
+            "cs" | "csx" => LanguageId::Csharp,
+            "css" => LanguageId::Css,
+            "d" | "di" | "dlang" => LanguageId::Dlang,
+            "diff" | "patch" => LanguageId::Diff,
+            "dart" => LanguageId::Dart,
+            "dockerfile" => LanguageId::Dockerfile,
+            "elm" => LanguageId::Elm,
+            "ex" | "exs" => LanguageId::Elixir,
+            "erl" | "hrl" => LanguageId::Elixir,
+            "fs" | "fsi" | "fsx" | "fsscript" => LanguageId::Fsharp,
+            "git-commit" | "git-rebase" => LanguageId::Git,
+            "go" => LanguageId::Go,
+            "groovy" | "gvy" | "gy" | "gsh" => LanguageId::Groovy,
+            "hbs" => LanguageId::Handlebars,
+            "htm" | "html" | "xhtml" => LanguageId::Html,
+            "ini" => LanguageId::Ini,
+            "java" | "class" => LanguageId::Java,
+            "js" => LanguageId::JavaScript,
+            "jsx" => LanguageId::JavaScriptReact,
+            "json" => LanguageId::Json,
+            "jl" => LanguageId::Julia,
+            "kt" | "kts" => LanguageId::Kotlin,
+            "less" => LanguageId::Less,
+            "lua" => LanguageId::Lua,
+            "makefile" | "gnumakefile" => LanguageId::Makefile,
+            "md" | "markdown" => LanguageId::Markdown,
+            "m" => LanguageId::ObjectiveC,
+            "mm" => LanguageId::ObjectiveCpp,
+            "plx" | "pl" | "pm" | "xs" | "t" | "pod" | "cgi" => LanguageId::Perl,
+            "p6" | "pm6" | "pod6" | "t6" | "raku" | "rakumod" | "rakudoc"
+            | "rakutest" => LanguageId::Perl6,
+            "php" | "phtml" | "pht" | "phps" => LanguageId::Php,
+            "proto" => LanguageId::Proto,
+            "ps1" | "ps1xml" | "psc1" | "psm1" | "psd1" | "pssc" | "psrc" => {
+                LanguageId::Powershell
+            }
+            "py" | "pyi" | "pyc" | "pyd" | "pyw" => LanguageId::Python,
+            "r" => LanguageId::R,
+            "rb" => LanguageId::Ruby,
+            "rs" => LanguageId::Rust,
+            "scss" | "sass" => LanguageId::Scss,
+            "sc" | "scala" => LanguageId::Scala,
+            "sh" | "bash" | "zsh" => LanguageId::ShellScript,
+            "sql" => LanguageId::Sql,
+            "swift" => LanguageId::Swift,
+            "svelte" => LanguageId::Svelte,
+            "toml" => LanguageId::Toml,
+            "ts" => LanguageId::TypeScript,
+            "tsx" => LanguageId::TypeScriptReact,
+            "tex" => LanguageId::Tex,
+            "vb" => LanguageId::Vb,
+            "xml" => LanguageId::Xml,
+            "xsl" => LanguageId::Xsl,
+            "yml" | "yaml" => LanguageId::Yaml,
+            "zig" => LanguageId::Zig,
+            "vue" => LanguageId::Vue,
+            _ => LanguageId::Unknown,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LanguageId::Cpp => todo!(),
+            LanguageId::ObjectiveC => todo!(),
+            LanguageId::Bat => todo!(),
+            LanguageId::Clojure => todo!(),
+            LanguageId::C => todo!(),
+            LanguageId::CoffeeScript => todo!(),
+            LanguageId::Csharp => todo!(),
+            LanguageId::Css => todo!(),
+            LanguageId::Dlang => todo!(),
+            LanguageId::Diff => todo!(),
+            LanguageId::Dart => todo!(),
+            LanguageId::Dockerfile => todo!(),
+            LanguageId::Elm => todo!(),
+            LanguageId::Elixir => todo!(),
+            LanguageId::Erlang => todo!(),
+            LanguageId::Fsharp => todo!(),
+            LanguageId::Git => todo!(),
+            LanguageId::Go => todo!(),
+            LanguageId::Groovy => todo!(),
+            LanguageId::Handlebars => todo!(),
+            LanguageId::Html => todo!(),
+            LanguageId::Ini => todo!(),
+            LanguageId::Java => todo!(),
+            LanguageId::JavaScript => todo!(),
+            LanguageId::JavaScriptReact => todo!(),
+            LanguageId::Json => todo!(),
+            LanguageId::Julia => todo!(),
+            LanguageId::Kotlin => todo!(),
+            LanguageId::Less => todo!(),
+            LanguageId::Lua => todo!(),
+            LanguageId::Makefile => todo!(),
+            LanguageId::Markdown => todo!(),
+            LanguageId::ObjectiveCpp => todo!(),
+            LanguageId::Perl => todo!(),
+            LanguageId::Perl6 => todo!(),
+            LanguageId::Php => todo!(),
+            LanguageId::Proto => todo!(),
+            LanguageId::Powershell => todo!(),
+            LanguageId::Python => todo!(),
+            LanguageId::R => todo!(),
+            LanguageId::Ruby => todo!(),
+            LanguageId::Rust => todo!(),
+            LanguageId::Scss => todo!(),
+            LanguageId::Scala => todo!(),
+            LanguageId::ShellScript => todo!(),
+            LanguageId::Sql => todo!(),
+            LanguageId::Swift => todo!(),
+            LanguageId::Svelte => todo!(),
+            LanguageId::Toml => todo!(),
+            LanguageId::TypeScript => todo!(),
+            LanguageId::TypeScriptReact => todo!(),
+            LanguageId::Tex => todo!(),
+            LanguageId::Vb => todo!(),
+            LanguageId::Xml => todo!(),
+            LanguageId::Xsl => todo!(),
+            LanguageId::Yaml => todo!(),
+            LanguageId::Zig => todo!(),
+            LanguageId::Vue => todo!(),
+            LanguageId::Unknown => todo!(),
+        }
+    }
+}

--- a/lapce-rpc/src/language_id.rs
+++ b/lapce-rpc/src/language_id.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Copy, Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Deserialize, Clone, Debug, Serialize, PartialEq, Eq)]
 pub enum LanguageId {
     Cpp,
     ObjectiveC,
@@ -233,4 +233,11 @@ impl LanguageId {
             LanguageId::Unknown => todo!(),
         }
     }
+}
+
+#[test]
+fn test_language_id_size() {
+    assert_eq!(std::mem::size_of::<LanguageId>(), 1);
+    assert_eq!(std::mem::size_of::<String>(), 24);
+    assert_eq!(std::mem::size_of::<Option<String>>(), 24);
 }

--- a/lapce-rpc/src/lib.rs
+++ b/lapce-rpc/src/lib.rs
@@ -4,6 +4,7 @@ pub mod buffer;
 pub mod core;
 pub mod counter;
 pub mod file;
+pub mod language_id;
 mod parse;
 pub mod plugin;
 pub mod proxy;

--- a/lapce-rpc/src/plugin.rs
+++ b/lapce-rpc/src/plugin.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, path::PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::counter::Counter;
+use crate::{counter::Counter, language_id::LanguageId};
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct PluginId(pub u64);
@@ -45,7 +45,7 @@ impl VoltInfo {
 #[derive(Deserialize, Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct VoltActivation {
-    pub language: Option<Vec<String>>,
+    pub language: Option<Vec<LanguageId>>,
     pub workspace_contains: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
Pros:
1. This means that it is 3x cheaper to move this thing around
2. Remove the need to wrap this in Option, which removes 1 usize of flag

Cons:
1. It might be harder to debug
2. We need to maintain the mapping between str <-> LanguageId. This can be fixed by introducing Other(String) variation.

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users