### PR TITLE
Enable plugins to act as LSP themselves

### DIFF
--- a/lapce-proxy/src/plugin/lsp.rs
+++ b/lapce-proxy/src/plugin/lsp.rs
@@ -21,11 +21,14 @@ use lsp_types::{
     *,
 };
 use parking_lot::Mutex;
-use serde_json::{json, Value};
+use serde_json::Value;
 
-use super::psp::{
-    handle_plugin_server_message, PluginHandlerNotification, PluginHostHandler,
-    PluginServerHandler, PluginServerRpcHandler, RpcCallback,
+use super::{
+    client_capabilities,
+    psp::{
+        handle_plugin_server_message, PluginHandlerNotification, PluginHostHandler,
+        PluginServerHandler, PluginServerRpcHandler, RpcCallback,
+    },
 };
 use crate::{buffer::Buffer, plugin::PluginCatalogRpcHandler};
 
@@ -300,120 +303,12 @@ impl LspClient {
             .workspace
             .clone()
             .map(|p| Url::from_directory_path(p).unwrap());
-        let client_capabilities = ClientCapabilities {
-            text_document: Some(TextDocumentClientCapabilities {
-                synchronization: Some(TextDocumentSyncClientCapabilities {
-                    did_save: Some(true),
-                    dynamic_registration: Some(true),
-                    ..Default::default()
-                }),
-                completion: Some(CompletionClientCapabilities {
-                    completion_item: Some(CompletionItemCapability {
-                        snippet_support: Some(true),
-                        resolve_support: Some(
-                            CompletionItemCapabilityResolveSupport {
-                                properties: vec!["additionalTextEdits".to_string()],
-                            },
-                        ),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                }),
-                signature_help: Some(SignatureHelpClientCapabilities {
-                    signature_information: Some(SignatureInformationSettings {
-                        documentation_format: Some(vec![
-                            MarkupKind::Markdown,
-                            MarkupKind::PlainText,
-                        ]),
-                        parameter_information: Some(ParameterInformationSettings {
-                            label_offset_support: Some(true),
-                        }),
-                        active_parameter_support: Some(true),
-                    }),
-                    ..Default::default()
-                }),
-                hover: Some(HoverClientCapabilities {
-                    content_format: Some(vec![
-                        MarkupKind::Markdown,
-                        MarkupKind::PlainText,
-                    ]),
-                    ..Default::default()
-                }),
-                inlay_hint: Some(InlayHintClientCapabilities {
-                    ..Default::default()
-                }),
-                code_action: Some(CodeActionClientCapabilities {
-                    data_support: Some(true),
-                    resolve_support: Some(CodeActionCapabilityResolveSupport {
-                        properties: vec!["edit".to_string()],
-                    }),
-                    code_action_literal_support: Some(CodeActionLiteralSupport {
-                        code_action_kind: CodeActionKindLiteralSupport {
-                            value_set: vec![
-                                CodeActionKind::EMPTY.as_str().to_string(),
-                                CodeActionKind::QUICKFIX.as_str().to_string(),
-                                CodeActionKind::REFACTOR.as_str().to_string(),
-                                CodeActionKind::REFACTOR_EXTRACT
-                                    .as_str()
-                                    .to_string(),
-                                CodeActionKind::REFACTOR_INLINE.as_str().to_string(),
-                                CodeActionKind::REFACTOR_REWRITE
-                                    .as_str()
-                                    .to_string(),
-                                CodeActionKind::SOURCE.as_str().to_string(),
-                                CodeActionKind::SOURCE_ORGANIZE_IMPORTS
-                                    .as_str()
-                                    .to_string(),
-                                "quickassist".to_string(),
-                                "source.fixAll".to_string(),
-                            ],
-                        },
-                    }),
-                    ..Default::default()
-                }),
-                semantic_tokens: Some(SemanticTokensClientCapabilities {
-                    ..Default::default()
-                }),
-                type_definition: Some(GotoCapability {
-                    // Note: This is explicitly specified rather than left to the Default because
-                    // of a bug in lsp-types https://github.com/gluon-lang/lsp-types/pull/244
-                    link_support: Some(false),
-                    ..Default::default()
-                }),
-                definition: Some(GotoCapability {
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }),
-            window: Some(WindowClientCapabilities {
-                work_done_progress: Some(true),
-                show_message: Some(ShowMessageRequestClientCapabilities {
-                    message_action_item: Some(MessageActionItemCapabilities {
-                        additional_properties_support: Some(true),
-                    }),
-                }),
-                ..Default::default()
-            }),
-            workspace: Some(WorkspaceClientCapabilities {
-                symbol: Some(WorkspaceSymbolClientCapabilities {
-                    ..Default::default()
-                }),
-                configuration: Some(false),
-                ..Default::default()
-            }),
-
-            experimental: Some(json!({
-                "serverStatusNotification": true,
-            })),
-            ..Default::default()
-        };
-
         #[allow(deprecated)]
         let params = InitializeParams {
             process_id: Some(process::id()),
             root_uri: root_uri.clone(),
             initialization_options: self.options.clone(),
-            capabilities: client_capabilities,
+            capabilities: client_capabilities(),
             trace: Some(TraceValue::Verbose),
             workspace_folders: root_uri.map(|uri| {
                 vec![WorkspaceFolder {

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -36,17 +36,27 @@ use lsp_types::{
         ResolveCompletionItem, SelectionRangeRequest, SemanticTokensFullRequest,
         SignatureHelpRequest, WorkspaceSymbol,
     },
-    CodeAction, CodeActionContext, CodeActionParams, CodeActionResponse,
-    CompletionItem, CompletionParams, CompletionResponse, Diagnostic,
-    DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
-    FormattingOptions, GotoDefinitionParams, GotoDefinitionResponse, Hover,
-    HoverParams, InlayHint, InlayHintParams, Location, PartialResultParams,
-    Position, PrepareRenameResponse, Range, ReferenceContext, ReferenceParams,
-    RenameParams, SelectionRange, SelectionRangeParams, SemanticTokens,
-    SemanticTokensParams, SignatureHelp, SignatureHelpParams, SymbolInformation,
-    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, TextEdit,
-    Url, VersionedTextDocumentIdentifier, WorkDoneProgressParams, WorkspaceEdit,
-    WorkspaceSymbolParams,
+    ClientCapabilities, CodeAction, CodeActionCapabilityResolveSupport,
+    CodeActionClientCapabilities, CodeActionContext, CodeActionKind,
+    CodeActionKindLiteralSupport, CodeActionLiteralSupport, CodeActionParams,
+    CodeActionResponse, CompletionClientCapabilities, CompletionItem,
+    CompletionItemCapability, CompletionItemCapabilityResolveSupport,
+    CompletionParams, CompletionResponse, Diagnostic, DocumentFormattingParams,
+    DocumentSymbolParams, DocumentSymbolResponse, FormattingOptions, GotoCapability,
+    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverClientCapabilities,
+    HoverParams, InlayHint, InlayHintClientCapabilities, InlayHintParams, Location,
+    MarkupKind, MessageActionItemCapabilities, ParameterInformationSettings,
+    PartialResultParams, Position, PrepareRenameResponse, Range, ReferenceContext,
+    ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
+    SemanticTokens, SemanticTokensClientCapabilities, SemanticTokensParams,
+    ShowMessageRequestClientCapabilities, SignatureHelp,
+    SignatureHelpClientCapabilities, SignatureHelpParams,
+    SignatureInformationSettings, SymbolInformation, TextDocumentClientCapabilities,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
+    TextDocumentSyncClientCapabilities, TextEdit, Url,
+    VersionedTextDocumentIdentifier, WindowClientCapabilities,
+    WorkDoneProgressParams, WorkspaceClientCapabilities, WorkspaceEdit,
+    WorkspaceSymbolClientCapabilities, WorkspaceSymbolParams,
 };
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -1072,4 +1082,104 @@ pub fn remove_volt(
         Ok(())
     });
     Ok(())
+}
+
+fn client_capabilities() -> ClientCapabilities {
+    ClientCapabilities {
+        text_document: Some(TextDocumentClientCapabilities {
+            synchronization: Some(TextDocumentSyncClientCapabilities {
+                did_save: Some(true),
+                dynamic_registration: Some(true),
+                ..Default::default()
+            }),
+            completion: Some(CompletionClientCapabilities {
+                completion_item: Some(CompletionItemCapability {
+                    snippet_support: Some(true),
+                    resolve_support: Some(CompletionItemCapabilityResolveSupport {
+                        properties: vec!["additionalTextEdits".to_string()],
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            signature_help: Some(SignatureHelpClientCapabilities {
+                signature_information: Some(SignatureInformationSettings {
+                    documentation_format: Some(vec![
+                        MarkupKind::Markdown,
+                        MarkupKind::PlainText,
+                    ]),
+                    parameter_information: Some(ParameterInformationSettings {
+                        label_offset_support: Some(true),
+                    }),
+                    active_parameter_support: Some(true),
+                }),
+                ..Default::default()
+            }),
+            hover: Some(HoverClientCapabilities {
+                content_format: Some(vec![
+                    MarkupKind::Markdown,
+                    MarkupKind::PlainText,
+                ]),
+                ..Default::default()
+            }),
+            inlay_hint: Some(InlayHintClientCapabilities {
+                ..Default::default()
+            }),
+            code_action: Some(CodeActionClientCapabilities {
+                data_support: Some(true),
+                resolve_support: Some(CodeActionCapabilityResolveSupport {
+                    properties: vec!["edit".to_string()],
+                }),
+                code_action_literal_support: Some(CodeActionLiteralSupport {
+                    code_action_kind: CodeActionKindLiteralSupport {
+                        value_set: vec![
+                            CodeActionKind::EMPTY.as_str().to_string(),
+                            CodeActionKind::QUICKFIX.as_str().to_string(),
+                            CodeActionKind::REFACTOR.as_str().to_string(),
+                            CodeActionKind::REFACTOR_EXTRACT.as_str().to_string(),
+                            CodeActionKind::REFACTOR_INLINE.as_str().to_string(),
+                            CodeActionKind::REFACTOR_REWRITE.as_str().to_string(),
+                            CodeActionKind::SOURCE.as_str().to_string(),
+                            CodeActionKind::SOURCE_ORGANIZE_IMPORTS
+                                .as_str()
+                                .to_string(),
+                            "quickassist".to_string(),
+                            "source.fixAll".to_string(),
+                        ],
+                    },
+                }),
+                ..Default::default()
+            }),
+            semantic_tokens: Some(SemanticTokensClientCapabilities {
+                ..Default::default()
+            }),
+            type_definition: Some(GotoCapability {
+                // Note: This is explicitly specified rather than left to the Default because
+                // of a bug in lsp-types https://github.com/gluon-lang/lsp-types/pull/244
+                link_support: Some(false),
+                ..Default::default()
+            }),
+            definition: Some(GotoCapability {
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        window: Some(WindowClientCapabilities {
+            work_done_progress: Some(true),
+            show_message: Some(ShowMessageRequestClientCapabilities {
+                message_action_item: Some(MessageActionItemCapabilities {
+                    additional_properties_support: Some(true),
+                }),
+            }),
+            ..Default::default()
+        }),
+        workspace: Some(WorkspaceClientCapabilities {
+            symbol: Some(WorkspaceSymbolClientCapabilities {
+                ..Default::default()
+            }),
+            configuration: Some(false),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
 }

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -285,10 +285,12 @@ impl PluginServerRpcHandler {
         }
     }
 
-    /// Make a request to plugin/language server and get the response
-    /// when check is true, the request will be in the handler mainloop to
-    /// do checks like if the server has the capability of the request
-    /// when check is false, the request will be sent out straight away
+    /// Make a request to plugin/language server and get the response.
+    ///
+    /// When check is true, the request will be in the handler mainloop to
+    /// do checks like if the server has the capability of the request.
+    ///
+    /// When check is false, the request will be sent out straight away.
     pub fn server_request<P: Serialize>(
         &self,
         method: &'static str,

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -482,6 +482,17 @@ pub fn start_volt(
                     pattern: None,
                     scheme: None,
                 })
+                .chain(
+                    meta.activation
+                        .iter()
+                        .flat_map(|m| m.workspace_contains.iter().flatten())
+                        .cloned()
+                        .map(|s| DocumentFilter {
+                            language: None,
+                            pattern: Some(s),
+                            scheme: None,
+                        }),
+                )
                 .collect(),
             rpc.clone(),
             plugin_rpc.clone(),


### PR DESCRIPTION
As of now, plugins are merely there to spawn the actual LSP by way of `host/startLspServer` command and then it does _nothing_ because it never registered any capabilities and lapce itself never cared about the response from the init request. This changes that.

1. Use volt activation filters for the document filters.
2. Extract out the client capabilities struct to a function and pass it to the plugin as well.

This does require the plugin themselves to reply to the host init request like here: https://github.com/lapce/lapce-plugin-rust/pull/17

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users