### PR TITLE
Feature: Add basic Vim marks feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 
 - [#1964](https://github.com/lapce/lapce/pull/1964): Add option to open files at line/column
+- [#2403](https://github.com/lapce/lapce/pull/2403): Add basic Vim marks feature
 
 ### Bug Fixes
 

--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -547,6 +547,16 @@ command = "delete_forward"
 mode = "v"
 
 [[keymaps]]
+key = "m"
+command = "create_mark"
+mode = "nv"
+
+[[keymaps]]
+key = "'"
+command = "go_to_mark"
+mode = "nv"
+
+[[keymaps]]
 key = "f"
 command = "inline_find_right"
 mode = "nv"

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -319,6 +319,10 @@ pub enum FocusCommand {
     InlineFindRight,
     #[strum(serialize = "inline_find_left")]
     InlineFindLeft,
+    #[strum(serialize = "create_mark")]
+    CreateMark,
+    #[strum(serialize = "go_to_mark")]
+    GoToMark,
     #[strum(serialize = "repeat_last_inline_find")]
     RepeatLastInlineFind,
     #[strum(message = "Save")]


### PR DESCRIPTION
Adds CreateMark and GoToMark functionality, but only the local version: e.g. within the current buffer. (no global marks yet).
Will add an entry to the changelog.md if everything is fine with MR

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users
