### PR TITLE
Update reactive usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.7.0"
+source = "git+https://github.com/lapce/cosmic-text?rev=6b1dbb529a2396378c05e452b5dc82376ee25040#6b1dbb529a2396378c05e452b5dc82376ee25040"
 dependencies = [
  "fontdb 0.13.0",
  "libm",
@@ -3475,15 +3476,16 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "leptos_reactive"
-version = "0.1.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f20215c7374ddcf4147bcd0b354dcedb01c2942e3837a4c198fdaa63788a2ea"
+checksum = "c2e740411ce3a6bce88d7e3724f9544408885a5cd29dd41f998be2e51dbb0fca"
 dependencies = [
  "base64 0.21.0",
  "cfg-if 1.0.0",
  "futures",
+ "indexmap",
  "js-sys",
- "log",
+ "rustc-hash",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -5243,9 +5245,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
 dependencies = [
  "js-sys",
  "serde",
@@ -7027,13 +7029,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vger"
 version = "0.2.5"
+source = "git+https://github.com/lapce/vger-rs?rev=25696dc6cf79da499d466646cc4b0b30e5225d6a#25696dc6cf79da499d466646cc4b0b30e5225d6a"
 dependencies = [
  "cosmic-text",
  "euclid",
  "fontdue",
  "rand 0.7.3",
  "rect_packer",
- "swash 0.1.6 (git+https://github.com/dfrg/swash)",
  "wgpu",
 ]
 

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -1,7 +1,6 @@
 use std::{
-    iter::Enumerate,
     ops::Range,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{atomic::AtomicU64, Arc},
 };
 
@@ -9,14 +8,12 @@ use floem::{
     app::AppContext,
     cosmic_text::{Attrs, AttrsList, TextLayout},
     event::{Event, EventListner},
-    parley::style::{FontFamily, FontStack, FontWeight, StyleProperty},
-    peniko::{
-        kurbo::{Point, Rect, Size},
-        Brush, Color,
-    },
+    parley::style::FontWeight,
+    peniko::kurbo::{Point, Rect, Size},
     reactive::{
-        create_effect, create_memo, create_signal, provide_context, use_context,
-        ReadSignal, RwSignal, UntrackedGettableSignal, WriteSignal,
+        create_memo, provide_context, ReadSignal, RwSignal, SignalGet,
+        SignalGetUntracked, SignalSet, SignalUpdate, SignalWith,
+        SignalWithUntracked,
     },
     stack::stack,
     style::{
@@ -39,24 +36,20 @@ use lapce_core::{
 use lsp_types::CompletionItemKind;
 
 use crate::{
-    command::{CommandKind, LapceWorkbenchCommand},
-    completion::{CompletionData, ScoredCompletionItem},
     config::{color::LapceColor, icon::LapceIcons, LapceConfig},
     db::LapceDb,
-    doc::{DocContent, DocLine, Document, TextLayoutLine},
+    doc::{DocContent, DocLine, Document},
     editor::EditorData,
     editor_tab::{EditorTabChild, EditorTabData},
     focus_text::focus_text,
     id::{EditorId, EditorTabId, SplitId},
-    keypress::{condition::Condition, DefaultKeyPress, KeyPressData, KeyPressFocus},
     main_split::{MainSplitData, SplitContent, SplitData, SplitDirection},
     palette::{
         item::{PaletteItem, PaletteItemContent},
-        PaletteData, PaletteStatus,
+        PaletteStatus,
     },
-    proxy::{start_proxy, ProxyData},
     title::title,
-    window_tab::{Focus, WindowTabData},
+    window_tab::WindowTabData,
     workspace::{LapceWorkspace, LapceWorkspaceType},
 };
 

--- a/lapce-app/src/completion.rs
+++ b/lapce-app/src/completion.rs
@@ -3,7 +3,9 @@ use std::{path::PathBuf, sync::Arc};
 use floem::{
     app::AppContext,
     peniko::kurbo::Rect,
-    reactive::{create_rw_signal, ReadSignal, RwSignal, UntrackedGettableSignal},
+    reactive::{
+        create_rw_signal, ReadSignal, RwSignal, SignalGetUntracked, SignalSet,
+    },
 };
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use lapce_core::movement::Movement;

--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -17,9 +17,7 @@ use crate::workspace::{LapceWorkspace, LapceWorkspaceType};
 
 use self::{
     color::LapceColor,
-    color_theme::{
-        ColorThemeConfig, ThemeBaseColor, ThemeColor, ThemeColorPreference,
-    },
+    color_theme::{ColorThemeConfig, ThemeColor, ThemeColorPreference},
     core::CoreConfig,
     editor::EditorConfig,
     icon::LapceIcons,

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -1,18 +1,13 @@
-use std::{
-    borrow::Cow,
-    cell::RefCell,
-    collections::HashMap,
-    path::{Path, PathBuf},
-    rc::Rc,
-    sync::Arc,
-};
+use std::{cell::RefCell, collections::HashMap, path::PathBuf, rc::Rc, sync::Arc};
 
 use floem::{
     app::AppContext,
-    cosmic_text::{Attrs, AttrsList, Family, FamilyOwned, TextLayout},
+    cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
     ext_event::create_ext_action,
-    peniko::{kurbo::Point, Brush, Color},
-    reactive::{create_rw_signal, ReadSignal, RwSignal, UntrackedGettableSignal},
+    peniko::{kurbo::Point, Color},
+    reactive::{
+        ReadSignal, RwSignal, SignalGetUntracked, SignalUpdate, SignalWithUntracked,
+    },
     views::VirtualListVector,
 };
 use itertools::Itertools;
@@ -43,10 +38,7 @@ use lapce_xi_rope::{
 use lsp_types::{Diagnostic, DiagnosticSeverity, InlayHint, InlayHintLabel};
 use smallvec::SmallVec;
 
-use crate::{
-    config::{color::LapceColor, LapceConfig},
-    proxy::ProxyData,
-};
+use crate::config::{color::LapceColor, LapceConfig};
 
 use self::phantom_text::{PhantomText, PhantomTextKind, PhantomTextLine};
 

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, path::PathBuf, str::FromStr, sync::Arc};
+use std::{cmp::Ordering, str::FromStr, sync::Arc};
 
 use anyhow::Result;
 use floem::{
@@ -7,7 +7,8 @@ use floem::{
     glazier::Modifiers,
     peniko::kurbo::{Point, Rect, Vec2},
     reactive::{
-        create_rw_signal, ReadSignal, RwSignal, UntrackedGettableSignal, WriteSignal,
+        create_rw_signal, ReadSignal, RwSignal, SignalGetUntracked, SignalSet,
+        SignalUpdate, SignalWithUntracked, WriteSignal,
     },
 };
 use lapce_core::{
@@ -156,9 +157,7 @@ impl EditorData {
 
         let deltas = self
             .doc
-            .update_returning(|doc| {
-                doc.do_edit(&mut cursor, cmd, modal, &mut register)
-            })
+            .try_update(|doc| doc.do_edit(&mut cursor, cmd, modal, &mut register))
             .unwrap();
 
         if !deltas.is_empty() {
@@ -729,7 +728,7 @@ impl EditorData {
         let old_cursor = cursor.mode.clone();
         let (delta, inval_lines, edits) = self
             .doc
-            .update_returning(|doc| {
+            .try_update(|doc| {
                 doc.do_raw_edit(
                     &[
                         &[(selection.clone(), text.as_str())][..],
@@ -811,7 +810,7 @@ impl EditorData {
         let mut cursor = self.cursor.get_untracked();
         let (delta, inval_lines, edits) = self
             .doc
-            .update_returning(|doc| {
+            .try_update(|doc| {
                 let (delta, inval_lines, edits) =
                     doc.do_raw_edit(edits, EditType::Completion);
                 let selection =
@@ -907,7 +906,7 @@ impl KeyPressFocus for EditorData {
             let config = self.config.get_untracked();
             let deltas = self
                 .doc
-                .update_returning(|doc| doc.do_insert(&mut cursor, c, &config))
+                .try_update(|doc| doc.do_insert(&mut cursor, c, &config))
                 .unwrap();
             self.cursor.set(cursor);
 

--- a/lapce-app/src/editor_tab.rs
+++ b/lapce-app/src/editor_tab.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use floem::{
     peniko::kurbo::{Point, Rect},
-    reactive::RwSignal,
+    reactive::{RwSignal, SignalGet, SignalWith},
 };
 
 use crate::{

--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use floem::{
     app::AppContext,
     glazier::{KbKey, KeyEvent, Modifiers, MouseEvent},
-    reactive::WriteSignal,
+    reactive::{SignalSet, WriteSignal},
 };
 use indexmap::IndexMap;
 use lapce_core::mode::Mode;

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -7,10 +7,10 @@ use floem::{
     app::AppContext,
     ext_event::create_ext_action,
     glazier::KeyEvent,
-    peniko::kurbo::{Point, Rect, Vec2},
+    peniko::kurbo::{Point, Rect},
     reactive::{
-        create_effect, create_rw_signal, ReadSignal, RwSignal,
-        UntrackedGettableSignal, WriteSignal,
+        create_effect, create_rw_signal, ReadSignal, RwSignal, SignalGetUntracked,
+        SignalSet, SignalUpdate, SignalWith, SignalWithUntracked, WriteSignal,
     },
 };
 use lapce_core::register::Register;
@@ -22,11 +22,11 @@ use crate::{
     command::InternalCommand,
     completion::CompletionData,
     config::LapceConfig,
-    doc::{DocContent, Document},
+    doc::{Document},
     editor::EditorData,
     editor_tab::{EditorTabChild, EditorTabData},
     id::{EditorId, EditorTabId, SplitId},
-    keypress::{KeyPressData, KeyPressFocus},
+    keypress::{KeyPressData},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -587,7 +587,7 @@ impl MainSplitData {
         let parent_split = splits.get(&parent_split_id).copied()?;
 
         let split_len = parent_split
-            .update_returning(|split| {
+            .try_update(|split| {
                 split
                     .children
                     .retain(|c| c != &SplitContent::Split(split_id));
@@ -703,7 +703,7 @@ impl MainSplitData {
         })?;
 
         let editor_tab_children_len = editor_tab
-            .update_returning(|editor_tab| {
+            .try_update(|editor_tab| {
                 editor_tab.children.remove(index);
                 editor_tab.active =
                     index.min(editor_tab.children.len().saturating_sub(1));

--- a/lapce-app/src/palette.rs
+++ b/lapce-app/src/palette.rs
@@ -14,23 +14,17 @@ use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use floem::{
     app::AppContext,
-    ext_event::{
-        create_ext_action, create_signal_from_channel,
-        create_signal_from_channel_oneshot,
-    },
+    ext_event::{create_ext_action, create_signal_from_channel},
     reactive::{
-        create_effect, create_memo, create_rw_signal, create_signal, ReadSignal,
-        RwSignal, UntrackedGettableSignal, WriteSignal,
+        create_effect, create_rw_signal, create_signal, ReadSignal, RwSignal,
+        SignalGet, SignalGetUntracked, SignalSet, SignalUpdate, SignalWith,
+        SignalWithUntracked, WriteSignal,
     },
 };
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use itertools::Itertools;
 use lapce_core::{
-    command::FocusCommand,
-    cursor::{Cursor, CursorMode},
-    mode::Mode,
-    movement::Movement,
-    register::Register,
+    command::FocusCommand, mode::Mode, movement::Movement, register::Register,
     selection::Selection,
 };
 use lapce_rpc::proxy::{ProxyResponse, ProxyRpcHandler};
@@ -239,7 +233,7 @@ impl PaletteData {
 
                 if changed {
                     let new_kind = input
-                        .update_returning(|input| {
+                        .try_update(|input| {
                             let kind = input.kind;
                             input.update_input(new_input.clone());
                             if last_input_is_none || kind != input.kind {

--- a/lapce-app/src/proxy.rs
+++ b/lapce-app/src/proxy.rs
@@ -1,10 +1,13 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use crossbeam_channel::Sender;
 use floem::{
     app::AppContext,
     ext_event::create_signal_from_channel,
-    reactive::{create_effect, create_signal, ReadSignal, WriteSignal},
+    reactive::{
+        create_effect, create_signal, ReadSignal, SignalSet, SignalUpdate,
+        SignalWith, WriteSignal,
+    },
 };
 use lapce_proxy::dispatch::Dispatcher;
 use lapce_rpc::{

--- a/lapce-app/src/title.rs
+++ b/lapce-app/src/title.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use floem::{
     app::AppContext,
-    reactive::{create_signal, ReadSignal},
+    reactive::{create_signal, ReadSignal, SignalGet},
     stack::stack,
     style::{AlignItems, Dimension, JustifyContent, Style},
     view::View,

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -6,7 +6,7 @@ use floem::{
     peniko::kurbo::{Point, Rect, Vec2},
     reactive::{
         create_effect, create_rw_signal, create_signal, use_context, ReadSignal,
-        RwSignal, UntrackedGettableSignal,
+        RwSignal, SignalGet, SignalGetUntracked, SignalSet, SignalWithUntracked,
     },
 };
 use lapce_core::register::Register;
@@ -16,7 +16,7 @@ use crate::{
     completion::{CompletionData, CompletionStatus},
     config::LapceConfig,
     db::LapceDb,
-    keypress::{DefaultKeyPress, KeyPressData, KeyPressFocus},
+    keypress::{DefaultKeyPress, KeyPressData},
     main_split::MainSplitData,
     palette::{kind::PaletteKind, PaletteData},
     proxy::{start_proxy, ProxyData},


### PR DESCRIPTION
Updates leptos_reactive usage.  
This primarily consisted of importing the relevant traits for the used functions. Some unused imports were cleaned up.  
`update_returning` had also been deprecated and renamed to `try_update`.