### PR TITLE
fix: remove remote web url copy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#1820](https://github.com/lapce/lapce/pull/1820): Add remote svg icon colour to theme, disable plugin settings when none are available
 - [#1988](https://github.com/lapce/lapce/pull/1987): Replace modal status background with background/foreground theme keys
+- [#2068](https://github.com/lapce/lapce/pull/2068): Remove `Copy remote file URL` command
 
 ### Features/Changes
 - [#1899](https://github.com/lapce/lapce/pull/1899): Improve sorting files with numbers

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -436,10 +436,6 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "source_control_commit")]
     SourceControlCommit,
 
-    #[strum(message = "Source Control: Copy Remote File Url")]
-    #[strum(serialize = "source_control_copy_active_file_remote_url")]
-    SourceControlCopyActiveFileRemoteUrl,
-
     #[strum(message = "Source Control: Discard File Changes")]
     #[strum(serialize = "source_control_discard_active_file_changes")]
     SourceControlDiscardActiveFileChanges,

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1730,29 +1730,6 @@ impl LapceTabData {
                     Cursor::new(CursorMode::Insert(Selection::caret(0)), None, None)
                 };
             }
-            LapceWorkbenchCommand::SourceControlCopyActiveFileRemoteUrl => {
-                if let Some(editor) = self.main_split.active_editor() {
-                    if let BufferContent::File(path) = &editor.content {
-                        let event_sink = ctx.get_external_handle();
-
-                        self.proxy.proxy_rpc.git_get_remote_file_url(
-                            path.clone(),
-                            move |result| {
-                                if let Ok(ProxyResponse::GitGetRemoteFileUrl {
-                                    file_url,
-                                }) = result
-                                {
-                                    let _ = event_sink.submit_command(
-                                        LAPCE_UI_COMMAND,
-                                        LapceUICommand::PutToClipboard(file_url),
-                                        Target::Auto,
-                                    );
-                                }
-                            },
-                        )
-                    }
-                }
-            }
             LapceWorkbenchCommand::SourceControlDiscardActiveFileChanges => {
                 if let Some(editor) = self.main_split.active_editor() {
                     if let BufferContent::File(path) = &editor.content {

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -33,7 +33,6 @@ use lapce_rpc::{
 use lapce_xi_rope::Rope;
 use lsp_types::{Position, Range, TextDocumentItem, Url};
 use parking_lot::Mutex;
-use regex::Regex;
 
 use crate::{
     buffer::{get_mod_time, load_file, Buffer},
@@ -390,17 +389,6 @@ impl ProxyHandler for Dispatcher {
                         proxy_rpc.handle_response(id, result);
                     },
                 );
-            }
-            GitGetRemoteFileUrl { file } => {
-                if let Some(workspace) = self.workspace.as_ref() {
-                    match git_get_remote_file_url(workspace, &file) {
-                        Ok(s) => self.proxy_rpc.handle_response(
-                            id,
-                            Ok(ProxyResponse::GitGetRemoteFileUrl { file_url: s }),
-                        ),
-                        Err(e) => eprintln!("{e:?}"),
-                    }
-                }
             }
             GetDefinition {
                 request_id,
@@ -1195,58 +1183,6 @@ fn file_get_head(workspace_path: &Path, path: &Path) -> Result<(String, String)>
         .with_context(|| "content bytes to string")?
         .to_string();
     Ok((id, content))
-}
-
-fn git_get_remote_file_url(workspace_path: &Path, file: &Path) -> Result<String> {
-    let repo = Repository::open(
-        workspace_path
-            .to_str()
-            .ok_or_else(|| anyhow!("can't to str"))?,
-    )?;
-
-    let head = repo.head()?;
-
-    let target_remote = repo.find_remote("origin")?;
-
-    let target_remote_file_url =
-        target_remote.url().ok_or_else(|| anyhow!("can't to str"))?;
-
-    // This Regex isn't perfect, but it's good enough for now
-    // git@github.com:rust-lang/rust.git
-    // https://github.com/rust-lang/rust.git
-
-    let git_repo_remote_regex = Regex::new(
-        r"^(?:git@|https://)(?P<host>[^:/]+)[:/](?P<org>[^/]+)/(?P<repo>.+)$",
-    )
-    .unwrap();
-
-    let (host, org, repo) =
-        if let Some(v) = git_repo_remote_regex.captures(target_remote_file_url) {
-            let host = v
-                .name("host")
-                .ok_or_else(|| anyhow!("can't to str"))?
-                .as_str();
-            let org = v
-                .name("org")
-                .ok_or_else(|| anyhow!("can't to str"))?
-                .as_str();
-            let repo = v
-                .name("repo")
-                .ok_or_else(|| anyhow!("can't to str"))?
-                .as_str();
-            (host, org, repo)
-        } else {
-            return Err(anyhow!("can't parse remote url"));
-        };
-
-    Ok(format!(
-        "https://{}/{}/{}/blob/{}/{}",
-        host,
-        org,
-        repo,
-        head.peel_to_commit()?.id(),
-        file.strip_prefix(workspace_path)?.to_str().unwrap()
-    ))
 }
 
 fn search_in_path(

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -73,9 +73,6 @@ pub enum ProxyRequest {
         path: PathBuf,
         positions: Vec<Position>,
     },
-    GitGetRemoteFileUrl {
-        file: PathBuf,
-    },
     GetReferences {
         path: PathBuf,
         position: Position,
@@ -805,14 +802,6 @@ impl ProxyRpcHandler {
         f: impl ProxyCallback + 'static,
     ) {
         self.request_async(ProxyRequest::PrepareRename { path, position }, f);
-    }
-
-    pub fn git_get_remote_file_url(
-        &self,
-        file: PathBuf,
-        f: impl ProxyCallback + 'static,
-    ) {
-        self.request_async(ProxyRequest::GitGetRemoteFileUrl { file }, f);
     }
 
     pub fn rename(


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Git doesn't have any guarantees about web interface so the command should not be provided by Lapce