### PR TITLE
allow hide open editors

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -13,6 +13,7 @@ code-lens-font-size = 2
 line-height = 1.5
 tab-width = 4
 show-tab = true
+hide-open-editors = false
 show-bread-crumbs = true
 scroll-beyond-last-line = true
 cursor-surrounding-lines = 1

--- a/extra/schemas/settings.json
+++ b/extra/schemas/settings.json
@@ -203,6 +203,9 @@
                 "show-tab": {
                     "type": "boolean"
                 },
+                "hide-open-editors": {
+                    "type": "boolean"
+                },
                 "show-bread-crumbs": {
                     "type": "boolean"
                 },

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -364,6 +364,8 @@ pub struct EditorConfig {
     pub tab_width: usize,
     #[field_names(desc = "If opened editors are shown in a tab")]
     pub show_tab: bool,
+    #[field_names(desc = "If the 'Open Editors' is hidden in the Explorer panel.")]
+    pub hide_open_editors: bool,
     #[field_names(desc = "If navigation breadcrumbs are shown for the file")]
     pub show_bread_crumbs: bool,
     #[field_names(desc = "If the editor can scroll beyond the last line")]

--- a/lapce-ui/src/explorer.rs
+++ b/lapce-ui/src/explorer.rs
@@ -368,33 +368,37 @@ impl FileExplorer {
 
     pub fn new_panel(data: &mut LapceTabData) -> LapcePanel {
         let split_id = WidgetId::next();
-        LapcePanel::new(
-            PanelKind::FileExplorer,
-            data.file_explorer.widget_id,
+        let mut sections = vec![(
             split_id,
-            vec![
+            PanelHeaderKind::Simple(
+                data.workspace
+                    .path
+                    .as_ref()
+                    .and_then(|p| p.file_name())
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "No Folder Open".to_string())
+                    .into(),
+            ),
+            Self::new(data).boxed(),
+            PanelSizing::Flex(true),
+        )];
+        if !data.config.editor.hide_open_editors {
+            sections.insert(
+                0,
                 (
                     WidgetId::next(),
                     PanelHeaderKind::Simple("Open Editors".into()),
                     LapceScroll::new(OpenEditorList::new()).boxed(),
                     PanelSizing::Size(200.0),
                 ),
-                (
-                    split_id,
-                    PanelHeaderKind::Simple(
-                        data.workspace
-                            .path
-                            .as_ref()
-                            .and_then(|p| p.file_name())
-                            .and_then(|s| s.to_str())
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|| "No Folder Open".to_string())
-                            .into(),
-                    ),
-                    Self::new(data).boxed(),
-                    PanelSizing::Flex(true),
-                ),
-            ],
+            )
+        }
+        LapcePanel::new(
+            PanelKind::FileExplorer,
+            data.file_explorer.widget_id,
+            split_id,
+            sections,
         )
     }
 }


### PR DESCRIPTION
feat: https://github.com/lapce/lapce/issues/2268

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/4404609/226806484-572d487d-e05c-42d3-b918-7962afeba3b9.png">

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/4404609/226806589-465a6cb0-a468-485f-82f7-9b97a6556a02.png">



- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users