### PR TITLE
Fix: truncate filenames when they overflow

### DIFF
--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -25,7 +25,8 @@ use lapce_rpc::{file::FileNodeItem, source_control::FileDiff};
 use crate::{
     editor::view::LapceEditorView,
     panel::{LapcePanel, PanelHeaderKind, PanelSizing},
-    scroll::LapceScroll, text::truncate,
+    scroll::LapceScroll,
+    text::truncate,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -128,7 +129,7 @@ fn paint_single_file_node_item(
     }
 
     let path = item.path_buf.file_name().unwrap().to_str().unwrap();
-    
+
     let text_layout = ctx
         .text()
         .new_text_layout(path.to_string())
@@ -1396,7 +1397,7 @@ impl OpenEditorList {
                         .get_color_unchecked(LapceTheme::PANEL_FOREGROUND)
                         .clone(),
                 );
-            
+
             // the second condition ensures that the 3 dots are als in the same color
             if !hint.is_empty() && (truncated.len() - 3) > (total_len - hint.len()) {
                 text_layout = text_layout.range_attribute(
@@ -1413,7 +1414,8 @@ impl OpenEditorList {
                 &text_layout,
                 Point::new(
                     svg_rect.x1 + 5.0,
-                    i as f64 * self.line_height + text_layout.y_offset(self.line_height),
+                    i as f64 * self.line_height
+                        + text_layout.y_offset(self.line_height),
                 ),
             );
         } else {
@@ -1421,7 +1423,8 @@ impl OpenEditorList {
                 &text_layout,
                 Point::new(
                     svg_rect.x1 + 5.0,
-                    i as f64 * self.line_height + text_layout.y_offset(self.line_height),
+                    i as f64 * self.line_height
+                        + text_layout.y_offset(self.line_height),
                 ),
             );
         }

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -127,24 +127,37 @@ fn paint_single_file_node_item(
         ctx.draw_svg(&svg, rect, svg_color);
     }
 
+    let path = item.path_buf.file_name().unwrap().to_str().unwrap();
+    
     let text_layout = ctx
         .text()
-        .new_text_layout(
-            item.path_buf
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string(),
-        )
+        .new_text_layout(path.to_string())
         .font(config.ui.font_family(), font_size)
         .text_color(config.get_color_unchecked(text_color).clone())
         .build()
         .unwrap();
-    ctx.draw_text(
-        &text_layout,
-        Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
-    );
+
+    let max_width = width - (38.0 + padding) - 5.0;
+
+    if let Some(truncated) = truncate(&text_layout, max_width, path.to_string()) {
+        let text_layout = ctx
+            .text()
+            .new_text_layout(truncated)
+            .font(config.ui.font_family(), font_size)
+            .text_color(config.get_color_unchecked(text_color).clone())
+            .build()
+            .unwrap();
+
+        ctx.draw_text(
+            &text_layout,
+            Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
+        );
+    } else {
+        ctx.draw_text(
+            &text_layout,
+            Point::new(38.0 + padding, y + text_layout.y_offset(line_height)),
+        );
+    }
 }
 
 /// Paint the file node item, if it is in view, and its children

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -1400,7 +1400,7 @@ impl OpenEditorList {
             // the second condition ensures that the 3 dots are als in the same color
             if !hint.is_empty() && (truncated.len() - 3) > (total_len - hint.len()) {
                 text_layout = text_layout.range_attribute(
-                    total_len - hint.len()..total_len,
+                    total_len - hint.len()..,
                     TextAttribute::TextColor(
                         data.config
                             .get_color_unchecked(LapceTheme::PANEL_FOREGROUND_DIM)

--- a/lapce-ui/src/lib.rs
+++ b/lapce-ui/src/lib.rs
@@ -31,6 +31,6 @@ pub mod status;
 pub mod svg;
 mod tab;
 pub mod terminal;
+pub mod text;
 pub mod title;
 pub mod window;
-pub mod text;

--- a/lapce-ui/src/lib.rs
+++ b/lapce-ui/src/lib.rs
@@ -33,3 +33,4 @@ mod tab;
 pub mod terminal;
 pub mod title;
 pub mod window;
+pub mod text;

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -482,7 +482,7 @@ impl Widget<LapceTabData> for SourceControlFileList {
                 // the second condition ensures that the 3 dots are all in the same color
                 if !folder.is_empty() && (truncated.len() - 3) > (total_len - folder.len()) {
                     text_layout = text_layout.range_attribute(
-                        total_len - folder.len()..total_len,
+                        total_len - folder.len()..,
                         TextAttribute::TextColor(
                             data.config
                                 .get_color_unchecked(LapceTheme::PANEL_FOREGROUND_DIM)

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use druid::{
     kurbo::BezPath,
-    piet::{Text, TextLayout as PietTextLayout, TextLayoutBuilder},
+    piet::{Text, TextLayoutBuilder, TextAttribute},
     BoxConstraints, Command, Env, Event, EventCtx, LayoutCtx, LifeCycle,
     LifeCycleCtx, MouseButton, MouseEvent, PaintCtx, Point, Rect, RenderContext,
     Size, Target, UpdateCtx, Widget, WidgetExt, WidgetId,
@@ -21,7 +21,7 @@ use lapce_rpc::source_control::FileDiff;
 use crate::{
     button::Button,
     editor::view::LapceEditorView,
-    panel::{LapcePanel, PanelHeaderKind, PanelSizing},
+    panel::{LapcePanel, PanelHeaderKind, PanelSizing}, text::truncate,
 };
 
 pub fn new_source_control_panel(data: &LapceTabData) -> LapcePanel {
@@ -432,54 +432,78 @@ impl Widget<LapceTabData> for SourceControlFileList {
                 .and_then(|s| s.to_str())
                 .unwrap_or("")
                 .to_string();
-
-            let text_layout = ctx
-                .text()
-                .new_text_layout(file_name)
-                .font(
-                    data.config.ui.font_family(),
-                    data.config.ui.font_size() as f64,
-                )
-                .text_color(
-                    data.config
-                        .get_color_unchecked(LapceTheme::EDITOR_FOREGROUND)
-                        .clone(),
-                )
-                .build()
-                .unwrap();
-            ctx.draw_text(
-                &text_layout,
-                Point::new(
-                    self.line_height * 2.0,
-                    y + text_layout.y_offset(self.line_height),
-                ),
-            );
+            
             let folder = path
                 .parent()
                 .and_then(|s| s.to_str())
                 .unwrap_or("")
                 .to_string();
-            if !folder.is_empty() {
-                let x = text_layout.size().width;
 
-                let text_layout = ctx
+            let text = if !folder.is_empty() {
+                format!("{file_name} {folder}")
+            } else {
+                file_name
+            };
+            
+            let total_len = text.len();
+            let mut text_layout = ctx
+                .text()
+                .new_text_layout(text.to_string())
+                .font(data.config.ui.font_family(), data.config.ui.font_size() as f64)
+                .text_color(
+                    data.config
+                        .get_color_unchecked(LapceTheme::PANEL_FOREGROUND)
+                        .clone(),
+                );
+            if !folder.is_empty() {
+                text_layout = text_layout.range_attribute(
+                    total_len - folder.len()..total_len,
+                    TextAttribute::TextColor(
+                        data.config
+                            .get_color_unchecked(LapceTheme::PANEL_FOREGROUND_DIM)
+                            .clone(),
+                    ),
+                );
+            }
+            let text_layout = text_layout.build().unwrap();
+
+            let max_width = current_line.width() - 2.0 * self.line_height - 2.0 * svg_size;
+
+            if let Some(truncated) = truncate(&text_layout, max_width, text) {
+                let mut text_layout = ctx
                     .text()
-                    .new_text_layout(folder)
-                    .font(
-                        data.config.ui.font_family(),
-                        data.config.ui.font_size() as f64,
-                    )
+                    .new_text_layout(truncated.to_string())
+                    .font(data.config.ui.font_family(), data.config.ui.font_size() as f64)
                     .text_color(
                         data.config
-                            .get_color_unchecked(LapceTheme::EDITOR_DIM)
+                            .get_color_unchecked(LapceTheme::PANEL_FOREGROUND)
                             .clone(),
-                    )
-                    .build()
-                    .unwrap();
+                    );
+                // the second condition ensures that the 3 dots are all in the same color
+                if !folder.is_empty() && (truncated.len() - 3) > (total_len - folder.len()) {
+                    text_layout = text_layout.range_attribute(
+                        total_len - folder.len()..total_len,
+                        TextAttribute::TextColor(
+                            data.config
+                                .get_color_unchecked(LapceTheme::PANEL_FOREGROUND_DIM)
+                                .clone(),
+                        ),
+                    );
+                }
+                let text_layout = text_layout.build().unwrap();
+
                 ctx.draw_text(
                     &text_layout,
                     Point::new(
-                        self.line_height * 2.0 + x + 5.0,
+                        self.line_height * 2.0,
+                        y + text_layout.y_offset(self.line_height),
+                    ),
+                );
+            } else {
+                ctx.draw_text(
+                    &text_layout,
+                    Point::new(
+                        self.line_height * 2.0,
                         y + text_layout.y_offset(self.line_height),
                     ),
                 );

--- a/lapce-ui/src/source_control.rs
+++ b/lapce-ui/src/source_control.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use druid::{
     kurbo::BezPath,
-    piet::{Text, TextLayoutBuilder, TextAttribute},
+    piet::{Text, TextAttribute, TextLayoutBuilder},
     BoxConstraints, Command, Env, Event, EventCtx, LayoutCtx, LifeCycle,
     LifeCycleCtx, MouseButton, MouseEvent, PaintCtx, Point, Rect, RenderContext,
     Size, Target, UpdateCtx, Widget, WidgetExt, WidgetId,
@@ -21,7 +21,8 @@ use lapce_rpc::source_control::FileDiff;
 use crate::{
     button::Button,
     editor::view::LapceEditorView,
-    panel::{LapcePanel, PanelHeaderKind, PanelSizing}, text::truncate,
+    panel::{LapcePanel, PanelHeaderKind, PanelSizing},
+    text::truncate,
 };
 
 pub fn new_source_control_panel(data: &LapceTabData) -> LapcePanel {
@@ -432,7 +433,7 @@ impl Widget<LapceTabData> for SourceControlFileList {
                 .and_then(|s| s.to_str())
                 .unwrap_or("")
                 .to_string();
-            
+
             let folder = path
                 .parent()
                 .and_then(|s| s.to_str())
@@ -444,12 +445,15 @@ impl Widget<LapceTabData> for SourceControlFileList {
             } else {
                 file_name
             };
-            
+
             let total_len = text.len();
             let mut text_layout = ctx
                 .text()
                 .new_text_layout(text.to_string())
-                .font(data.config.ui.font_family(), data.config.ui.font_size() as f64)
+                .font(
+                    data.config.ui.font_family(),
+                    data.config.ui.font_size() as f64,
+                )
                 .text_color(
                     data.config
                         .get_color_unchecked(LapceTheme::PANEL_FOREGROUND)
@@ -467,25 +471,33 @@ impl Widget<LapceTabData> for SourceControlFileList {
             }
             let text_layout = text_layout.build().unwrap();
 
-            let max_width = current_line.width() - 2.0 * self.line_height - 2.0 * svg_size;
+            let max_width =
+                current_line.width() - 2.0 * self.line_height - 2.0 * svg_size;
 
             if let Some(truncated) = truncate(&text_layout, max_width, text) {
                 let mut text_layout = ctx
                     .text()
                     .new_text_layout(truncated.to_string())
-                    .font(data.config.ui.font_family(), data.config.ui.font_size() as f64)
+                    .font(
+                        data.config.ui.font_family(),
+                        data.config.ui.font_size() as f64,
+                    )
                     .text_color(
                         data.config
                             .get_color_unchecked(LapceTheme::PANEL_FOREGROUND)
                             .clone(),
                     );
                 // the second condition ensures that the 3 dots are all in the same color
-                if !folder.is_empty() && (truncated.len() - 3) > (total_len - folder.len()) {
+                if !folder.is_empty()
+                    && (truncated.len() - 3) > (total_len - folder.len())
+                {
                     text_layout = text_layout.range_attribute(
                         total_len - folder.len()..,
                         TextAttribute::TextColor(
                             data.config
-                                .get_color_unchecked(LapceTheme::PANEL_FOREGROUND_DIM)
+                                .get_color_unchecked(
+                                    LapceTheme::PANEL_FOREGROUND_DIM,
+                                )
                                 .clone(),
                         ),
                     );

--- a/lapce-ui/src/text.rs
+++ b/lapce-ui/src/text.rs
@@ -1,0 +1,49 @@
+use druid::{piet::TextLayout, Point};
+
+/// This method truncates the text string if its width, as determined
+/// by the `text_layout` object, exceeds the specified `max_width`. If
+/// the text does not need to be truncated, the method returns `None`.
+///
+/// ## Parameters
+/// * `text_layout`: A reference to an object implementing the TextLayout trait.
+/// * `max_width`: A f64 value representing the maximum width allowed for the `text_layout`.
+/// * `text`: A String value representing the text to be truncated if necessary.
+///
+/// ## Return Value
+/// * If the text needs to be truncated, the method returns `Some(truncated_text)`,
+///   where `truncated_text` is a `String` value representing the truncated text.
+/// * If the text does not need to be truncated, the method returns `None`.
+pub fn truncate<T: TextLayout>(
+    text_layout: &T,
+    max_width: f64,
+    text: String,
+) -> Option<String> {
+    if text_layout.size().width > max_width {
+        let hit_point = text_layout.hit_test_point(Point::new(max_width, 0.0));
+
+        let end = text
+            .char_indices()
+            .filter(|(i, _)| hit_point.idx.overflowing_sub(*i).0 < 3)
+            .collect::<Vec<(usize, char)>>();
+
+        let end = if end.is_empty() {
+            // the text does exceed the `max_width`
+            // this should never be reached since it was
+            // already checked if the width is okay
+            text.len()
+        } else {
+            end[0].0
+        };
+
+        if end == 0 {
+            // the length of the truncated string must be
+            // zero for it not to exceed the `max_width`
+            Some("".to_string())
+        } else {
+            // add ellipsis to the truncated text
+            Some(format!("{}...", &text[0..end].trim_end()))
+        }
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
Fixes #2043

Added to
* explorer: open editors
* explorer: file list
* source control


- [x]  Added an entry to `CHANGELOG.md` if this change could be valuable to users