### PR TITLE
Cargo: added --wait flag and explaining note

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,14 @@ codegen-units = 1
 # but Lapce code in dev mode. This gives a good debugging experience for your
 # code and fast performance of other people's code. After the initial
 # build subsequent ones are as fast as dev mode builds.
-# See https://doc.rust-lang.org/cargo/reference/profiles.html
+# See: https://doc.rust-lang.org/cargo/reference/profiles.html
+#
 # To use this profile:
 #   cargo build --profile fastdev
-#   cargo run --profile fastdev --bin lapce
+#   cargo run --profile fastdev --bin lapce -- --wait
+#
+# Note: the --wait flag is passed to lapce for blocking the terminal
+#       in order to receive stdout and stderr output.
 [profile.fastdev.package."*"]
 opt-level = 3
 


### PR DESCRIPTION
It took me a while to figure out why I didn't get any console output when starting lapce. A note like this would've been helpful. :slightly_smiling_face: