### PR TITLE
fix: remove ssh timeout option on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#1971](https://github.com/lapce/lapce/pull/1971): Fix up/down movement on first/last line
 - [#2036](https://github.com/lapce/lapce/pull/2036): Fix movement on selections with up/down arrow keys
 - [#2056](https://github.com/lapce/lapce/pull/2056): Fix default directory of remote session file picker
+- [#2072](https://github.com/lapce/lapce/pull/2072): Fix connection issues from Windows to lapce proxy
 
 ## 0.2.5
 

--- a/lapce-data/src/proxy.rs
+++ b/lapce-data/src/proxy.rs
@@ -812,7 +812,7 @@ struct SshRemote {
 
 impl SshRemote {
     #[cfg(windows)]
-    const SSH_ARGS: &'static [&'static str] = &["-o", "ConnectTimeout=15"];
+    const SSH_ARGS: &'static [&'static str] = &[];
 
     #[cfg(unix)]
     const SSH_ARGS: &'static [&'static str] = &[


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Fixes #1993 
Fixes #1383 