### PR TITLE
editor: highlight multiple selections and words on cursor

### DIFF
--- a/lapce-core/src/cursor.rs
+++ b/lapce-core/src/cursor.rs
@@ -276,8 +276,8 @@ impl Cursor {
         RegisterData { content, mode }
     }
 
-    /// Return the current selection start and end position for a
-    /// Single cursor selection
+    /// Returns the current selection start and end position for a
+    /// single cursor selection.
     pub fn get_selection(&self) -> Option<(usize, usize)> {
         match &self.mode {
             CursorMode::Visual {
@@ -285,11 +285,27 @@ impl Cursor {
                 end,
                 mode: _,
             } => Some((*start, *end)),
+
             CursorMode::Insert(selection) => selection
                 .regions()
                 .first()
                 .map(|region| (region.start, region.end)),
+
             _ => None,
+        }
+    }
+
+    /// Returns the [`Selection`] of the current mode.
+    pub fn as_selection(&self, buffer: &Buffer) -> Selection {
+        match &self.mode {
+            CursorMode::Normal(offset) => Selection::caret(*offset),
+
+            CursorMode::Visual { start, end, .. } => Selection::region(
+                (*start).min(*end),
+                buffer.next_grapheme_offset((*start).max(*end), 1, buffer.len()),
+            ),
+
+            CursorMode::Insert(selection) => selection.clone(),
         }
     }
 


### PR DESCRIPTION
Hi!

I reworked the `paint_selection_find` function so that:
- Multiple cursor regions are taken into account.
- `data.doc.selection_find` is used directly because a `FindProgress` isn't really necessary for an implicit search like this which is also limited to the visible lines.
- The "active" selection under the cursor isn't filled with a color as it's distracting and makes only sense with a `Ctrl+F` search.
- The phantom text (to the right) isn't included in the rectangular highlight (also fixed for `Ctrl+F`).
- Selecting backwards is working (`start` and `end` are swapped).
- Renamed variables for readability.

Notes/Issues:
- I'm still learning Rust, so there may be beginner mistakes.
- The code for getting multiple regions and iterating over them seems correct to me, but it doesn't actually highlight all selections. Only those of the first cursor. Not experienced enough to debug this.
- I left the curly braces block in there after removing the if clause, so that the diff remains readable.