### PR TITLE
Fixed a deadlock when trying to initialize LSPs

### DIFF
--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -465,7 +465,6 @@ pub fn start_volt(
             .unwrap();
         for msg in io_rx {
             if let Ok(msg) = serde_json::to_string(&msg) {
-                println!("plugin stdin:\n{msg}");
                 let _ = writeln!(stdin.write().unwrap(), "{msg}");
             }
             if let Err(err) = handle_rpc.call(&mut store, ()) {


### PR DESCRIPTION
The deadlock was introduced in this PR here when the thread is removed. A better alternative to this PR: https://github.com/lapce/lapce/pull/2100 by using `server_request_async`. That other PR will still cause a deadlock, it just terminates the blocked request. This one should instead allow all requests to be served properly.

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users