### PR TITLE
fix: Do not auto close matching pairs in inappropriate inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [#2072](https://github.com/lapce/lapce/pull/2072): Fix connection issues from Windows to lapce proxy
 - [#2069](https://github.com/lapce/lapce/pull/2045): Fix not finding git repositories in parent path
 - [#2131](https://github.com/lapce/lapce/pull/2131): Fix overwriting symlink
+- [#2188](https://github.com/lapce/lapce/pull/2188): Fix auto closing matching pairs in inappropriate inputs
 
 ## 0.2.5
 

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -1372,12 +1372,19 @@ impl Document {
         config: &LapceConfig,
     ) -> Vec<(RopeDelta, InvalLines, SyntaxEdit)> {
         let old_cursor = cursor.mode.clone();
+        let auto_closing = config.editor.auto_closing_matching_pairs
+            & match self.content {
+                BufferContent::File(_) => true,
+                BufferContent::Local(_) => false,
+                BufferContent::SettingsValue(_) => false,
+                BufferContent::Scratch(_, _) => true,
+            };
         let deltas = Editor::insert(
             cursor,
             &mut self.buffer,
             s,
             self.syntax.as_ref(),
-            config.editor.auto_closing_matching_pairs,
+            auto_closing,
         );
         // Keep track of the change in the cursor mode for undo/redo
         self.buffer_mut().set_cursor_before(old_cursor);


### PR DESCRIPTION
Do not auto close parentheses/matching pairs when typing in settings, search fields, commit messages, ...
Fixes #2155 
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users