### PR TITLE
Set term

### DIFF
--- a/lapce-data/src/terminal.rs
+++ b/lapce-data/src/terminal.rs
@@ -592,7 +592,8 @@ impl RawTerminal {
         proxy: Arc<LapceProxy>,
         event_sink: ExtEventSink,
     ) -> Self {
-        let config = TermConfig::default();
+        let mut config = TermConfig::default();
+        config.env.insert("TERM".to_string(), "xterm-256color".to_string());
         let event_proxy = EventProxy {
             proxy,
             event_sink,

--- a/lapce-data/src/terminal.rs
+++ b/lapce-data/src/terminal.rs
@@ -593,7 +593,9 @@ impl RawTerminal {
         event_sink: ExtEventSink,
     ) -> Self {
         let mut config = TermConfig::default();
-        config.env.insert("TERM".to_string(), "xterm-256color".to_string());
+        config
+            .env
+            .insert("TERM".to_string(), "xterm-256color".to_string());
         let event_proxy = EventProxy {
             proxy,
             event_sink,

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -49,6 +49,7 @@ impl Terminal {
     ) -> Terminal {
         let poll = mio::Poll::new().unwrap();
         let mut config = TermConfig::default();
+        config.env.insert("TERM".to_string(), "xterm-256color".to_string());
         config.pty_config.working_directory =
             if cwd.is_some() && cwd.clone().unwrap().exists() {
                 cwd

--- a/lapce-proxy/src/terminal.rs
+++ b/lapce-proxy/src/terminal.rs
@@ -49,7 +49,9 @@ impl Terminal {
     ) -> Terminal {
         let poll = mio::Poll::new().unwrap();
         let mut config = TermConfig::default();
-        config.env.insert("TERM".to_string(), "xterm-256color".to_string());
+        config
+            .env
+            .insert("TERM".to_string(), "xterm-256color".to_string());
         config.pty_config.working_directory =
             if cwd.is_some() && cwd.clone().unwrap().exists() {
                 cwd


### PR DESCRIPTION
Alacritty supports this (and uses it by default on my system install of alacritty)
This is necessary for commands such as `clear` to work

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users