### PR TITLE
Development environment for lapce using devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "latest",
+			"profile": "default"
+		},
+		"ghcr.io/akhildevelops/devcontainer-features/apt": {
+			"PACKAGES": "pkg-config,libfontconfig-dev,libgtk-3-dev,g++"
+		}
+	},
+	"containerEnv": {
+		"CARGO_REGISTRIES_CRATES_IO_PROTOCOL": "sparse",
+		"DISPLAY": "${localEnv:DISPLAY}"
+	},
+	"mounts": [
+		{
+			"source": "devcontainer-cargo-cache-${devcontainerId}",
+			"target": "/usr/local/cargo",
+			"type": "volume"
+		},
+		{
+			"source": "/tmp/.X11-unix",
+			"target": "/tmp/.X11-unix",
+			"type": "bind"
+		}
+	]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "Ubuntu",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {


### PR DESCRIPTION
I felt it would be great to have a devcontainer easing the pain for lot many contributors to setup environment.

Few of the them even mentioned for the need of it.https://github.com/lapce/lapce/issues/2235

Here's the devcontainer.json file that can be used to setup development environment in docker and build lapce.

Running the binary creates a seperate gui window that uses host's X11 server.

Reference: http://fabiorehm.com/blog/2014/09/11/running-gui-apps-with-docker/

![image](https://user-images.githubusercontent.com/6951100/226342283-6cc85dc9-58d7-4573-a114-05250b3a7b3a.png)
