### PR TITLE
ci: do not build lapce twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-        
+
       - name: Fetch dependencies
         run: cargo fetch --locked
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run tests and coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
-          
+
       - name: Run doc tests
         run: cargo test --doc --workspace
 
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
@@ -94,7 +94,7 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-        
+
       - name: Fetch dependencies
         run: cargo fetch --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Fetch dependencies
         run: cargo fetch --locked
 
-      - name: Build
-        run: cargo build --frozen
-
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
@@ -50,7 +47,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run tests and coverage
-        run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --frozen --all-features --workspace --lcov --output-path lcov.info
 
       - name: Run doc tests
         run: cargo test --doc --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,11 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Run tests and coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
 
       - name: Run doc tests
         run: cargo test --doc --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: 'lapce-tests'
+          save-if: ${{ github.ref_name == 'master' }}
 
       - name: Fetch dependencies
         run: cargo fetch --locked
@@ -94,6 +97,9 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: 'lapce-clippy'
+          save-if: ${{ github.ref_name == 'master' }}
 
       - name: Fetch dependencies
         run: cargo fetch --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,9 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
+      # include doctests when resolved: https://github.com/taiki-e/cargo-llvm-cov/issues/2
       - name: Run tests and coverage
         run: cargo llvm-cov nextest --frozen --all-features --workspace --lcov --output-path lcov.info
-
-      - name: Run doc tests
-        run: cargo test --doc --workspace
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           TAG_NAME=${{ github.ref }}
           echo "TAG_NAME=${TAG_NAME#refs/tags/}" >> $GITHUB_ENV
-          
+
       - if: github.event_name == 'pull_request'
         run: echo 'TAG_NAME=debug' >> $GITHUB_ENV
 
@@ -49,7 +49,7 @@ jobs:
 
       - id: tag
         run: echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
-  
+
   windows:
     runs-on: windows-latest
     needs: tagname
@@ -65,7 +65,7 @@ jobs:
 
       - name: Update rust
         run: rustup update
-        
+
       - name: Fetch dependencies
         run: cargo fetch --locked
 
@@ -122,7 +122,7 @@ jobs:
         run: |
           apt-get -y update
           apt-get -y install cmake pkg-config libfontconfig-dev libgtk-3-dev
-      
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -304,8 +304,8 @@ jobs:
       # before running, and would therefore delete the downloaded artifacts
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3          
-      
+      - uses: actions/download-artifact@v3
+
       - if: github.event_name == 'workflow_dispatch'
         run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
 


### PR DESCRIPTION
- changed `llvm-cov` to use `nextest`
- removed building lapce since it wastes time and resources as it's rebuilt again for coverage + tests
- removed whitespace