### PR TITLE
Enable XML syntax highlighting for csproj files

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -960,7 +960,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         indent: "    ",
         code_lens: (DEFAULT_CODE_LENS_LIST, DEFAULT_CODE_LENS_IGNORE_LIST),
         sticky_headers: &[],
-        extensions: &["xml"],
+        extensions: &["xml", "csproj"],
     },
     #[cfg(feature = "lang-yaml")]
     SyntaxProperties {

--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -239,7 +239,7 @@ pub fn language_id_from_path(path: &Path) -> Option<&'static str> {
                     "tsx" => "typescriptreact",
                     "tex" => "tex",
                     "vb" => "vb",
-                    "xml" => "xml",
+                    "xml" | "csproj" => "xml",
                     "xsl" => "xsl",
                     "yml" | "yaml" => "yaml",
                     "zig" => "zig",


### PR DESCRIPTION
Fixes #2296.

I've tested with a local build, seems to work fine. Basically I did the same thing as [this PR](https://github.com/lapce/lapce/pull/1603).