### PR TITLE
Impl completion lens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features/Changes
+- [#2425](https://github.com/lapce/lapce/pull/2425): Reimplement completion lens
 
 ### Bug Fixes
 

--- a/lapce-app/src/config/editor.rs
+++ b/lapce-app/src/config/editor.rs
@@ -177,7 +177,7 @@ impl EditorConfig {
         if self.inlay_hint_font_size < 5
             || self.inlay_hint_font_size > self.font_size
         {
-            self.font_size
+            self.font_size()
         } else {
             self.inlay_hint_font_size
         }
@@ -185,9 +185,17 @@ impl EditorConfig {
 
     pub fn error_lens_font_size(&self) -> usize {
         if self.error_lens_font_size == 0 {
-            self.font_size
+            self.inlay_hint_font_size()
         } else {
             self.error_lens_font_size
+        }
+    }
+
+    pub fn completion_lens_font_size(&self) -> usize {
+        if self.completion_lens_font_size == 0 {
+            self.inlay_hint_font_size()
+        } else {
+            self.completion_lens_font_size
         }
     }
 

--- a/lapce-core/src/buffer/rope_text.rs
+++ b/lapce-core/src/buffer/rope_text.rs
@@ -216,6 +216,14 @@ impl<'a> RopeText<'a> {
         new_offset
     }
 
+    pub fn prev_code_boundary(&self, offset: usize) -> usize {
+        WordCursor::new(self.text, offset).prev_code_boundary()
+    }
+
+    pub fn next_code_boundary(&self, offset: usize) -> usize {
+        WordCursor::new(self.text, offset).next_code_boundary()
+    }
+
     /// Return the previous and end boundaries of the word under cursor.
     pub fn select_word(&self, offset: usize) -> (usize, usize) {
         WordCursor::new(self.text, offset).select_word()


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR reimplements completion lens from #1968, with similar limitations  
- No multiline (need multiline phantom text)
- Doesn't display every possible way of displaying a completion item. Ex: If you type `r` and there's a suggestion for p**r**intln!()', then it won't display that as then lens since it doesn't start with 'r'. 


There is also various added comments to the completion logic, and some rearranging of logic.  
  
I've changed the `config` font size functions to fallback, which I believe is the more correct option based on the docs we have for them. As well, using `font_size` directly when `error lens font size == 0` has the issue that then error lens font size won't be clamped to a reasonable value like `font_size()` does, which this fixes.

------

I'm a bit uncertain that storing that last editor id is the best method for completion lens.   
Updating the document's completion lens needs the `EditorData::cursor` field, to get the offset. However, it is received in `window_tab.rs` and thus wouldn't know which editor data it should utilize.  
I thought of passing the `EditorId` as a field on the request, but I don't think that's a better solution either...