### PR TITLE
Add an option to disable moving the focus area when you type

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -45,6 +45,7 @@ render-whitespace = "none"
 show-indent-guide = true
 atomic-soft-tabs = false
 double-click = false
+move-focus-while-search = true
 
 [terminal]
 font-family = ""

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -470,6 +470,8 @@ pub struct EditorConfig {
     pub atomic_soft_tabs: bool,
     #[field_names(desc = "Use double click to open interact with file explorer")]
     pub double_click: bool,
+    #[field_names(desc = "Move the focus as you type in the global search box")]
+    pub move_focus_while_search: bool,
 }
 
 impl EditorConfig {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -821,6 +821,7 @@ impl LapceTab {
                             find.set_find(pattern, false, false);
                             find.visual = true;
                             if data.focus_area == FocusArea::Panel(PanelKind::Search)
+                                && data.config.editor.move_focus_while_search
                             {
                                 if let Some(widget_id) = *data.main_split.active {
                                     ctx.submit_command(Command::new(


### PR DESCRIPTION
It's extremely annoying when it flies to multiple places with each and every keystroke

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users