### PR TITLE
Truncate filename and path if they overflow

### DIFF
--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -25,7 +25,8 @@ use lapce_rpc::{file::FileNodeItem, source_control::FileDiff};
 use crate::{
     editor::view::LapceEditorView,
     panel::{LapcePanel, PanelHeaderKind, PanelSizing},
-    scroll::LapceScroll, truncated_text::truncate_if_necessary,
+    scroll::LapceScroll,
+    truncated_text::truncate_if_necessary,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -127,33 +128,29 @@ fn paint_single_file_node_item(
         ctx.draw_svg(&svg, rect, svg_color);
     }
 
-    let path = item.path_buf
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap();
+    let path = item.path_buf.file_name().unwrap().to_str().unwrap();
 
     let text_layout = ctx
         .text()
-        .new_text_layout(
-            path.to_string(),
-        )
+        .new_text_layout(path.to_string())
         .font(config.ui.font_family(), font_size)
         .text_color(config.get_color_unchecked(text_color).clone())
         .build()
         .unwrap();
-    
-    if let Some(text) = truncate_if_necessary(&text_layout, width - (38.0 + padding) - 5.0, path.to_string()) {
+
+    if let Some(text) = truncate_if_necessary(
+        &text_layout,
+        width - (38.0 + padding) - 5.0,
+        path.to_string(),
+    ) {
         let text_layout = ctx
             .text()
-            .new_text_layout(
-                text,
-            )
+            .new_text_layout(text)
             .font(config.ui.font_family(), font_size)
             .text_color(config.get_color_unchecked(text_color).clone())
             .build()
             .unwrap();
-        
+
         ctx.draw_text(
             &text_layout,
             Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
@@ -164,7 +161,6 @@ fn paint_single_file_node_item(
             Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
         );
     }
-
 }
 
 /// Paint the file node item, if it is in view, and its children
@@ -1391,7 +1387,11 @@ impl OpenEditorList {
         }
         let text_layout = text_layout.build().unwrap();
 
-        if let Some(truncated) = truncate_if_necessary(&text_layout, size.width - (svg_rect.x1 + 5.0) - 5.0, text) {
+        if let Some(truncated) = truncate_if_necessary(
+            &text_layout,
+            size.width - (svg_rect.x1 + 5.0) - 5.0,
+            text,
+        ) {
             let mut text_layout = ctx
                 .text()
                 .new_text_layout(truncated.to_string())
@@ -1418,7 +1418,8 @@ impl OpenEditorList {
                 &text_layout,
                 Point::new(
                     svg_rect.x1 + 5.0,
-                    i as f64 * self.line_height + text_layout.y_offset(self.line_height),
+                    i as f64 * self.line_height
+                        + text_layout.y_offset(self.line_height),
                 ),
             );
         } else {
@@ -1426,11 +1427,11 @@ impl OpenEditorList {
                 &text_layout,
                 Point::new(
                     svg_rect.x1 + 5.0,
-                    i as f64 * self.line_height + text_layout.y_offset(self.line_height),
+                    i as f64 * self.line_height
+                        + text_layout.y_offset(self.line_height),
                 ),
             );
         }
-
     }
 }
 

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -25,7 +25,7 @@ use lapce_rpc::{file::FileNodeItem, source_control::FileDiff};
 use crate::{
     editor::view::LapceEditorView,
     panel::{LapcePanel, PanelHeaderKind, PanelSizing},
-    scroll::LapceScroll,
+    scroll::LapceScroll, truncated_text::truncate_if_necessary,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -127,24 +127,44 @@ fn paint_single_file_node_item(
         ctx.draw_svg(&svg, rect, svg_color);
     }
 
+    let path = item.path_buf
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap();
+
     let text_layout = ctx
         .text()
         .new_text_layout(
-            item.path_buf
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string(),
+            path.to_string(),
         )
         .font(config.ui.font_family(), font_size)
         .text_color(config.get_color_unchecked(text_color).clone())
         .build()
         .unwrap();
-    ctx.draw_text(
-        &text_layout,
-        Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
-    );
+    
+    if let Some(text) = truncate_if_necessary(&text_layout, width - (38.0 + padding) - 5.0, path.to_string()) {
+        let text_layout = ctx
+            .text()
+            .new_text_layout(
+                text,
+            )
+            .font(config.ui.font_family(), font_size)
+            .text_color(config.get_color_unchecked(text_color).clone())
+            .build()
+            .unwrap();
+        
+        ctx.draw_text(
+            &text_layout,
+            Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
+        );
+    } else {
+        ctx.draw_text(
+            &text_layout,
+            Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
+        );
+    }
+
 }
 
 /// Paint the file node item, if it is in view, and its children
@@ -1352,7 +1372,7 @@ impl OpenEditorList {
         let total_len = text.len();
         let mut text_layout = ctx
             .text()
-            .new_text_layout(text)
+            .new_text_layout(text.to_string())
             .font(data.config.ui.font_family(), font_size)
             .text_color(
                 data.config
@@ -1370,13 +1390,47 @@ impl OpenEditorList {
             );
         }
         let text_layout = text_layout.build().unwrap();
-        ctx.draw_text(
-            &text_layout,
-            Point::new(
-                svg_rect.x1 + 5.0,
-                i as f64 * self.line_height + text_layout.y_offset(self.line_height),
-            ),
-        );
+
+        if let Some(truncated) = truncate_if_necessary(&text_layout, size.width - (svg_rect.x1 + 5.0) - 5.0, text) {
+            let mut text_layout = ctx
+                .text()
+                .new_text_layout(truncated.to_string())
+                .font(data.config.ui.font_family(), font_size)
+                .text_color(
+                    data.config
+                        .get_color_unchecked(LapceTheme::PANEL_FOREGROUND)
+                        .clone(),
+                );
+            // the second condition ensures that the 3 dots are als in the same color
+            if !hint.is_empty() && (truncated.len() - 3) > (total_len - hint.len()) {
+                text_layout = text_layout.range_attribute(
+                    total_len - hint.len()..(total_len + 2),
+                    TextAttribute::TextColor(
+                        data.config
+                            .get_color_unchecked(LapceTheme::PANEL_FOREGROUND_DIM)
+                            .clone(),
+                    ),
+                );
+            }
+            let text_layout = text_layout.build().unwrap();
+
+            ctx.draw_text(
+                &text_layout,
+                Point::new(
+                    svg_rect.x1 + 5.0,
+                    i as f64 * self.line_height + text_layout.y_offset(self.line_height),
+                ),
+            );
+        } else {
+            ctx.draw_text(
+                &text_layout,
+                Point::new(
+                    svg_rect.x1 + 5.0,
+                    i as f64 * self.line_height + text_layout.y_offset(self.line_height),
+                ),
+            );
+        }
+
     }
 }
 

--- a/lapce-ui/src/lib.rs
+++ b/lapce-ui/src/lib.rs
@@ -32,5 +32,5 @@ pub mod svg;
 mod tab;
 pub mod terminal;
 pub mod title;
-pub mod window;
 mod truncated_text;
+pub mod window;

--- a/lapce-ui/src/lib.rs
+++ b/lapce-ui/src/lib.rs
@@ -33,3 +33,4 @@ mod tab;
 pub mod terminal;
 pub mod title;
 pub mod window;
+mod truncated_text;

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use druid::{
     kurbo::BezPath,
-    piet::{Text, TextLayoutBuilder, TextAttribute},
+    piet::{Text, TextAttribute, TextLayoutBuilder},
     BoxConstraints, Command, Env, Event, EventCtx, LayoutCtx, LifeCycle,
     LifeCycleCtx, MouseButton, MouseEvent, PaintCtx, Point, Rect, RenderContext,
     Size, Target, UpdateCtx, Widget, WidgetExt, WidgetId,
@@ -21,7 +21,8 @@ use lapce_rpc::source_control::FileDiff;
 use crate::{
     button::Button,
     editor::view::LapceEditorView,
-    panel::{LapcePanel, PanelHeaderKind, PanelSizing}, truncated_text::truncate_if_necessary,
+    panel::{LapcePanel, PanelHeaderKind, PanelSizing},
+    truncated_text::truncate_if_necessary,
 };
 
 pub fn new_source_control_panel(data: &LapceTabData) -> LapcePanel {
@@ -427,10 +428,7 @@ impl Widget<LapceTabData> for SourceControlFileList {
                     ));
             ctx.draw_svg(&svg, rect, svg_color);
 
-            let file_name = path
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or("");
+            let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
 
             let folder = path
                 .parent()
@@ -475,7 +473,7 @@ impl Widget<LapceTabData> for SourceControlFileList {
             if let Some(truncated) = truncate_if_necessary(
                 &text_layout,
                 current_line.width() - self.line_height * 2.0 - svg_size * 2.0,
-                text
+                text,
             ) {
                 let mut text_layout = ctx
                     .text()
@@ -490,19 +488,23 @@ impl Widget<LapceTabData> for SourceControlFileList {
                             .clone(),
                     );
                 // the second condition ensures that the 3 dots are all in the same color
-                if !folder.is_empty() && (truncated.len() - 3) > (total_len - folder.len()){
+                if !folder.is_empty()
+                    && (truncated.len() - 3) > (total_len - folder.len())
+                {
                     text_layout = text_layout.range_attribute(
                         total_len - folder.len()..(total_len + 2),
                         TextAttribute::TextColor(
                             data.config
-                                .get_color_unchecked(LapceTheme::PANEL_FOREGROUND_DIM)
+                                .get_color_unchecked(
+                                    LapceTheme::PANEL_FOREGROUND_DIM,
+                                )
                                 .clone(),
                         ),
                     );
                 }
 
                 let text_layout = text_layout.build().unwrap();
-    
+
                 ctx.draw_text(
                     &text_layout,
                     Point::new(
@@ -556,4 +558,3 @@ impl Widget<LapceTabData> for SourceControlFileList {
         }
     }
 }
-

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -472,7 +472,11 @@ impl Widget<LapceTabData> for SourceControlFileList {
 
             let text_layout = text_layout.build().unwrap();
 
-            if let Some(truncated) = truncate_if_necessary(&text_layout, current_line.width() - self.line_height * 2.0 - svg_size * 2.0, text) {
+            if let Some(truncated) = truncate_if_necessary(
+                &text_layout,
+                current_line.width() - self.line_height * 2.0 - svg_size * 2.0,
+                text
+            ) {
                 let mut text_layout = ctx
                     .text()
                     .new_text_layout(truncated.to_string())
@@ -485,7 +489,7 @@ impl Widget<LapceTabData> for SourceControlFileList {
                             .get_color_unchecked(LapceTheme::PANEL_FOREGROUND)
                             .clone(),
                     );
-                // the second condition ensures that the 3 dots are als in the same color
+                // the second condition ensures that the 3 dots are all in the same color
                 if !folder.is_empty() && (truncated.len() - 3) > (total_len - folder.len()){
                     text_layout = text_layout.range_attribute(
                         total_len - folder.len()..(total_len + 2),

--- a/lapce-ui/src/truncated_text.rs
+++ b/lapce-ui/src/truncated_text.rs
@@ -1,25 +1,46 @@
 use druid::{piet::TextLayout, Point};
 
-
-pub fn truncate_if_necessary<T: TextLayout>(text_layout: &T, max_width: f64, text: String) -> Option<String> {
+/// This method truncates the text string if its width, as determined
+/// by the `text_layout` object, exceeds the specified `max_width`. If
+/// the text does not need to be truncated, the method returns `None`.
+///
+/// ## Parameters
+/// * `text_layout`: A reference to an object implementing the TextLayout trait.
+/// * `max_width`: A f64 value representing the maximum width allowed for the `text_layout`.
+/// * `text`: A String value representing the text to be truncated if necessary.
+///
+/// ## Return Value
+/// * If the text needs to be truncated, the method returns `Some(truncated_text)`,
+///   where `truncated_text` is a `String` value representing the truncated text.
+/// * If the text does not need to be truncated, the method returns `None`.
+pub fn truncate_if_necessary<T: TextLayout>(
+    text_layout: &T,
+    max_width: f64,
+    text: String,
+) -> Option<String> {
     if text_layout.size().width > max_width {
-        let hit_point = text_layout.hit_test_point(
-            Point::new(max_width, 0.0));
+        let hit_point = text_layout.hit_test_point(Point::new(max_width, 0.0));
 
         let end = text
             .char_indices()
-            .filter(|(i,_)| hit_point.idx.overflowing_sub(*i).0 < 3)
+            .filter(|(i, _)| hit_point.idx.overflowing_sub(*i).0 < 3)
             .collect::<Vec<(usize, char)>>();
 
         let end = if end.is_empty() {
+            // the text does exceed the `max_width`
+            // this should never be reached since it was
+            // already checked if the width is okay
             text.len()
         } else {
             end[0].0
         };
 
         if end == 0 {
+            // the length of the truncated string must be
+            // zero for it not to exceed the `max_width`
             Some("".to_string())
         } else {
+            // add ellipsis to the truncated text
             Some(format!("{}...", &text[0..end].trim_end()))
         }
     } else {

--- a/lapce-ui/src/truncated_text.rs
+++ b/lapce-ui/src/truncated_text.rs
@@ -1,0 +1,28 @@
+use druid::{piet::TextLayout, Point};
+
+
+pub fn truncate_if_necessary<T: TextLayout>(text_layout: &T, max_width: f64, text: String) -> Option<String> {
+    if text_layout.size().width > max_width {
+        let hit_point = text_layout.hit_test_point(
+            Point::new(max_width, 0.0));
+
+        let end = text
+            .char_indices()
+            .filter(|(i,_)| hit_point.idx.overflowing_sub(*i).0 < 3)
+            .collect::<Vec<(usize, char)>>();
+
+        let end = if end.is_empty() {
+            text.len()
+        } else {
+            end[0].0
+        };
+
+        if end == 0 {
+            Some("".to_string())
+        } else {
+            Some(format!("{}...", &text[0..end].trim_end()))
+        }
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
As described in #2043 the text overflows when it is too long. I added checks that determine if the text overflows and then truncate it + add an ellipsis (...) to it.

Fixes #2043 

This is my first pull request to an opensource project, so let me know what you think :)