### PR TITLE
Remove duplicate binding for Shift-Delete

### DIFF
--- a/defaults/keymaps-nonmacos.toml
+++ b/defaults/keymaps-nonmacos.toml
@@ -112,11 +112,6 @@ command = "delete_word_forward"
 mode = "i"
 
 [[keymaps]]
-key = "shift+delete"
-command = "delete_line"
-mode = "i"
-
-[[keymaps]]
 key = "ctrl+|"
 command = "match_pairs"
 mode = "i"


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

#2071 added this binding, but it's redundant with the existing one (for cut). Worse, the result is that two lines are removed instead of a single one.

I think it's better to cut instead of deleting because that's what every editor I've seen does. And `Cut` without a selection, already cuts the whole line, as it does everywhere else.