### PR TITLE
fix: `ce` motion respects whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- [#2315](https://github.com/lapce/lapce/pull/2315): Fix `ce` motion to respect whitespace
+
 ## 0.2.7
 
 ### Features/Changes

--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -458,7 +458,7 @@ mode = "n"
 
 [[keymaps]]
 key = "c e"
-command = "delete_word_and_insert"
+command = "delete_word_end_and_insert"
 mode = "n"
 
 [[keymaps]]

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -36,6 +36,8 @@ pub enum EditCommand {
     DeleteForwardAndInsert,
     #[strum(serialize = "delete_word_and_insert")]
     DeleteWordAndInsert,
+    #[strum(serialize = "delete_word_end_and_insert")]
+    DeleteWordEndAndInsert,
     #[strum(serialize = "delete_line_and_insert")]
     DeleteLineAndInsert,
     #[strum(serialize = "delete_word_forward")]

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -1353,13 +1353,18 @@ impl Editor {
                 cursor.mode = CursorMode::Insert(selection);
                 vec![(delta, inval_lines, edits)]
             }
-            DeleteWordAndInsert => {
+            DeleteWordAndInsert | DeleteWordEndAndInsert => {
                 let selection = {
                     let mut new_selection = Selection::new();
                     let selection = cursor.edit_selection(buffer);
 
                     for region in selection.regions() {
-                        let end = buffer.move_word_forward(region.end);
+                        let end = if cmd == &DeleteWordEndAndInsert {
+                            buffer.move_n_wordends_forward(region.end, 1, true)
+                        } else { 
+                            buffer.move_word_forward(region.end)
+                        };
+                        
                         let new_region = SelRegion::new(region.start, end, None);
                         new_selection.add_region(new_region);
                     }


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

The `de` motion respects whitespace as this is compromised of two different keymaps: `d` for `DeleteWord` and `e` for `WordEndForward`, where the `WordEndForward` implementation accounts for whitespace. 

I've introduced a new EditCommand called `DeleteWordEndAndInsert` and slightly tweaked the current implementation to alter the selection logic when `DeleteWordEndAndInsert` is used.

Fixes #1848