### PR TITLE
Add placeholder text to filter input in settings

### DIFF
--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -116,6 +116,7 @@ impl LapceSettingsPanel {
             WidgetId::next(),
             None,
         )
+        .set_placeholder("Filter Settings...".to_string())
         .hide_header()
         .hide_gutter()
         .padding((5.0, 2.0, 5.0, 2.0));


### PR DESCRIPTION
This just adds a placehoder text in the settings filter input, to make it clear that it's a text field (which was added in https://github.com/lapce/lapce/pull/2289)


![2023-04-11_01-16](https://user-images.githubusercontent.com/3624853/231016980-1eda4404-e279-41a4-8c28-a72179bd7cff.png)


- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users