### PR TITLE
Fix crash when switching plugin tabs too fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [#2056](https://github.com/lapce/lapce/pull/2056): Fix default directory of remote session file picker
 - [#2072](https://github.com/lapce/lapce/pull/2072): Fix connection issues from Windows to lapce proxy
 - [#2069](https://github.com/lapce/lapce/pull/2045): Fix not finding git repositories in parent path
+- [#2119](https://github.com/lapce/lapce/pull/2119) Fix crash when switching plugin tabs too quickly
 
 ## 0.2.5
 

--- a/lapce-data/src/markdown/layout_content.rs
+++ b/lapce-data/src/markdown/layout_content.rs
@@ -119,6 +119,14 @@ impl LayoutContent {
         }
     }
 
+    pub fn needs_rebuild(&self) -> bool {
+        match self {
+            LayoutContent::Text(layout) => layout.needs_rebuild(),
+            LayoutContent::BrokenImage { text } => text.needs_rebuild(),
+            LayoutContent::Image { .. } | LayoutContent::Separator { .. } => false,
+        }
+    }
+
     pub fn rebuild_if_needed(&mut self, factory: &mut PietText, env: &Env) {
         match self {
             LayoutContent::Text(layout) => {

--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -1220,9 +1220,11 @@ impl Widget<LapceTabData> for PluginInfo {
             y += self.gap;
 
             for layout in &self.readme_layout {
-                let origin = Point::new(padding + self.padding, y);
-                layout.draw(ctx, &data.images, &data.config, origin);
-                y += layout.size(&data.images, &data.config).height;
+                if !layout.needs_rebuild() {
+                    let origin = Point::new(padding + self.padding, y);
+                    layout.draw(ctx, &data.images, &data.config, origin);
+                    y += layout.size(&data.images, &data.config).height;
+                }
             }
         }
     }


### PR DESCRIPTION
I have tried to debug the actual cause but I can't find it. The only place where `readme_layout` is mutated is within the `event`. So the only thing I could think of is that the `layout` phase is skipped somehow?

So simply check if the layout needs to be rebuilt. Else skip.

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users