### PR TITLE
Incorrect version extraction and comparison in proxy.sh

### DIFF
--- a/extra/proxy.sh
+++ b/extra/proxy.sh
@@ -14,7 +14,7 @@ test_cmd() {
 
 _TMP='/tmp'
 # proxy version
-_VER="${1}"
+_VER=$(echo ${1} | grep -Po '\d+.\d+.\d+')
 # proxy directory
 # eval to resolve '~' into proper user dir
 eval _DIR="'${2}'"
@@ -22,10 +22,10 @@ eval _DIR="'${2}'"
 if [ -e "${_DIR}/lapce" ]; then
   chmod +x "${_DIR}/lapce"
 
-  _ver=$("${_DIR}/lapce" --version | cut -d'v' -f2)
+  _ver=$("${_DIR}/lapce" --version | grep -Po '\d+.\d+.\d+')
 
   printf '[DEBUG]: %s = %s\n' "${_ver}" "${_VER}"
-  if [ "${_ver}" = "${_VER}" ]; then
+  if [ "${_ver}" != "${_VER}" ]; then
     printf 'Proxy outdated. Replacing proxy\n'
     rm "${_DIR}/lapce"
   else


### PR DESCRIPTION
Previous version number extraction was incorrect resulting in no proxy update on remote after upgrading to 0.2.5, see log example below :

`[lapce_data::proxy::upload_file][DEBUG] [DEBUG]: Lapce 0.2.4 = v0.2.5Proxy already exists`

The changes make sure no matter what format input version and extracted version have, as long as those strings contain xx.xx.xx version number, they can be compared. 

Also the `=` should be `!=` 
