### PR TITLE
Svg lapce remote high quality

### DIFF
--- a/icons/lapce/lapce_remote.svg
+++ b/icons/lapce/lapce_remote.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> <!-- Created with Vectornator for iOS (http://vectornator.io/) --><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:vectornator="http://vectornator.io" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 2880 2880" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:vectornator="http://vectornator.io" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-900 -400 4600 3700" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" version="1.1">
 <metadata>
 <vectornator:setting key="WDRulersVisible" value="true"/>
 <vectornator:setting key="WDIsolateActiveLayer" value="false"/>

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -184,17 +184,14 @@ impl Title {
         let remote_svg = data.config.ui_svg(LapceIcons::REMOTE);
         self.svgs.push((
             remote_svg,
-            Size::new(size.height, size.height)
-                .to_rect()
-                .with_origin(Point::new(x + 5.0, 0.0))
-                .inflate(-5.0, -5.0),
+            remote_rect,
             Some(
                 data.config
                     .get_color_unchecked(LapceTheme::LAPCE_REMOTE_ICON)
                     .clone(),
             ),
             None,
-        ));
+        ));     
         let x = x + remote_rect.width();
         let command_rect =
             command_rect.with_size(Size::new(x - command_rect.x0, size.height));


### PR DESCRIPTION
![image](https://github.com/lapce/lapce/assets/38021321/10c4bb6f-89a1-40da-a86c-8979f89ab1eb)

The lapce remote image was ugly distorted with loss of quality due to resizing. I removed the resize and adjusted the svg to keep the previous aspect ratio