### PR TITLE
Add option to hide files from .gitignore (Fixes #811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 
 - [#1964](https://github.com/lapce/lapce/pull/1964): Add option to open files at line/column
+- [#2388](https://github.com/lapce/lapce/pull/2388): Add option to hide gitignored files
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,12 +1901,12 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 1.4.0",
  "fnv",
  "log 0.4.17",
  "regex",
@@ -1950,7 +1960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1345f8d33c89f2d5b081f2f2a41175adef9fd0bed2fea6a26c96c2deb027e58e"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 0.2.17",
  "grep-matcher",
  "log 0.4.17",
  "regex",
@@ -1964,7 +1974,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48852bd08f9b4eb3040ecb6d2f4ade224afe880a9a0909c5563cc59fa67932cc"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "bytecount",
  "encoding_rs",
  "encoding_rs_io",
@@ -2219,11 +2229,10 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
- "crossbeam-utils",
  "globset",
  "lazy_static",
  "log 0.4.17",
@@ -2653,6 +2662,7 @@ dependencies = [
  "fs_extra",
  "fuzzy-matcher",
  "hashbrown 0.12.3",
+ "ignore",
  "im",
  "include_dir",
  "indexmap",

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -29,6 +29,7 @@ highlight-selection-occurrences = true
 highlight-scope-lines = false
 autosave-interval = 0
 format-on-autosave = true
+hide-gitignored-files = false
 enable-inlay-hints = true
 inlay-hint-font-family = ""
 inlay-hint-font-size = 0

--- a/extra/schemas/settings.json
+++ b/extra/schemas/settings.json
@@ -230,6 +230,9 @@
                 "format-on-save": {
                     "type": "boolean"
                 },
+                "hide-gitignored-files": {
+                    "type": "boolean"
+                },
                 "highlight-matching-brackets": {
                     "type": "boolean"
                 },

--- a/lapce-data/Cargo.toml
+++ b/lapce-data/Cargo.toml
@@ -55,6 +55,7 @@ bytemuck = "1.8.0"
 # For parsing markdown data, such as in hovers
 pulldown-cmark = "0.9.1"
 url = "2.3.1"
+ignore = "0.4.20"
 
 [target.'cfg(target_os="macos")'.dependencies]
 dmg = "0.1.1"

--- a/lapce-data/src/config.rs
+++ b/lapce-data/src/config.rs
@@ -478,6 +478,10 @@ pub struct EditorConfig {
     )]
     pub format_on_autosave: bool,
     #[field_names(
+        desc = "Whether to hide files based on the .gitignore at the project root"
+    )]
+    pub hide_gitignored_files: bool,
+    #[field_names(
         desc = "If enabled the cursor treats leading soft tabs as if they are hard tabs."
     )]
     pub atomic_soft_tabs: bool,

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -796,6 +796,7 @@ impl LapceTabData {
             workspace.clone(),
             proxy.clone(),
             event_sink.clone(),
+            &config,
         ));
         let search = Arc::new(SearchData::new());
         let file_picker = Arc::new(FilePickerData::new());


### PR DESCRIPTION
This is a draft PR (unfinished) to an option to hide files based on a `.gitignore` at the project root (Fixes #811).

<img src="https://github.com/lapce/lapce/assets/5875019/a8624f51-1b02-4e05-8be2-c8a30520e2ff" width="491"/>

Remaining work:
 - [ ] Trigger update when config value changed
    - Right now when the config value is changed, it doesn't update the file explorer. I need to find out how to subscribe to this change and trigger an update. Any pointers are welcome

Possible future work:
 - Support nested `.gitignore`  files
 - Support custom ignore patterns