### PR TITLE
Fix attempting to canonicalize a path when saving a new file

### DIFF
--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -168,6 +168,7 @@ pub enum BufferContent {
     /// name
     Scratch(BufferId, String),
 }
+
 impl BufferContent {
     pub fn path(&self) -> Option<&Path> {
         if let BufferContent::File(p) = self {

--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -54,7 +54,11 @@ impl Buffer {
                 ext
             },
         );
-        let path = self.path.canonicalize()?;
+        let path = if self.path.is_symlink() {
+            self.path.canonicalize()?
+        } else {
+            self.path.clone()
+        };
         let tmp_path = &path.with_extension(tmp_extension);
 
         let mut f = File::create(tmp_path)?;


### PR DESCRIPTION
Since the file doesn't exist, it is going to fail. Thus aborting the save procedure.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users