### PR TITLE
feat: Panel enhancement

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -292,6 +292,13 @@ name = ""
 "panel.restore" = "chevron-down.svg"
 "panel.maximise" = "chevron-right.svg"
 
+"panel.restore_left" = "chevron-left.svg"
+"panel.maximise_left" = "chevron-right.svg"
+"panel.restore_right" = "chevron-right.svg"
+"panel.maximise_right" = "chevron-left.svg"
+"panel.restore_bottom" = "chevron-down.svg"
+"panel.maximise_bottom" = "chevron-up.svg"
+
 "panel_section.expand_vertical" = "chevron-down.svg"
 "panel_section.collapse_vertical" = "chevron-left.svg"
 "panel_section.expand_horizontal" = "chevron-right.svg"

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -292,6 +292,11 @@ name = ""
 "panel.restore" = "chevron-down.svg"
 "panel.maximise" = "chevron-right.svg"
 
+"panel_section.expand_vertical" = "chevron-down.svg"
+"panel_section.collapse_vertical" = "chevron-left.svg"
+"panel_section.expand_horizontal" = "chevron-right.svg"
+"panel_section.collapse_horizontal" = "chevron-down.svg"
+
 "split.horizontal" = "split-horizontal.svg"
 
 "tab.previous" = "chevron-left.svg"

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -387,6 +387,27 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "toggle_panel_bottom_visual")]
     TogglePanelBottomVisual,
 
+    #[strum(serialize = "toggle_panel_visual_in_container")]
+    TogglePanelVisualInContainer,
+
+    #[strum(serialize = "move_panel_to_left_top")]
+    MovePanelToLeftTop,
+
+    #[strum(serialize = "move_panel_to_left_bottom")]
+    MovePanelToLeftBottom,
+
+    #[strum(serialize = "move_panel_to_right_top")]
+    MovePanelToRightTop,
+
+    #[strum(serialize = "move_panel_to_right_bottom")]
+    MovePanelToRightBottom,
+
+    #[strum(serialize = "move_panel_to_bottom_left")]
+    MovePanelToBottomLeft,
+
+    #[strum(serialize = "move_panel_to_bottom_right")]
+    MovePanelToBottomRight,
+
     // Focus toggle commands
     #[strum(message = "Toggle Terminal Focus")]
     #[strum(serialize = "toggle_terminal_focus")]

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -248,10 +248,20 @@ impl LapceIcons {
     pub const PANEL_RESTORE: &str = "panel.restore";
     pub const PANEL_MAXIMISE: &str = "panel.maximise";
 
+    pub const PANEL_RESTORE_LEFT: &str = "panel.restore_left";
+    pub const PANEL_MAXIMISE_LEFT: &str = "panel.maximise_left";
+    pub const PANEL_RESTORE_RIGHT: &str = "panel.restore_right";
+    pub const PANEL_MAXIMISE_RIGHT: &str = "panel.maximise_right";
+    pub const PANEL_RESTORE_BOTTOM: &str = "panel.restore_bottom";
+    pub const PANEL_MAXIMISE_BOTTOM: &str = "panel.maximise_bottom";
+
     pub const PANEL_SECTION_EXPAND_VERTICAL: &str = "panel_section.expand_vertical";
-    pub const PANEL_SECTION_COLLAPSE_VERTICAL: &str = "panel_section.collapse_vertical";
-    pub const PANEL_SECTION_EXPAND_HORIZONTAL: &str = "panel_section.expand_horizontal";
-    pub const PANEL_SECTION_COLLAPSE_HORIZONTAL: &str = "panel_section.collapse_horizontal";
+    pub const PANEL_SECTION_COLLAPSE_VERTICAL: &str =
+        "panel_section.collapse_vertical";
+    pub const PANEL_SECTION_EXPAND_HORIZONTAL: &str =
+        "panel_section.expand_horizontal";
+    pub const PANEL_SECTION_COLLAPSE_HORIZONTAL: &str =
+        "panel_section.collapse_horizontal";
 
     pub const SPLIT_HORIZONTAL: &str = "split.horizontal";
 

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -248,6 +248,11 @@ impl LapceIcons {
     pub const PANEL_RESTORE: &str = "panel.restore";
     pub const PANEL_MAXIMISE: &str = "panel.maximise";
 
+    pub const PANEL_SECTION_EXPAND_VERTICAL: &str = "panel_section.expand_vertical";
+    pub const PANEL_SECTION_COLLAPSE_VERTICAL: &str = "panel_section.collapse_vertical";
+    pub const PANEL_SECTION_EXPAND_HORIZONTAL: &str = "panel_section.expand_horizontal";
+    pub const PANEL_SECTION_COLLAPSE_HORIZONTAL: &str = "panel_section.collapse_horizontal";
+
     pub const SPLIT_HORIZONTAL: &str = "split.horizontal";
 
     pub const TAB_PREVIOUS: &str = "tab.previous";

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1671,8 +1671,10 @@ impl LapceTabData {
             }
             LapceWorkbenchCommand::ToggleMaximizedPanel => {
                 if let Some(data) = data {
-                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
-                        Arc::make_mut(&mut self.panel).toggle_maximize(&kind);
+                    if let Ok(position) =
+                        serde_json::from_value::<PanelPosition>(data)
+                    {
+                        Arc::make_mut(&mut self.panel).toggle_maximize(&position);
                     }
                 } else {
                     Arc::make_mut(&mut self.panel).toggle_active_maximize();

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -1680,6 +1680,54 @@ impl LapceTabData {
                     Arc::make_mut(&mut self.panel).toggle_active_maximize();
                 }
             }
+            LapceWorkbenchCommand::MovePanelToLeftTop => {
+                if let Some(data) = data {
+                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
+                        Arc::make_mut(&mut self.panel)
+                            .handle_move_panel(&kind, &PanelPosition::LeftTop);
+                    }
+                }
+            }
+            LapceWorkbenchCommand::MovePanelToLeftBottom => {
+                if let Some(data) = data {
+                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
+                        Arc::make_mut(&mut self.panel)
+                            .handle_move_panel(&kind, &PanelPosition::LeftBottom);
+                    }
+                }
+            }
+            LapceWorkbenchCommand::MovePanelToRightTop => {
+                if let Some(data) = data {
+                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
+                        Arc::make_mut(&mut self.panel)
+                            .handle_move_panel(&kind, &PanelPosition::RightTop);
+                    }
+                }
+            }
+            LapceWorkbenchCommand::MovePanelToRightBottom => {
+                if let Some(data) = data {
+                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
+                        Arc::make_mut(&mut self.panel)
+                            .handle_move_panel(&kind, &PanelPosition::RightBottom);
+                    }
+                }
+            }
+            LapceWorkbenchCommand::MovePanelToBottomLeft => {
+                if let Some(data) = data {
+                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
+                        Arc::make_mut(&mut self.panel)
+                            .handle_move_panel(&kind, &PanelPosition::BottomLeft);
+                    }
+                }
+            }
+            LapceWorkbenchCommand::MovePanelToBottomRight => {
+                if let Some(data) = data {
+                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
+                        Arc::make_mut(&mut self.panel)
+                            .handle_move_panel(&kind, &PanelPosition::BottomRight);
+                    }
+                }
+            }
             LapceWorkbenchCommand::FocusEditor => {
                 if let Some(active) = *self.main_split.active_tab {
                     ctx.submit_command(Command::new(
@@ -1730,6 +1778,13 @@ impl LapceTabData {
             }
             LapceWorkbenchCommand::TogglePanelBottomVisual => {
                 self.toggle_container_visual(ctx, &PanelContainerPosition::Bottom);
+            }
+            LapceWorkbenchCommand::TogglePanelVisualInContainer => {
+                if let Some(data) = data {
+                    if let Ok(kind) = serde_json::from_value::<PanelKind>(data) {
+                        self.toggle_panel_visual_in_container(ctx, kind);
+                    }
+                }
             }
             LapceWorkbenchCommand::ToggleSourceControlFocus => {
                 self.toggle_panel_focus(ctx, PanelKind::SourceControl);
@@ -2265,6 +2320,14 @@ impl LapceTabData {
         } else {
             self.show_panel(ctx, kind);
         }
+    }
+
+    fn toggle_panel_visual_in_container(
+        &mut self,
+        _ctx: &mut EventCtx,
+        kind: PanelKind,
+    ) {
+        Arc::make_mut(&mut self.panel).toggle_panel_visual_in_container(&kind);
     }
 
     fn toggle_panel_focus(&mut self, ctx: &mut EventCtx, kind: PanelKind) {

--- a/lapce-data/src/panel.rs
+++ b/lapce-data/src/panel.rs
@@ -36,6 +36,17 @@ impl PanelKind {
             PanelKind::Problem => LapceIcons::PROBLEM,
         }
     }
+
+    pub fn panel_name(&self) -> &'static str {
+        match &self {
+            PanelKind::FileExplorer => "File Explorer",
+            PanelKind::SourceControl => "Source Control",
+            PanelKind::Plugin => "Plugin",
+            PanelKind::Terminal => "Terminal",
+            PanelKind::Search => "Search",
+            PanelKind::Problem => "Problem",
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/lapce-ui/src/panel.rs
+++ b/lapce-ui/src/panel.rs
@@ -329,11 +329,16 @@ impl Widget<LapceTabData> for PanelSection {
         if let Some(header) = self.header.as_mut() {
             header.paint(ctx, data, env);
 
-            let icon_name = if self.display_content {
-                LapceIcons::PANEL_RESTORE
+            let mut icon_name = if self.display_content {
+                LapceIcons::PANEL_SECTION_EXPAND_VERTICAL
             } else {
-                LapceIcons::PANEL_MAXIMISE
+                LapceIcons::PANEL_SECTION_COLLAPSE_VERTICAL
             };
+            if let Some((_,position)) = data.panel.panel_position(&self.kind) {
+                if position.is_bottom() {
+                    icon_name = LapceIcons::PANEL_SECTION_COLLAPSE_HORIZONTAL
+                }
+            }
 
             let header_rect = header.layout_rect();
 

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -2375,7 +2375,22 @@ impl Widget<LapceTabData> for LapceTab {
         );
         self.status_height = status_size.height;
 
-        let left_width = data.panel.size.left;
+        let left_width = if data
+            .panel
+            .is_contianer_maximized(&PanelContainerPosition::Left)
+        {
+            self_size.width
+                - if data
+                    .panel
+                    .is_container_shown(&PanelContainerPosition::Right)
+                {
+                    data.panel.size.right
+                } else {
+                    0.0
+                }
+        } else {
+            data.panel.size.left
+        };
         self.panel_left.layout(
             ctx,
             &BoxConstraints::tight(Size::new(
@@ -2387,14 +2402,26 @@ impl Widget<LapceTabData> for LapceTab {
         );
         self.panel_left
             .set_origin(ctx, data, env, Point::new(0.0, title_height));
-        let panel_left_width =
+        let panel_left_width: f64 =
             if data.panel.is_container_shown(&PanelContainerPosition::Left) {
                 left_width
             } else {
                 0.0
             };
 
-        let right_width = data.panel.size.right;
+        let right_width = if data
+            .panel
+            .is_contianer_maximized(&PanelContainerPosition::Right)
+        {
+            self_size.width
+                - if data.panel.is_container_shown(&PanelContainerPosition::Left) {
+                    data.panel.size.left
+                } else {
+                    0.0
+                }
+        } else {
+            data.panel.size.right
+        };
         self.panel_right.layout(
             ctx,
             &BoxConstraints::tight(Size::new(
@@ -2419,7 +2446,10 @@ impl Widget<LapceTabData> for LapceTab {
             0.0
         };
 
-        let bottom_height = if data.panel.panel_bottom_maximized() {
+        let bottom_height = if data
+            .panel
+            .is_contianer_maximized(&PanelContainerPosition::Bottom)
+        {
             self_size.height - status_size.height - title_height
         } else {
             data.panel.size.bottom

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -481,9 +481,6 @@ impl LapceTab {
                 }
 
                 let (_, from_position) = data.panel.panel_position(kind).unwrap();
-                if from_position == *p {
-                    return;
-                }
 
                 let panel = Arc::make_mut(&mut data.panel);
                 if let Some(order) = panel.order.get_mut(&from_position) {
@@ -498,6 +495,7 @@ impl LapceTab {
                     active: 0,
                     shown: true,
                     maximized: false,
+                    panels: im::HashMap::new(),
                 });
 
                 style.active = order.len() - 1;


### PR DESCRIPTION
Panel enhancement:

1. Panel actions (context meun)

**features**:
- hide/show one panel
- maximize/restore/hide panels
- move panel to another position
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/4404609/233956797-7bbc8495-b94c-4876-8c38-7f13e150585b.png">




2.  Allow toggle left/right panel maximize
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/4404609/233956212-97e69d91-cc3f-40e7-a479-341cd871a711.png">

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/4404609/233956357-473ca2dc-fdc0-4d3e-bc50-c62a39b9627a.png">







- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users