### PR TITLE
feat: filter settings

### DIFF
--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -805,6 +805,13 @@ impl LapceTabData {
             event_sink.clone(),
         );
         main_split.add_editor(
+            settings.filter_editor_id,
+            None,
+            LocalBufferKind::SettingsFilter,
+            &config,
+            event_sink.clone(),
+        );
+        main_split.add_editor(
             rename.view_id,
             None,
             LocalBufferKind::Rename,

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -151,6 +151,8 @@ pub enum LocalBufferKind {
     Rename,
     /// Search buffer in plugin panel
     PluginSearch,
+    /// Settings filter in settings panel
+    SettingsFilter,
     /// Source Control branch filter in the branch list
     BranchesFilter,
 }
@@ -192,6 +194,7 @@ impl BufferContent {
                 | LocalBufferKind::BranchesFilter
                 | LocalBufferKind::FilePicker
                 | LocalBufferKind::Settings
+                | LocalBufferKind::SettingsFilter
                 | LocalBufferKind::Keymap
                 | LocalBufferKind::PathName
                 | LocalBufferKind::PluginSearch
@@ -213,6 +216,7 @@ impl BufferContent {
                 | LocalBufferKind::Palette
                 | LocalBufferKind::FilePicker
                 | LocalBufferKind::Settings
+                | LocalBufferKind::SettingsFilter
                 | LocalBufferKind::Keymap
                 | LocalBufferKind::PathName
                 | LocalBufferKind::PluginSearch
@@ -1023,6 +1027,7 @@ impl Document {
                     LocalBufferKind::PluginSearch => {}
                     LocalBufferKind::SourceControl => {}
                     LocalBufferKind::BranchesFilter => {}
+                    LocalBufferKind::SettingsFilter => {}
                     LocalBufferKind::Empty => {}
                     LocalBufferKind::Rename => {}
                     LocalBufferKind::Palette => {

--- a/lapce-data/src/settings.rs
+++ b/lapce-data/src/settings.rs
@@ -48,9 +48,11 @@ pub struct LapceSettingsPanelData {
     pub settings_widget_id: WidgetId,
     pub settings_view_id: WidgetId,
     pub settings_split_id: WidgetId,
+    pub settings_sections: IndexMap<LapceSettingsKind, String>,
+    pub plugin_section: String,
 
     pub filter_editor_id: WidgetId,
-    pub filter_matches: IndexMap<LapceSettingsKind, usize>,
+    pub filter_matches: IndexMap<String, usize>,
 
     /// Mapping of setting key to dropdown data for that key
     pub dropdown_data:
@@ -95,6 +97,14 @@ impl KeyPressFocus for LapceSettingsPanelData {
 
 impl LapceSettingsPanelData {
     pub fn new() -> Self {
+        let settings_sections = IndexMap::from([
+            (LapceSettingsKind::Core, "Core Settings".to_string()),
+            (LapceSettingsKind::UI, "UI Settings".to_string()),
+            (LapceSettingsKind::Editor, "Editor Settings".to_string()),
+            (LapceSettingsKind::Terminal, "Terminal Settings".to_string()),
+            (LapceSettingsKind::Theme, "Theme Settings".to_string()),
+            (LapceSettingsKind::Keymap, "Keybindings".to_string()),
+        ]);
         Self {
             panel_widget_id: WidgetId::next(),
             keymap_widget_id: WidgetId::next(),
@@ -106,7 +116,13 @@ impl LapceSettingsPanelData {
             filter_editor_id: WidgetId::next(),
             dropdown_data: im::HashMap::new(),
             filter_matches: IndexMap::new(),
+            settings_sections,
+            plugin_section: String::from("Plugin Settings"),
         }
+    }
+
+    pub fn update_matches(&mut self, key: String, count: usize) {
+        self.filter_matches.insert(key, count);
     }
 }
 

--- a/lapce-data/src/settings.rs
+++ b/lapce-data/src/settings.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use druid::{Command, Env, EventCtx, Modifiers, Target, WidgetId};
+use indexmap::IndexMap;
 use lapce_core::{
     command::{EditCommand, FocusCommand, MoveCommand},
     mode::Mode,
@@ -47,6 +48,9 @@ pub struct LapceSettingsPanelData {
     pub settings_widget_id: WidgetId,
     pub settings_view_id: WidgetId,
     pub settings_split_id: WidgetId,
+
+    pub filter_editor_id: WidgetId,
+    pub filter_matches: IndexMap<LapceSettingsKind, usize>,
 
     /// Mapping of setting key to dropdown data for that key
     pub dropdown_data:
@@ -99,8 +103,9 @@ impl LapceSettingsPanelData {
             settings_widget_id: WidgetId::next(),
             settings_view_id: WidgetId::next(),
             settings_split_id: WidgetId::next(),
-
+            filter_editor_id: WidgetId::next(),
             dropdown_data: im::HashMap::new(),
+            filter_matches: IndexMap::new(),
         }
     }
 }

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -179,6 +179,7 @@ impl LapceEditorView {
                 LocalBufferKind::Settings => {}
                 LocalBufferKind::PluginSearch => {}
                 LocalBufferKind::BranchesFilter => {}
+                LocalBufferKind::SettingsFilter => {}
                 LocalBufferKind::Palette => {
                     data.focus_area = FocusArea::Palette;
                 }

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -54,6 +54,8 @@ pub struct LapceSettingsPanel {
         LapceSettingsKind,
         WidgetPod<LapceTabData, Box<dyn Widget<LapceTabData>>>,
     >,
+    filter_input: WidgetPod<LapceTabData, Box<dyn Widget<LapceTabData>>>,
+    last_idle_timer: TimerToken,
 }
 
 impl LapceSettingsPanel {
@@ -109,7 +111,14 @@ impl LapceSettingsPanel {
         }
 
         let switcher = LapceScroll::new(SettingsSwitcher::new(widget_id));
-
+        let input = LapceEditorView::new(
+            data.settings.filter_editor_id,
+            WidgetId::next(),
+            None,
+        )
+        .hide_header()
+        .hide_gutter()
+        .padding((5.0, 2.0, 5.0, 2.0));
         Self {
             widget_id,
             editor_tab_id,
@@ -118,6 +127,8 @@ impl LapceSettingsPanel {
             switcher: WidgetPod::new(switcher),
             children,
             active: LapceSettingsKind::Core,
+            filter_input: WidgetPod::new(input.boxed()),
+            last_idle_timer: TimerToken::INVALID,
         }
     }
 
@@ -191,6 +202,7 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
         env: &Env,
     ) {
         match event {
+            Event::Timer(token) if *token == self.last_idle_timer => {}
             Event::KeyDown(key_event) => {
                 if ctx.is_focused() {
                     let mut keypress = data.keypress.clone();
@@ -282,6 +294,7 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
             return;
         }
 
+        self.filter_input.event(ctx, event, data, env);
         self.switcher.event(ctx, event, data, env);
         if event.should_propagate_to_hidden() {
             for child in self.children.values_mut() {
@@ -299,6 +312,7 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
         data: &LapceTabData,
         env: &Env,
     ) {
+        self.filter_input.lifecycle(ctx, event, data, env);
         self.switcher.lifecycle(ctx, event, data, env);
         for child in self.children.values_mut() {
             child.lifecycle(ctx, event, data, env);
@@ -308,13 +322,25 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,
-        _old_data: &LapceTabData,
+        old_data: &LapceTabData,
         data: &LapceTabData,
         env: &Env,
     ) {
+        self.filter_input.update(ctx, data, env);
         self.switcher.update(ctx, data, env);
         for child in self.children.values_mut() {
             child.update(ctx, data, env);
+        }
+
+        let editor_data = data.editor_view_content(data.settings.filter_editor_id);
+        let old_editor_data =
+            old_data.editor_view_content(data.settings.filter_editor_id);
+        if editor_data.doc.buffer().len() != old_editor_data.doc.buffer().len()
+            || editor_data.doc.buffer().text().slice_to_cow(..)
+                != old_editor_data.doc.buffer().text().slice_to_cow(..)
+        {
+            self.last_idle_timer =
+                ctx.request_timer(Duration::from_millis(300), None);
         }
     }
 
@@ -329,24 +355,40 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
         let origin = Point::ZERO;
         self.content_rect = self_size.to_rect().with_origin(origin).round();
 
-        let switcher_size = self.switcher.layout(
+        let filter_size = self.filter_input.layout(
             ctx,
-            &BoxConstraints::new(Size::ZERO, bc.max()),
+            &BoxConstraints::tight(self_size),
             data,
             env,
         );
-        self.switcher.set_origin(ctx, data, env, Point::ZERO);
+        self.filter_input.set_origin(ctx, data, env, Point::ZERO);
+        let switcher_size = self.switcher.layout(
+            ctx,
+            &BoxConstraints::new(
+                Size::ZERO,
+                Size::new(self_size.width, self_size.height - filter_size.height),
+            ),
+            data,
+            env,
+        );
+        self.switcher.set_origin(
+            ctx,
+            data,
+            env,
+            Point::new(0.0, filter_size.height),
+        );
 
         self.switcher_rect = Size::new(150.0, self_size.height)
             .to_rect()
-            .with_origin(Point::ZERO)
+            .with_origin(Point::new(0.0, filter_size.height))
             .round();
 
         let content_size = Size::new(
             self_size.width - switcher_size.width - 20.0,
-            self_size.height,
+            self_size.height - filter_size.height,
         );
-        let content_origin = Point::new(switcher_size.width + 20.0, 0.0);
+        let content_origin =
+            Point::new(switcher_size.width + 20.0, filter_size.height);
         let content_bc = BoxConstraints::tight(content_size);
         if let Some(child) = self.children.get_mut(&self.active) {
             child.layout(ctx, &content_bc, data, env);
@@ -370,6 +412,7 @@ impl Widget<LapceTabData> for LapceSettingsPanel {
             data.config.get_color_unchecked(LapceTheme::LAPCE_BORDER),
             1.0,
         );
+        self.filter_input.paint(ctx, data, env);
     }
 }
 
@@ -377,6 +420,7 @@ struct LapceSettings {
     widget_id: WidgetId,
     kind: LapceSettingsKind,
     children: Vec<WidgetPod<LapceTabData, Box<dyn Widget<LapceTabData>>>>,
+    last_idle_timer: TimerToken,
 }
 
 impl LapceSettings {
@@ -387,6 +431,7 @@ impl LapceSettings {
             widget_id: WidgetId::next(),
             kind,
             children: Vec::new(),
+            last_idle_timer: TimerToken::INVALID,
         })
     }
 
@@ -401,7 +446,8 @@ impl LapceSettings {
         }
 
         self.children.clear();
-
+        let editor_data = data.editor_view_content(data.settings.filter_editor_id);
+        let query = editor_data.doc.buffer().text().to_string().to_lowercase();
         let (kind, fields, descs, mut settings) = match &self.kind {
             LapceSettingsKind::Core => (
                 "core",
@@ -436,6 +482,15 @@ impl LapceSettings {
                         for (key, config) in
                             config.iter().sorted_by_key(|(key, _)| *key)
                         {
+                            if !query.is_empty()
+                                && !key.to_lowercase().contains(&query)
+                                && !config
+                                    .description
+                                    .to_lowercase()
+                                    .contains(&query)
+                            {
+                                continue;
+                            }
                             let mut value = config.default.clone();
                             if let Some(plugin_config) =
                                 data.config.plugins.get(&volt.name)
@@ -462,6 +517,12 @@ impl LapceSettings {
         };
 
         for (field, desc) in fields.iter().zip(descs.iter()) {
+            if !query.is_empty()
+                && !field.to_lowercase().contains(&query)
+                && !desc.to_lowercase().contains(&query)
+            {
+                continue;
+            }
             // TODO(dbuga): we should generate kebab-case field names
             let field = field.replace('_', "-");
             let value = if let Some(dropdown) =
@@ -499,6 +560,14 @@ impl Widget<LapceTabData> for LapceSettings {
         for child in self.children.iter_mut() {
             child.event(ctx, event, data, env);
         }
+        match event {
+            Event::Timer(token) if token == &self.last_idle_timer => {
+                self.update_children(ctx, data);
+                ctx.children_changed();
+                return;
+            }
+            _ => {}
+        }
         if self.children.is_empty() {
             self.update_children(ctx, data);
             ctx.children_changed();
@@ -520,12 +589,22 @@ impl Widget<LapceTabData> for LapceSettings {
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,
-        _old_data: &LapceTabData,
+        old_data: &LapceTabData,
         data: &LapceTabData,
         env: &Env,
     ) {
         for child in self.children.iter_mut() {
             child.update(ctx, data, env);
+        }
+        let editor_data = data.editor_view_content(data.settings.filter_editor_id);
+        let old_editor_data =
+            old_data.editor_view_content(data.settings.filter_editor_id);
+        if editor_data.doc.buffer().len() != old_editor_data.doc.buffer().len()
+            || editor_data.doc.buffer().text().slice_to_cow(..)
+                != old_editor_data.doc.buffer().text().slice_to_cow(..)
+        {
+            self.last_idle_timer =
+                ctx.request_timer(Duration::from_millis(300), None);
         }
     }
 
@@ -1519,6 +1598,7 @@ pub struct ThemeSection {
     colors: Vec<String>,
     text_layouts: Option<Vec<PietTextLayout>>,
     items: Vec<WidgetPod<LapceTabData, Box<dyn Widget<LapceTabData>>>>,
+    last_idle_timer: TimerToken,
 }
 
 impl ThemeSection {
@@ -1544,14 +1624,20 @@ impl ThemeSection {
             items: Vec::new(),
             text_layouts: None,
             colors,
+            last_idle_timer: TimerToken::INVALID,
         }
     }
 
     fn update_items(&mut self, ctx: &mut EventCtx, data: &mut LapceTabData) {
         let event_sink = ctx.get_external_handle();
+        let editor_data = data.editor_view_content(data.settings.filter_editor_id);
+        let query = editor_data.doc.buffer().text().to_string().to_lowercase();
         self.items = self
             .colors
             .iter()
+            .filter(|color| {
+                query.is_empty() || color.to_lowercase().contains(&query)
+            })
             .map(|color| {
                 WidgetPod::new(LapcePadding::new(
                     5.0,
@@ -1580,7 +1666,11 @@ impl Widget<LapceTabData> for ThemeSection {
         for item in self.items.iter_mut() {
             item.event(ctx, event, data, env);
         }
-
+        if let Event::Timer(token) = event {
+            if *token == self.last_idle_timer {
+                self.last_idle_timer = TimerToken::INVALID;
+            }
+        }
         if self.items.is_empty() {
             self.update_items(ctx, data);
         }
@@ -1601,12 +1691,22 @@ impl Widget<LapceTabData> for ThemeSection {
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,
-        _old_data: &LapceTabData,
+        old_data: &LapceTabData,
         data: &LapceTabData,
         env: &Env,
     ) {
         for item in self.items.iter_mut() {
             item.update(ctx, data, env);
+        }
+        let editor_data = data.editor_view_content(data.settings.filter_editor_id);
+        let old_editor_data =
+            old_data.editor_view_content(data.settings.filter_editor_id);
+        if editor_data.doc.buffer().len() != old_editor_data.doc.buffer().len()
+            || editor_data.doc.buffer().text().slice_to_cow(..)
+                != old_editor_data.doc.buffer().text().slice_to_cow(..)
+        {
+            self.last_idle_timer =
+                ctx.request_timer(Duration::from_millis(300), None);
         }
     }
 
@@ -1618,9 +1718,12 @@ impl Widget<LapceTabData> for ThemeSection {
         env: &Env,
     ) -> Size {
         let mut text_layouts = Vec::new();
-
+        let editor_data = data.editor_view_content(data.settings.filter_editor_id);
+        let query = editor_data.doc.buffer().text().to_string().to_lowercase();
         let mut width = 0.0;
-        for color in self.colors.iter() {
+        for color in self.colors.iter().filter(|color| {
+            query.is_empty() || color.to_lowercase().contains(&query)
+        }) {
             let text_layout = ctx
                 .text()
                 .new_text_layout(color.to_string())


### PR DESCRIPTION
Feature: [Allow filtering on the settings view](https://github.com/lapce/lapce/issues/2283)

Filter setting items and show matches count

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/4404609/227852872-69605fb6-5cc7-49ea-af76-5d0e1cb55bd8.png">


- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users