### PR TITLE
feat: configurable diff context lines

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -46,6 +46,7 @@ show-indent-guide = true
 atomic-soft-tabs = false
 double-click = false
 move-focus-while-search = true
+diff-context-lines=3
 
 [terminal]
 font-family = ""

--- a/lapce-core/src/buffer/mod.rs
+++ b/lapce-core/src/buffer/mod.rs
@@ -1068,7 +1068,7 @@ pub fn rope_diff(
     right_rope: Rope,
     rev: u64,
     atomic_rev: Arc<AtomicU64>,
-    extend_lines: usize,
+    context_lines: Option<usize>,
 ) -> Option<Vec<DiffLines>> {
     let left_lines = left_rope.lines(..).collect::<Vec<Cow<str>>>();
     let right_lines = right_rope.lines(..).collect::<Vec<Cow<str>>>();
@@ -1197,7 +1197,8 @@ pub fn rope_diff(
             right_count - trailing_equals..right_count,
         ));
     }
-    if !changes.is_empty() {
+    if !changes.is_empty() && context_lines.is_some() {
+        let context_lines = context_lines.unwrap();
         let changes_last = changes.len() - 1;
         for (i, change) in changes.clone().iter().enumerate().rev() {
             if atomic_rev.load(atomic::Ordering::Acquire) != rev {
@@ -1205,50 +1206,50 @@ pub fn rope_diff(
             }
             if let DiffLines::Both(l, r) = change {
                 if i == 0 || i == changes_last {
-                    if r.len() > extend_lines {
+                    if r.len() > context_lines {
                         if i == 0 {
                             changes[i] = DiffLines::Both(
-                                l.end - extend_lines..l.end,
-                                r.end - extend_lines..r.end,
+                                l.end - context_lines..l.end,
+                                r.end - context_lines..r.end,
                             );
                             changes.insert(
                                 i,
                                 DiffLines::Skip(
-                                    l.start..l.end - extend_lines,
-                                    r.start..r.end - extend_lines,
+                                    l.start..l.end - context_lines,
+                                    r.start..r.end - context_lines,
                                 ),
                             );
                         } else {
                             changes[i] = DiffLines::Skip(
-                                l.start + extend_lines..l.end,
-                                r.start + extend_lines..r.end,
+                                l.start + context_lines..l.end,
+                                r.start + context_lines..r.end,
                             );
                             changes.insert(
                                 i,
                                 DiffLines::Both(
-                                    l.start..l.start + extend_lines,
-                                    r.start..r.start + extend_lines,
+                                    l.start..l.start + context_lines,
+                                    r.start..r.start + context_lines,
                                 ),
                             );
                         }
                     }
-                } else if r.len() > extend_lines * 2 {
+                } else if r.len() > context_lines * 2 {
                     changes[i] = DiffLines::Both(
-                        l.end - extend_lines..l.end,
-                        r.end - extend_lines..r.end,
+                        l.end - context_lines..l.end,
+                        r.end - context_lines..r.end,
                     );
                     changes.insert(
                         i,
                         DiffLines::Skip(
-                            l.start + extend_lines..l.end - extend_lines,
-                            r.start + extend_lines..r.end - extend_lines,
+                            l.start + context_lines..l.end - context_lines,
+                            r.start + context_lines..r.end - context_lines,
                         ),
                     );
                     changes.insert(
                         i,
                         DiffLines::Both(
-                            l.start..l.start + extend_lines,
-                            r.start..r.start + extend_lines,
+                            l.start..l.start + context_lines,
+                            r.start..r.start + context_lines,
                         ),
                     );
                 }

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -849,7 +849,7 @@ pub enum LapceUICommand {
         rev: u64,
         history: String,
         changes: Arc<Vec<DiffLines>>,
-        diff_extend_lines: usize,
+        diff_context_lines: i32,
     },
     /// Publish diagnostics changes (from the proxy)
     PublishDiagnostics(PublishDiagnosticsParams),

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -472,7 +472,7 @@ pub struct EditorConfig {
     #[field_names(desc = "Move the focus as you type in the global search box")]
     pub move_focus_while_search: bool,
     #[field_names(
-        desc = "Set the default number of visible lines above and below the diff block"
+        desc = "Set the default number of visible lines above and below the diff block (-1 for infinite)"
     )]
     pub diff_context_lines: i32,
 }

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -471,6 +471,10 @@ pub struct EditorConfig {
     pub double_click: bool,
     #[field_names(desc = "Move the focus as you type in the global search box")]
     pub move_focus_while_search: bool,
+    #[field_names(
+        desc = "Set the default number of visible lines above and below the diff block"
+    )]
+    pub diff_context_lines: i32,
 }
 
 impl EditorConfig {

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -3389,7 +3389,7 @@ impl LapceMainSplitData {
 
             // Since we don't have document loaded, we'll have to retrieve it from the proxy
             // So, the document is not immediately filled with content!
-            doc.retrieve_file(vec![(editor_view_id, location)], None, cb);
+            doc.retrieve_file(vec![(editor_view_id, location)], None, cb, config);
             self.open_docs.insert(path.clone(), Arc::new(doc));
         } else {
             let doc = self.open_docs.get_mut(&path).unwrap().clone();
@@ -3423,7 +3423,8 @@ impl LapceMainSplitData {
                 let doc = self.open_docs.get_mut(&path).unwrap();
                 // TODO(minor): Could we avoid this make mut definitely cloning the `Document` by
                 // early-dropping our held doc above?
-                Arc::make_mut(doc).retrieve_history(version);
+                Arc::make_mut(doc)
+                    .retrieve_history(version, config.editor.diff_context_lines);
             }
 
             let editor = self.get_editor_or_new(
@@ -3601,7 +3602,7 @@ impl LapceMainSplitData {
                     .get(&path.to_str().unwrap().to_string())
                     .map(Rope::from);
                 Arc::make_mut(main_split_data.open_docs.get_mut(&path).unwrap())
-                    .retrieve_file(locations.clone(), unsaved_buffer, None);
+                    .retrieve_file(locations.clone(), unsaved_buffer, None, config);
             }
         } else {
             main_split_data.splits.insert(

--- a/lapce-data/src/history.rs
+++ b/lapce-data/src/history.rs
@@ -410,7 +410,7 @@ impl DocumentHistory {
                         rev,
                         history: "head".to_string(),
                         changes: Arc::new(changes),
-                        diff_context_lines: diff_context_lines,
+                        diff_context_lines,
                     },
                     Target::Widget(tab_id),
                 );

--- a/lapce-data/src/history.rs
+++ b/lapce-data/src/history.rs
@@ -36,7 +36,7 @@ pub struct DocumentHistory {
     line_styles: Rc<RefCell<LineStyles>>,
     changes: Arc<Vec<DiffLines>>,
     text_layouts: Rc<RefCell<TextLayoutCache>>,
-    diff_extend_lines: usize,
+    diff_context_lines: i32,
 }
 
 impl druid::Data for DocumentHistory {
@@ -58,9 +58,9 @@ impl druid::Data for DocumentHistory {
         }
     }
 }
-pub const DEFAULT_DIFF_EXTEND_LINES: usize = 3;
+pub const DEFAULT_DIFF_CONTEXT_LINES: usize = 3;
 impl DocumentHistory {
-    pub fn new(version: String) -> Self {
+    pub fn new(version: String, diff_context_lines: i32) -> Self {
         Self {
             version,
             buffer: None,
@@ -68,7 +68,7 @@ impl DocumentHistory {
             line_styles: Rc::new(RefCell::new(LineStyles::new())),
             text_layouts: Rc::new(RefCell::new(TextLayoutCache::new())),
             changes: Arc::new(Vec::new()),
-            diff_extend_lines: DEFAULT_DIFF_EXTEND_LINES,
+            diff_context_lines,
         }
     }
 
@@ -76,7 +76,7 @@ impl DocumentHistory {
         let mut buffer = Buffer::new("");
         buffer.init_content(content);
         self.buffer = Some(buffer);
-        self.trigger_update_change(doc, DEFAULT_DIFF_EXTEND_LINES);
+        self.trigger_update_change(doc);
         self.retrieve_history_styles(doc);
     }
 
@@ -353,14 +353,14 @@ impl DocumentHistory {
                     rev,
                     history: "head".to_string(),
                     changes: Arc::new(changes),
-                    diff_extend_lines: self.diff_extend_lines,
+                    diff_context_lines: self.diff_context_lines,
                 },
                 Target::Widget(tab_id),
             );
         }
     }
 
-    pub fn trigger_update_change(&self, doc: &Document, diff_extend_lines: usize) {
+    pub fn trigger_update_change(&self, doc: &Document) {
         if self.buffer.is_none() {
             return;
         }
@@ -373,7 +373,17 @@ impl DocumentHistory {
             let right_rope = doc.buffer().text().clone();
             let event_sink = doc.event_sink.clone();
             let tab_id = doc.tab_id;
+            let diff_context_lines = self.diff_context_lines;
             rayon::spawn(move || {
+                let context_lines = if diff_context_lines == -1 {
+                    // infinite context lines
+                    None
+                } else if diff_context_lines < 0 {
+                    // default context lines
+                    Some(DEFAULT_DIFF_CONTEXT_LINES)
+                } else {
+                    Some(diff_context_lines as usize)
+                };
                 if atomic_rev.load(atomic::Ordering::Acquire) != rev {
                     return;
                 }
@@ -382,7 +392,7 @@ impl DocumentHistory {
                     right_rope,
                     rev,
                     atomic_rev.clone(),
-                    diff_extend_lines,
+                    context_lines,
                 );
                 if changes.is_none() {
                     return;
@@ -400,7 +410,7 @@ impl DocumentHistory {
                         rev,
                         history: "head".to_string(),
                         changes: Arc::new(changes),
-                        diff_extend_lines,
+                        diff_context_lines: diff_context_lines,
                     },
                     Target::Widget(tab_id),
                 );
@@ -412,17 +422,17 @@ impl DocumentHistory {
         &self.changes
     }
 
-    pub fn diff_extend_lines(&self) -> usize {
-        self.diff_extend_lines
+    pub fn diff_context_lines(&self) -> i32 {
+        self.diff_context_lines
     }
 
     pub fn update_changes(
         &mut self,
         changes: Arc<Vec<DiffLines>>,
-        diff_extend_lines: usize,
+        diff_context_lines: i32,
     ) {
         self.changes = changes;
-        self.diff_extend_lines = diff_extend_lines;
+        self.diff_context_lines = diff_context_lines;
     }
 
     pub fn update_styles(&mut self, styles: Arc<Spans<Style>>) {

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -883,7 +883,11 @@ impl LapceTab {
                     } => {
                         let doc = data.main_split.open_docs.get_mut(path).unwrap();
                         let doc = Arc::make_mut(doc);
-                        doc.load_history(version, content.clone());
+                        doc.load_history(
+                            version,
+                            content.clone(),
+                            data.config.editor.diff_context_lines,
+                        );
                         ctx.set_handled();
                     }
                     LapceUICommand::PrepareRename {
@@ -1802,7 +1806,7 @@ impl LapceTab {
                         rev,
                         history,
                         changes,
-                        diff_extend_lines,
+                        diff_context_lines,
                         ..
                     } => {
                         ctx.set_handled();
@@ -1811,7 +1815,7 @@ impl LapceTab {
                             *rev,
                             history,
                             changes.clone(),
-                            *diff_extend_lines,
+                            *diff_context_lines,
                         );
                     }
                     LapceUICommand::UpdateHistoryStyle {


### PR DESCRIPTION
issue: https://github.com/lapce/lapce/issues/2029


- [x]  configurable diff context lines
![image](https://user-images.githubusercontent.com/4404609/216007080-98a72fe9-0d67-42e6-a777-203b0be3befe.png)
![image](https://user-images.githubusercontent.com/4404609/216004653-f82f50ed-fbf7-461e-bc6f-02013f4a9852.png)
- [x]  infinite context lines ( -1 )
![image](https://user-images.githubusercontent.com/4404609/216004779-a034c06b-82e5-41a7-aa86-6d1d370bfc67.png)
- [x]  default context lines ( 3)
![image](https://user-images.githubusercontent.com/4404609/216007419-67feda10-a710-486b-a45c-0e2409d9d32b.png)





- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users