### PR TITLE
Always try to canonicalize the list of paths to open

### DIFF
--- a/lapce-proxy/src/cli.rs
+++ b/lapce-proxy/src/cli.rs
@@ -19,14 +19,14 @@ pub struct PathObject {
 impl PathObject {
     pub fn new(path: PathBuf, line: usize, column: usize) -> PathObject {
         PathObject {
-            path,
+            path: path.canonicalize().unwrap_or(path),
             linecol: Some(LineCol { line, column }),
         }
     }
 
     pub fn from_path(path: PathBuf) -> PathObject {
         PathObject {
-            path,
+            path: path.canonicalize().unwrap_or(path),
             linecol: None,
         }
     }


### PR DESCRIPTION
Attempting to open cwd crashes `lapce-proxy`:

```shell
hbina@akarin ~/g/lapce (master)> cargo run -- --wait .
   Compiling lapce-proxy v0.2.7 (/home/hbina/git/lapce/lapce-proxy)
   Compiling lapce-data v0.2.7 (/home/hbina/git/lapce/lapce-data)
   Compiling lapce-ui v0.2.7 (/home/hbina/git/lapce/lapce-ui)
   Compiling lapce v0.2.7 (/home/hbina/git/lapce)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 07s
warning: the following packages contain code that will be rejected by a future version of Rust: fs_extra v1.2.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 941`
     Running `target/debug/lapce --wait .`
[2023-04-06][07:02:59][lapce_data::keypress][ERROR] Failed to load from "/home/hbina/.config/lapce-debug/keymaps.toml": no keymaps
Unknown option --wait
[2023-04-06][07:03:00][druid::core][WARN] WidgetId(257) received an event (MouseMove(MouseEvent { pos: (382.0, 379.0), window_pos: (382.0, 379.0), buttons: MouseButtons(00000), mods: Modifiers((empty)), count: 0, focus: false, button: None, wheel_delta: Vec2 { x: 0.0, y: 0.0 } })) without having been laid out. This likely indicates a missed call to set_origin.
[2023-04-06][07:03:02][panic][ERROR] thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ()': lapce-proxy/src/plugin/wasi.rs:190
```

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users