### PR TITLE
Always solve relative paths (not symlinks) in cli arguments

### DIFF
--- a/lapce-proxy/src/lib.rs
+++ b/lapce-proxy/src/lib.rs
@@ -27,7 +27,7 @@ use lapce_rpc::{
     RpcMessage,
 };
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[clap(name = "Lapce")]
 #[clap(version=*meta::VERSION)]
 struct Cli {


### PR DESCRIPTION
This will fix an issue where using `.` will cause lapce-proxy to crash because it is trying to create a Url like `./Cargo.toml` which is wrong.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users