### PR TITLE
Turn `RopeText` into a trait

### DIFF
--- a/lapce-app/src/completion.rs
+++ b/lapce-app/src/completion.rs
@@ -302,10 +302,8 @@ impl CompletionData {
         }
 
         let completion_lens = doc.with_untracked(|doc| {
-            let text = view.text();
-            let rope_text = RopeText::new(&text);
             completion_lens_text(
-                rope_text,
+                view.rope_text(),
                 cursor_offset,
                 self,
                 doc.completion_lens(),
@@ -346,7 +344,7 @@ pub fn clear_completion_lens(doc: RwSignal<Document>) {
 /// Returns `Some(None)` if the completion lens should be shown, but not changed.
 /// Returns `Some(Some(text))` if the completion lens should be shown and changed to the given text.
 fn completion_lens_text(
-    rope_text: RopeText<'_>,
+    rope_text: impl RopeText,
     cursor_offset: usize,
     completion: &CompletionData,
     current_completion: Option<&str>,

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -9,7 +9,7 @@ use floem::{
 };
 use itertools::Itertools;
 use lapce_core::{
-    buffer::{Buffer, InvalLines},
+    buffer::{rope_text::RopeText, Buffer, InvalLines},
     command::EditCommand,
     cursor::Cursor,
     editor::{EditType, Editor},
@@ -647,9 +647,8 @@ impl Document {
                     _ => {}
                 }
 
-                let rope_text = self.buffer.rope_text();
-                let col = rope_text.offset_of_line(line + 1)
-                    - rope_text.offset_of_line(line);
+                let col = self.buffer.offset_of_line(line + 1)
+                    - self.buffer.offset_of_line(line);
                 let fg = {
                     let severity = diag
                         .diagnostic

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -11,7 +11,7 @@ use floem::{
     },
 };
 use lapce_core::{
-    buffer::InvalLines,
+    buffer::{rope_text::RopeText, InvalLines},
     command::{EditCommand, FocusCommand, MotionModeCommand, MultiSelectionCommand},
     cursor::{Cursor, CursorMode},
     editor::EditType,

--- a/lapce-app/src/editor/location.rs
+++ b/lapce-app/src/editor/location.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use floem::peniko::kurbo::Vec2;
-use lapce_core::buffer::Buffer;
+use lapce_core::buffer::{rope_text::RopeText, Buffer};
 use lsp_types::Position;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -25,6 +25,7 @@ use floem::{
     AppContext, Renderer,
 };
 use lapce_core::{
+    buffer::rope_text::{RopeText, RopeTextVal},
     char_buffer::CharBuffer,
     cursor::{ColPosition, CursorMode},
     mode::{Mode, VisualMode},
@@ -1782,6 +1783,13 @@ impl EditorViewData {
     /// Return the underlying `Rope` of the document.
     pub fn text(&self) -> Rope {
         self.doc.with_untracked(|doc| doc.buffer().text().clone())
+    }
+
+    /// Return a [`RopeTextVal`] wrapper.  
+    /// Unfortunately, we can't implement [`RopeText`] directly on [`EditorViewData`] due to
+    /// it not having a reference to the rope.
+    pub fn rope_text(&self) -> RopeTextVal {
+        RopeTextVal::new(self.text())
     }
 
     /// Return the [`Document`]'s [`Find`] instance. Find uses signals, and so can be updated.

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -14,7 +14,9 @@ use floem::{
     },
 };
 use itertools::Itertools;
-use lapce_core::{cursor::Cursor, selection::Selection};
+use lapce_core::{
+    buffer::rope_text::RopeText, cursor::Cursor, selection::Selection,
+};
 use lapce_rpc::{plugin::PluginId, proxy::ProxyResponse};
 use lapce_xi_rope::Rope;
 use lsp_types::{

--- a/lapce-app/src/palette.rs
+++ b/lapce-app/src/palette.rs
@@ -23,7 +23,8 @@ use floem::{
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use itertools::Itertools;
 use lapce_core::{
-    command::FocusCommand, mode::Mode, movement::Movement, selection::Selection,
+    buffer::rope_text::RopeText, command::FocusCommand, mode::Mode,
+    movement::Movement, selection::Selection,
 };
 use lapce_rpc::proxy::ProxyResponse;
 use lapce_xi_rope::Rope;

--- a/lapce-app/src/text_input.rs
+++ b/lapce-app/src/text_input.rs
@@ -24,6 +24,7 @@ use floem::{
     AppContext, Renderer,
 };
 use lapce_core::{
+    buffer::rope_text::RopeText,
     cursor::{Cursor, CursorMode},
     selection::Selection,
 };

--- a/lapce-core/src/buffer/mod.rs
+++ b/lapce-core/src/buffer/mod.rs
@@ -12,12 +12,10 @@ use std::{
 use lapce_xi_rope::{
     delta::InsertDelta,
     diff::{Diff, LineHashDiff},
-    interval::IntervalBounds,
     multiset::{CountMatcher, Subset},
     tree::{Node, NodeInfo},
     Delta, DeltaBuilder, DeltaElement, Interval, Rope, RopeDelta, RopeInfo,
 };
-use lsp_types::Position;
 
 use crate::{
     char_buffer::CharBuffer,
@@ -190,14 +188,6 @@ impl Buffer {
         self.atomic_rev.clone()
     }
 
-    pub fn text(&self) -> &Rope {
-        &self.text
-    }
-
-    pub fn num_lines(&self) -> usize {
-        RopeText::new(&self.text).num_lines()
-    }
-
     fn get_max_line_len(&self) -> (usize, usize) {
         let mut pre_offset = 0;
         let mut max_len = 0;
@@ -245,10 +235,6 @@ impl Buffer {
 
     pub fn max_len(&self) -> usize {
         self.max_len
-    }
-
-    pub fn line_len(&self, line: usize) -> usize {
-        RopeText::new(&self.text).line_len(line)
     }
 
     pub fn init_content(&mut self, content: Rope) {
@@ -727,115 +713,12 @@ impl Buffer {
         Some((delta, inval_lines, edits, cursor_after))
     }
 
-    pub fn rope_text(&self) -> RopeText {
-        RopeText::new(&self.text)
-    }
-
-    pub fn last_line(&self) -> usize {
-        RopeText::new(&self.text).last_line()
-    }
-
-    pub fn offset_of_line(&self, line: usize) -> usize {
-        RopeText::new(&self.text).offset_of_line(line)
-    }
-
-    pub fn offset_line_end(&self, offset: usize, caret: bool) -> usize {
-        RopeText::new(&self.text).offset_line_end(offset, caret)
-    }
-
-    pub fn line_of_offset(&self, offset: usize) -> usize {
-        RopeText::new(&self.text).line_of_offset(offset)
-    }
-
-    /// Converts a UTF8 offset to a UTF16 LSP position
-    pub fn offset_to_position(&self, offset: usize) -> Position {
-        RopeText::new(&self.text).offset_to_position(offset)
-    }
-
-    pub fn offset_of_position(&self, pos: &Position) -> usize {
-        RopeText::new(&self.text).offset_of_position(pos)
-    }
-
-    pub fn position_to_line_col(&self, pos: &Position) -> (usize, usize) {
-        RopeText::new(&self.text).position_to_line_col(pos)
-    }
-
-    pub fn offset_to_line_col(&self, offset: usize) -> (usize, usize) {
-        RopeText::new(&self.text).offset_to_line_col(offset)
-    }
-
-    pub fn offset_of_line_col(&self, line: usize, col: usize) -> usize {
-        RopeText::new(&self.text).offset_of_line_col(line, col)
-    }
-
-    pub fn line_end_col(&self, line: usize, caret: bool) -> usize {
-        RopeText::new(&self.text).line_end_col(line, caret)
-    }
-
-    pub fn first_non_blank_character_on_line(&self, line: usize) -> usize {
-        RopeText::new(&self.text).first_non_blank_character_on_line(line)
-    }
-
-    pub fn indent_on_line(&self, line: usize) -> String {
-        RopeText::new(&self.text).indent_on_line(line)
-    }
-
-    pub fn line_end_offset(&self, line: usize, caret: bool) -> usize {
-        RopeText::new(&self.text).line_end_offset(line, caret)
-    }
-
-    pub fn line_content(&self, line: usize) -> Cow<str> {
-        RopeText::new(&self.text).line_content(line)
-    }
-
-    pub fn prev_grapheme_offset(
-        &self,
-        offset: usize,
-        count: usize,
-        limit: usize,
-    ) -> usize {
-        RopeText::new(&self.text).prev_grapheme_offset(offset, count, limit)
-    }
-
-    pub fn prev_code_boundary(&self, offset: usize) -> usize {
-        WordCursor::new(&self.text, offset).prev_code_boundary()
-    }
-
-    pub fn next_code_boundary(&self, offset: usize) -> usize {
-        WordCursor::new(&self.text, offset).next_code_boundary()
-    }
-
-    pub fn move_left(&self, offset: usize, mode: Mode, count: usize) -> usize {
-        RopeText::new(&self.text).move_left(offset, mode, count)
-    }
-
-    pub fn move_right(&self, offset: usize, mode: Mode, count: usize) -> usize {
-        RopeText::new(&self.text).move_right(offset, mode, count)
-    }
-
     pub fn move_word_forward(&self, offset: usize) -> usize {
         self.move_n_words_forward(offset, 1)
     }
 
     pub fn move_word_backward(&self, offset: usize, mode: Mode) -> usize {
         self.move_n_words_backward(offset, 1, mode)
-    }
-
-    pub fn next_grapheme_offset(
-        &self,
-        offset: usize,
-        count: usize,
-        limit: usize,
-    ) -> usize {
-        RopeText::new(&self.text).next_grapheme_offset(offset, count, limit)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn select_word(&self, offset: usize) -> (usize, usize) {
-        WordCursor::new(&self.text, offset).select_word()
     }
 
     pub fn char_at_offset(&self, offset: usize) -> Option<char> {
@@ -860,61 +743,11 @@ impl Buffer {
             WordCursor::new(&self.text, offset).previous_unmatched(c)
         }
     }
+}
 
-    /// Get the content of the rope as a Cow string, for 'nice' ranges (small, and at the right
-    /// offsets) this will be a reference to the rope's data. Otherwise, it allocates a new string.
-    /// You should be somewhat wary of requesting large parts of the rope, as it will allocate
-    /// a new string since it isn't contiguous in memory for large chunks.
-    pub fn slice_to_cow(&self, range: Range<usize>) -> Cow<str> {
-        self.text
-            .slice_to_cow(range.start.min(self.len())..range.end.min(self.len()))
-    }
-
-    /// Iterate over (utf8_offset, char) values in the given range  
-    /// This uses `iter_chunks` and so does not allocate, compared to `slice_to_cow` which can
-    pub fn char_indices_iter<T: IntervalBounds>(
-        &self,
-        range: T,
-    ) -> impl Iterator<Item = (usize, char)> + '_ {
-        CharIndicesJoin::new(self.text.iter_chunks(range).map(str::char_indices))
-    }
-
-    pub fn len(&self) -> usize {
-        self.text.len()
-    }
-
-    pub fn move_n_paragraphs_forward(&self, offset: usize, count: usize) -> usize {
-        RopeText::new(&self.text).move_n_paragraphs_forward(offset, count)
-    }
-
-    pub fn move_n_paragraphs_backward(&self, offset: usize, count: usize) -> usize {
-        RopeText::new(&self.text).move_n_paragraphs_backward(offset, count)
-    }
-
-    pub fn move_n_words_forward(&self, offset: usize, count: usize) -> usize {
-        RopeText::new(&self.text).move_n_words_forward(offset, count)
-    }
-
-    pub fn move_n_wordends_forward(
-        &self,
-        offset: usize,
-        count: usize,
-        inserting: bool,
-    ) -> usize {
-        RopeText::new(&self.text).move_n_wordends_forward(offset, count, inserting)
-    }
-
-    pub fn move_n_words_backward(
-        &self,
-        offset: usize,
-        count: usize,
-        mode: Mode,
-    ) -> usize {
-        RopeText::new(&self.text).move_n_words_backward(offset, count, mode)
-    }
-
-    pub fn move_word_backward_deletion(&self, offset: usize) -> usize {
-        RopeText::new(&self.text).move_word_backward_deletion(offset)
+impl RopeText for Buffer {
+    fn text(&self) -> &Rope {
+        &self.text
     }
 }
 

--- a/lapce-core/src/buffer/rope_text.rs
+++ b/lapce-core/src/buffer/rope_text.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, ops::Range};
 
-use lapce_xi_rope::{interval::IntervalBounds, Cursor, Rope};
+use lapce_xi_rope::{interval::IntervalBounds, rope::ChunkIter, Cursor, Rope};
 use lsp_types::Position;
 
 use crate::{
@@ -10,55 +10,48 @@ use crate::{
     word::WordCursor,
 };
 
-/// A wrapper around a rope that provides utility functions atop it.
-pub struct RopeText<'a> {
-    text: &'a Rope,
-}
+pub trait RopeText {
+    fn text(&self) -> &Rope;
 
-impl<'a> RopeText<'a> {
-    pub fn new(text: &'a Rope) -> Self {
-        Self { text }
+    fn len(&self) -> usize {
+        self.text().len()
     }
 
-    pub fn len(&self) -> usize {
-        self.text.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// The last line of the held rope
-    pub fn last_line(&self) -> usize {
+    fn last_line(&self) -> usize {
         self.line_of_offset(self.len())
     }
 
     /// Get the offset into the rope of the start of the given line.  
     /// If the line it out of bounds, then the last offset (the len) is returned.
-    pub fn offset_of_line(&self, line: usize) -> usize {
+    fn offset_of_line(&self, line: usize) -> usize {
         let last_line = self.last_line();
         let line = line.min(last_line + 1);
-        self.text.offset_of_line(line)
+        self.text().offset_of_line(line)
     }
 
-    pub fn offset_line_end(&self, offset: usize, caret: bool) -> usize {
+    fn offset_line_end(&self, offset: usize, caret: bool) -> usize {
         let line = self.line_of_offset(offset);
         self.line_end_offset(line, caret)
     }
 
-    pub fn line_of_offset(&self, offset: usize) -> usize {
+    fn line_of_offset(&self, offset: usize) -> usize {
         let offset = offset.min(self.len());
         let offset = self
-            .text
+            .text()
             .at_or_prev_codepoint_boundary(offset)
             .unwrap_or(offset);
 
-        self.text.line_of_offset(offset)
+        self.text().line_of_offset(offset)
     }
 
     /// Converts a UTF8 offset to a UTF16 LSP position  
     /// Returns None if it is not a valid UTF16 offset
-    pub fn offset_to_position(&self, offset: usize) -> Position {
+    fn offset_to_position(&self, offset: usize) -> Position {
         let (line, col) = self.offset_to_line_col(offset);
         let line_offset = self.offset_of_line(line);
 
@@ -71,13 +64,13 @@ impl<'a> RopeText<'a> {
         }
     }
 
-    pub fn offset_of_position(&self, pos: &Position) -> usize {
+    fn offset_of_position(&self, pos: &Position) -> usize {
         let (line, column) = self.position_to_line_col(pos);
 
         self.offset_of_line_col(line, column)
     }
 
-    pub fn position_to_line_col(&self, pos: &Position) -> (usize, usize) {
+    fn position_to_line_col(&self, pos: &Position) -> (usize, usize) {
         let line = pos.line as usize;
         let line_offset = self.offset_of_line(line);
 
@@ -89,7 +82,7 @@ impl<'a> RopeText<'a> {
         (line, column)
     }
 
-    pub fn offset_to_line_col(&self, offset: usize) -> (usize, usize) {
+    fn offset_to_line_col(&self, offset: usize) -> (usize, usize) {
         let offset = offset.min(self.len());
         let line = self.line_of_offset(offset);
         let line_start = self.offset_of_line(line);
@@ -101,7 +94,7 @@ impl<'a> RopeText<'a> {
         (line, col)
     }
 
-    pub fn offset_of_line_col(&self, line: usize, col: usize) -> usize {
+    fn offset_of_line_col(&self, line: usize, col: usize) -> usize {
         let mut pos = 0;
         let mut offset = self.offset_of_line(line);
         for c in self
@@ -122,7 +115,7 @@ impl<'a> RopeText<'a> {
         offset
     }
 
-    pub fn line_end_col(&self, line: usize, caret: bool) -> usize {
+    fn line_end_col(&self, line: usize, caret: bool) -> usize {
         let line_start = self.offset_of_line(line);
         let offset = self.line_end_offset(line, caret);
         offset - line_start
@@ -141,7 +134,7 @@ impl<'a> RopeText<'a> {
     /// // Out of bounds
     /// assert_eq!(text.line_end_offset(2, false), 11); // "world|"
     /// ```
-    pub fn line_end_offset(&self, line: usize, caret: bool) -> usize {
+    fn line_end_offset(&self, line: usize, caret: bool) -> usize {
         let mut offset = self.offset_of_line(line + 1);
         let mut line_content: &str = &self.line_content(line);
         if line_content.ends_with("\r\n") {
@@ -160,20 +153,20 @@ impl<'a> RopeText<'a> {
     /// Returns the content of the given line.
     /// Includes the line ending if it exists. (-> the last line won't have a line ending)    
     /// Lines past the end of the document will return an empty string.
-    pub fn line_content(&self, line: usize) -> Cow<'a, str> {
-        self.text
+    fn line_content(&self, line: usize) -> Cow<'_, str> {
+        self.text()
             .slice_to_cow(self.offset_of_line(line)..self.offset_of_line(line + 1))
     }
 
     /// Get the offset of the previous grapheme cluster.
-    pub fn prev_grapheme_offset(
+    fn prev_grapheme_offset(
         &self,
         offset: usize,
         count: usize,
         limit: usize,
     ) -> usize {
         let offset = offset.min(self.len());
-        let mut cursor = Cursor::new(self.text, offset);
+        let mut cursor = Cursor::new(self.text(), offset);
         let mut new_offset = offset;
         for _i in 0..count {
             if let Some(prev_offset) = cursor.prev_grapheme() {
@@ -189,7 +182,7 @@ impl<'a> RopeText<'a> {
         new_offset
     }
 
-    pub fn next_grapheme_offset(
+    fn next_grapheme_offset(
         &self,
         offset: usize,
         count: usize,
@@ -200,7 +193,7 @@ impl<'a> RopeText<'a> {
         } else {
             offset
         };
-        let mut cursor = Cursor::new(self.text, offset);
+        let mut cursor = Cursor::new(self.text(), offset);
         let mut new_offset = offset;
         for _i in 0..count {
             if let Some(next_offset) = cursor.next_grapheme() {
@@ -216,38 +209,38 @@ impl<'a> RopeText<'a> {
         new_offset
     }
 
-    pub fn prev_code_boundary(&self, offset: usize) -> usize {
-        WordCursor::new(self.text, offset).prev_code_boundary()
+    fn prev_code_boundary(&self, offset: usize) -> usize {
+        WordCursor::new(self.text(), offset).prev_code_boundary()
     }
 
-    pub fn next_code_boundary(&self, offset: usize) -> usize {
-        WordCursor::new(self.text, offset).next_code_boundary()
+    fn next_code_boundary(&self, offset: usize) -> usize {
+        WordCursor::new(self.text(), offset).next_code_boundary()
     }
 
     /// Return the previous and end boundaries of the word under cursor.
-    pub fn select_word(&self, offset: usize) -> (usize, usize) {
-        WordCursor::new(self.text, offset).select_word()
+    fn select_word(&self, offset: usize) -> (usize, usize) {
+        WordCursor::new(self.text(), offset).select_word()
     }
 
     /// Returns the offset of the first non-blank character on the given line.  
     /// If the line is one past the last line, then the offset at the end of the rope is returned.
     /// If the line is further past that, then it defaults to the last line.
-    pub fn first_non_blank_character_on_line(&self, line: usize) -> usize {
+    fn first_non_blank_character_on_line(&self, line: usize) -> usize {
         let last_line = self.last_line();
         let line = if line > last_line + 1 {
             last_line
         } else {
             line
         };
-        let line_start_offset = self.text.offset_of_line(line);
-        WordCursor::new(self.text, line_start_offset).next_non_blank_char()
+        let line_start_offset = self.text().offset_of_line(line);
+        WordCursor::new(self.text(), line_start_offset).next_non_blank_char()
     }
 
-    pub fn indent_on_line(&self, line: usize) -> String {
-        let line_start_offset = self.text.offset_of_line(line);
+    fn indent_on_line(&self, line: usize) -> String {
+        let line_start_offset = self.text().offset_of_line(line);
         let word_boundary =
-            WordCursor::new(self.text, line_start_offset).next_non_blank_char();
-        let indent = self.text.slice_to_cow(line_start_offset..word_boundary);
+            WordCursor::new(self.text(), line_start_offset).next_non_blank_char();
+        let indent = self.text().slice_to_cow(line_start_offset..word_boundary);
         indent.to_string()
     }
 
@@ -255,31 +248,41 @@ impl<'a> RopeText<'a> {
     /// offsets) this will be a reference to the rope's data. Otherwise, it allocates a new string.
     /// You should be somewhat wary of requesting large parts of the rope, as it will allocate
     /// a new string since it isn't contiguous in memory for large chunks.
-    pub fn slice_to_cow(&self, range: Range<usize>) -> Cow<'a, str> {
-        self.text
+    fn slice_to_cow(&self, range: Range<usize>) -> Cow<'_, str> {
+        self.text()
             .slice_to_cow(range.start.min(self.len())..range.end.min(self.len()))
     }
 
+    // TODO(minor): Once you can have an `impl Trait` return type in a trait, this could use that.
     /// Iterate over (utf8_offset, char) values in the given range  
+    #[allow(clippy::type_complexity)]
     /// This uses `iter_chunks` and so does not allocate, compared to `slice_to_cow` which can
-    pub fn char_indices_iter<T: IntervalBounds>(
-        &self,
+    fn char_indices_iter<'a, T: IntervalBounds>(
+        &'a self,
         range: T,
-    ) -> impl Iterator<Item = (usize, char)> + 'a {
-        CharIndicesJoin::new(self.text.iter_chunks(range).map(str::char_indices))
+    ) -> CharIndicesJoin<
+        std::str::CharIndices<'a>,
+        std::iter::Map<ChunkIter<'a>, fn(&str) -> std::str::CharIndices<'_>>,
+    > {
+        let iter: ChunkIter<'a> = self.text().iter_chunks(range);
+        let iter: std::iter::Map<
+            ChunkIter<'a>,
+            fn(&str) -> std::str::CharIndices<'_>,
+        > = iter.map(str::char_indices);
+        CharIndicesJoin::new(iter)
     }
 
     /// The number of lines in the file
-    pub fn num_lines(&self) -> usize {
+    fn num_lines(&self) -> usize {
         self.last_line() + 1
     }
 
     /// The length of the given line
-    pub fn line_len(&self, line: usize) -> usize {
+    fn line_len(&self, line: usize) -> usize {
         self.offset_of_line(line + 1) - self.offset_of_line(line)
     }
 
-    pub fn move_left(&self, offset: usize, mode: Mode, count: usize) -> usize {
+    fn move_left(&self, offset: usize, mode: Mode, count: usize) -> usize {
         let min_offset = if mode == Mode::Insert {
             0
         } else {
@@ -290,7 +293,7 @@ impl<'a> RopeText<'a> {
         self.prev_grapheme_offset(offset, count, min_offset)
     }
 
-    pub fn move_right(&self, offset: usize, mode: Mode, count: usize) -> usize {
+    fn move_right(&self, offset: usize, mode: Mode, count: usize) -> usize {
         let max_offset = if mode == Mode::Insert {
             self.len()
         } else {
@@ -309,7 +312,7 @@ impl<'a> RopeText<'a> {
     where
         F: FnMut(&mut ParagraphCursor) -> Option<usize>,
     {
-        let mut cursor = ParagraphCursor::new(self.text, offset);
+        let mut cursor = ParagraphCursor::new(self.text(), offset);
         let mut new_offset = offset;
         while count != 0 {
             // FIXME: wait for if-let-chain
@@ -323,11 +326,11 @@ impl<'a> RopeText<'a> {
         new_offset
     }
 
-    pub fn move_n_paragraphs_forward(&self, offset: usize, count: usize) -> usize {
+    fn move_n_paragraphs_forward(&self, offset: usize, count: usize) -> usize {
         self.find_nth_paragraph(offset, count, |cursor| cursor.next_boundary())
     }
 
-    pub fn move_n_paragraphs_backward(&self, offset: usize, count: usize) -> usize {
+    fn move_n_paragraphs_backward(&self, offset: usize, count: usize) -> usize {
         self.find_nth_paragraph(offset, count, |cursor| cursor.prev_boundary())
     }
 
@@ -347,7 +350,7 @@ impl<'a> RopeText<'a> {
     where
         F: FnMut(&mut WordCursor) -> Option<usize>,
     {
-        let mut cursor = WordCursor::new(self.text, offset);
+        let mut cursor = WordCursor::new(self.text(), offset);
         let mut new_offset = offset;
         while count != 0 {
             // FIXME: wait for if-let-chain
@@ -361,11 +364,11 @@ impl<'a> RopeText<'a> {
         new_offset
     }
 
-    pub fn move_n_words_forward(&self, offset: usize, count: usize) -> usize {
+    fn move_n_words_forward(&self, offset: usize, count: usize) -> usize {
         self.find_nth_word(offset, count, |cursor| cursor.next_boundary())
     }
 
-    pub fn move_n_wordends_forward(
+    fn move_n_wordends_forward(
         &self,
         offset: usize,
         count: usize,
@@ -379,7 +382,7 @@ impl<'a> RopeText<'a> {
         new_offset
     }
 
-    pub fn move_n_words_backward(
+    fn move_n_words_backward(
         &self,
         offset: usize,
         count: usize,
@@ -388,8 +391,47 @@ impl<'a> RopeText<'a> {
         self.find_nth_word(offset, count, |cursor| cursor.prev_boundary(mode))
     }
 
-    pub fn move_word_backward_deletion(&self, offset: usize) -> usize {
+    fn move_word_backward_deletion(&self, offset: usize) -> usize {
         self.find_nth_word(offset, 1, |cursor| cursor.prev_deletion_boundary())
+    }
+}
+
+#[derive(Clone)]
+pub struct RopeTextVal {
+    pub text: Rope,
+}
+impl RopeTextVal {
+    pub fn new(text: Rope) -> Self {
+        Self { text }
+    }
+}
+impl RopeText for RopeTextVal {
+    fn text(&self) -> &Rope {
+        &self.text
+    }
+}
+impl From<Rope> for RopeTextVal {
+    fn from(text: Rope) -> Self {
+        Self::new(text)
+    }
+}
+#[derive(Clone)]
+pub struct RopeTextRef<'a> {
+    pub text: &'a Rope,
+}
+impl<'a> RopeTextRef<'a> {
+    pub fn new(text: &'a Rope) -> Self {
+        Self { text }
+    }
+}
+impl<'a> RopeText for RopeTextRef<'a> {
+    fn text(&self) -> &Rope {
+        self.text
+    }
+}
+impl<'a> From<&'a Rope> for RopeTextRef<'a> {
+    fn from(text: &'a Rope) -> Self {
+        Self::new(text)
     }
 }
 
@@ -464,19 +506,21 @@ impl<I: Iterator<Item = (usize, char)>, O: Iterator<Item = I>> Iterator
 mod tests {
     use lapce_xi_rope::Rope;
 
+    use crate::buffer::rope_text::RopeTextVal;
+
     use super::RopeText;
 
     #[test]
     fn test_line_content() {
         let text = Rope::from("");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.line_content(0), "");
         assert_eq!(text.line_content(1), "");
         assert_eq!(text.line_content(2), "");
 
         let text = Rope::from("abc\ndef\nghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.line_content(0), "abc\n");
         assert_eq!(text.line_content(1), "def\n");
@@ -486,7 +530,7 @@ mod tests {
         assert_eq!(text.line_content(5), "");
 
         let text = Rope::from("abc\r\ndef\r\nghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.line_content(0), "abc\r\n");
         assert_eq!(text.line_content(1), "def\r\n");
@@ -499,14 +543,14 @@ mod tests {
     #[test]
     fn test_offset_of_line() {
         let text = Rope::from("");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.offset_of_line(0), 0);
         assert_eq!(text.offset_of_line(1), 0);
         assert_eq!(text.offset_of_line(2), 0);
 
         let text = Rope::from("abc\ndef\nghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.offset_of_line(0), 0);
         assert_eq!(text.offset_of_line(1), 4);
@@ -516,7 +560,7 @@ mod tests {
         assert_eq!(text.offset_of_line(5), text.len());
 
         let text = Rope::from("abc\r\ndef\r\nghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.offset_of_line(0), 0);
         assert_eq!(text.offset_of_line(1), 5);
@@ -529,7 +573,7 @@ mod tests {
     #[test]
     fn test_line_end_offset() {
         let text = Rope::from("");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.line_end_offset(0, false), 0);
         assert_eq!(text.line_end_offset(0, true), 0);
@@ -539,7 +583,7 @@ mod tests {
         assert_eq!(text.line_end_offset(2, true), 0);
 
         let text = Rope::from("abc\ndef\nghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.line_end_offset(0, false), 2);
         assert_eq!(text.line_end_offset(0, true), 3);
@@ -556,7 +600,8 @@ mod tests {
         // because you don't seem to be able to do a `use RopeText` in a doc test since it isn't
         // public..
         let text = Rope::from("hello\nworld");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
+
         assert_eq!(text.line_end_offset(0, false), 4); // "hell|o"
         assert_eq!(text.line_end_offset(0, true), 5); // "hello|"
         assert_eq!(text.line_end_offset(1, false), 10); // "worl|d"
@@ -568,14 +613,14 @@ mod tests {
     #[test]
     fn test_prev_grapheme_offset() {
         let text = Rope::from("");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.prev_grapheme_offset(0, 0, 0), 0);
         assert_eq!(text.prev_grapheme_offset(0, 1, 0), 0);
         assert_eq!(text.prev_grapheme_offset(0, 1, 1), 0);
 
         let text = Rope::from("abc def ghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.prev_grapheme_offset(0, 0, 0), 0);
         assert_eq!(text.prev_grapheme_offset(0, 1, 0), 0);
@@ -587,14 +632,14 @@ mod tests {
     #[test]
     fn test_first_non_blank_character_on_line() {
         let text = Rope::from("");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.first_non_blank_character_on_line(0), 0);
         assert_eq!(text.first_non_blank_character_on_line(1), 0);
         assert_eq!(text.first_non_blank_character_on_line(2), 0);
 
         let text = Rope::from("abc\ndef\nghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.first_non_blank_character_on_line(0), 0);
         assert_eq!(text.first_non_blank_character_on_line(1), 4);
@@ -604,7 +649,7 @@ mod tests {
         assert_eq!(text.first_non_blank_character_on_line(5), 8);
 
         let text = Rope::from("abc\r\ndef\r\nghi");
-        let text = RopeText::new(&text);
+        let text = RopeTextVal::new(text);
 
         assert_eq!(text.first_non_blank_character_on_line(0), 0);
         assert_eq!(text.first_non_blank_character_on_line(1), 5);

--- a/lapce-core/src/buffer/test.rs
+++ b/lapce-core/src/buffer/test.rs
@@ -1,4 +1,4 @@
-use super::Buffer;
+use super::{Buffer, RopeText};
 
 mod editing {
     use lapce_xi_rope::Rope;

--- a/lapce-core/src/cursor.rs
+++ b/lapce-core/src/cursor.rs
@@ -2,7 +2,7 @@ use lapce_xi_rope::{RopeDelta, Transformer};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    buffer::Buffer,
+    buffer::{rope_text::RopeText, Buffer},
     mode::{Mode, MotionMode, VisualMode},
     register::RegisterData,
     selection::{InsertDrift, SelRegion, Selection},

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use lapce_xi_rope::RopeDelta;
 
 use crate::{
-    buffer::{Buffer, InvalLines},
+    buffer::{rope_text::RopeText, Buffer, InvalLines},
     command::EditCommand,
     cursor::{get_first_selection_after, Cursor, CursorMode},
     mode::{Mode, MotionMode, VisualMode},
@@ -1525,7 +1525,7 @@ enum DuplicateDirection {
 #[cfg(test)]
 mod test {
     use crate::{
-        buffer::Buffer,
+        buffer::{rope_text::RopeText, Buffer},
         cursor::{Cursor, CursorMode},
         editor::{DuplicateDirection, Editor},
         selection::{SelRegion, Selection},

--- a/lapce-core/src/indent.rs
+++ b/lapce-core/src/indent.rs
@@ -1,7 +1,7 @@
 use lapce_xi_rope::Rope;
 
 use crate::{
-    buffer::Buffer,
+    buffer::{rope_text::RopeText, Buffer},
     chars::{char_is_line_ending, char_is_whitespace},
     selection::Selection,
 };

--- a/lapce-core/src/syntax/edit.rs
+++ b/lapce-core/src/syntax/edit.rs
@@ -1,7 +1,7 @@
 use lapce_xi_rope::Rope;
 use tree_sitter::Point;
 
-use crate::buffer::rope_text::RopeText;
+use crate::buffer::rope_text::{RopeText, RopeTextRef};
 
 #[derive(Clone)]
 pub struct SyntaxEdit(pub(crate) Vec<tree_sitter::InputEdit>);
@@ -13,7 +13,7 @@ impl SyntaxEdit {
 }
 
 fn point_at_offset(text: &Rope, offset: usize) -> Point {
-    let text = RopeText::new(text);
+    let text = RopeTextRef::new(text);
     let line = text.line_of_offset(offset);
     let col = text.offset_of_line(line + 1).saturating_sub(offset);
     Point::new(line, col)

--- a/lapce-data/src/atomic_soft_tabs.rs
+++ b/lapce-data/src/atomic_soft_tabs.rs
@@ -1,4 +1,4 @@
-use lapce_core::buffer::Buffer;
+use lapce_core::buffer::{rope_text::RopeText, Buffer};
 
 /// The direction to snap. Left is used when moving left, Right when moving right.
 /// Nearest is used for mouse selection.

--- a/lapce-data/src/command.rs
+++ b/lapce-data/src/command.rs
@@ -6,7 +6,7 @@ use druid::{
 };
 use indexmap::IndexMap;
 use lapce_core::{
-    buffer::DiffLines,
+    buffer::{rope_text::RopeText, DiffLines},
     command::{
         EditCommand, FocusCommand, MotionModeCommand, MoveCommand,
         MultiSelectionCommand,

--- a/lapce-data/src/completion.rs
+++ b/lapce-data/src/completion.rs
@@ -4,7 +4,7 @@ use anyhow::Error;
 use core::fmt;
 use druid::{EventCtx, Size, WidgetId};
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
-use lapce_core::command::FocusCommand;
+use lapce_core::{buffer::rope_text::RopeText, command::FocusCommand};
 use lapce_rpc::{buffer::BufferId, plugin::PluginId};
 use lsp_types::{CompletionItem, CompletionResponse, CompletionTextEdit, Position};
 use once_cell::sync::Lazy;

--- a/lapce-data/src/data.rs
+++ b/lapce-data/src/data.rs
@@ -22,6 +22,7 @@ use druid::{
 use im::Vector;
 use itertools::Itertools;
 use lapce_core::{
+    buffer::rope_text::RopeText,
     command::{FocusCommand, MultiSelectionCommand},
     cursor::{Cursor, CursorMode},
     directory::Directory,

--- a/lapce-data/src/document.rs
+++ b/lapce-data/src/document.rs
@@ -14,7 +14,7 @@ use druid::{
 };
 use itertools::Itertools;
 use lapce_core::{
-    buffer::{Buffer, DiffLines, InvalLines},
+    buffer::{rope_text::RopeText, Buffer, DiffLines, InvalLines},
     char_buffer::CharBuffer,
     command::{EditCommand, MultiSelectionCommand},
     cursor::{ColPosition, Cursor, CursorMode},
@@ -1261,9 +1261,8 @@ impl Document {
                     _ => {}
                 }
 
-                let rope_text = self.buffer.rope_text();
-                let col = rope_text.offset_of_line(line + 1)
-                    - rope_text.offset_of_line(line);
+                let col = self.buffer.offset_of_line(line + 1)
+                    - self.buffer.offset_of_line(line);
                 let fg = {
                     let severity = diag
                         .diagnostic

--- a/lapce-data/src/editor.rs
+++ b/lapce-data/src/editor.rs
@@ -19,7 +19,7 @@ use druid::{
 use indexmap::IndexMap;
 pub use lapce_core::syntax::Syntax;
 use lapce_core::{
-    buffer::{Buffer, DiffLines, InvalLines},
+    buffer::{rope_text::RopeText, Buffer, DiffLines, InvalLines},
     command::{EditCommand, FocusCommand, MotionModeCommand, MultiSelectionCommand},
     editor::EditType,
     mode::{Mode, MotionMode},

--- a/lapce-data/src/explorer.rs
+++ b/lapce-data/src/explorer.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use druid::{Command, EventCtx, ExtEventSink, Target, WidgetId};
-use lapce_core::{cursor::CursorMode, selection::Selection};
+use lapce_core::{
+    buffer::rope_text::RopeText, cursor::CursorMode, selection::Selection,
+};
 use lapce_rpc::{file::FileNodeItem, proxy::ProxyResponse};
 use lapce_xi_rope::Rope;
 

--- a/lapce-data/src/history.rs
+++ b/lapce-data/src/history.rs
@@ -12,7 +12,7 @@ use druid::{
 };
 use itertools::Itertools;
 use lapce_core::{
-    buffer::{rope_diff, Buffer, DiffLines},
+    buffer::{rope_diff, rope_text::RopeText, Buffer, DiffLines},
     style::line_styles,
     syntax::Syntax,
 };

--- a/lapce-data/src/palette.rs
+++ b/lapce-data/src/palette.rs
@@ -18,6 +18,7 @@ use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use lapce_core::{
+    buffer::rope_text::RopeText,
     command::{EditCommand, FocusCommand},
     language::LapceLanguage,
     mode::Mode,

--- a/lapce-data/src/rename.rs
+++ b/lapce-data/src/rename.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use druid::{Command, EventCtx, ExtEventSink, Target, WidgetId};
-use lapce_core::buffer::Buffer;
+use lapce_core::buffer::{rope_text::RopeText, Buffer};
 use lapce_xi_rope::Rope;
 use lsp_types::{Position, PrepareRenameResponse};
 

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -12,7 +12,10 @@ use anyhow::{anyhow, Result};
 use crossbeam_channel::{Receiver, Sender};
 use dyn_clone::DynClone;
 use jsonrpc_lite::{Id, JsonRpc, Params};
-use lapce_core::{buffer::rope_text::RopeText, encoding::offset_utf16_to_utf8};
+use lapce_core::{
+    buffer::rope_text::{RopeText, RopeTextRef},
+    encoding::offset_utf16_to_utf8,
+};
 use lapce_rpc::{
     plugin::{PluginId, VoltID},
     style::{LineStyle, Style},
@@ -1022,7 +1025,7 @@ fn get_document_content_change(
     let (interval, _) = delta.summary();
     let (start, end) = interval.start_end();
 
-    let text = RopeText::new(text);
+    let text = RopeTextRef::new(text);
 
     // TODO: Handle more trivial cases like typing when there's a selection or transpose
     if let Some(node) = delta.as_simple_insert() {
@@ -1069,7 +1072,7 @@ fn format_semantic_styles(
     let semantic_tokens_provider = semantic_tokens_provider?;
     let semantic_legends = semantic_tokens_legend(semantic_tokens_provider);
 
-    let text = RopeText::new(text);
+    let text = RopeTextRef::new(text);
     let mut highlights = Vec::new();
     let mut line = 0;
     let mut start = 0;

--- a/lapce-ui/src/diff.rs
+++ b/lapce-ui/src/diff.rs
@@ -5,7 +5,10 @@ use druid::{
     LifeCycleCtx, MouseEvent, PaintCtx, Point, Rect, RenderContext, Size, Target,
     UpdateCtx, Widget, WidgetId,
 };
-use lapce_core::{buffer::DiffLines, command::FocusCommand};
+use lapce_core::{
+    buffer::{rope_text::RopeText, DiffLines},
+    command::FocusCommand,
+};
 use lapce_data::{
     command::{CommandKind, LapceCommand, LAPCE_COMMAND},
     config::{LapceIcons, LapceTheme},

--- a/lapce-ui/src/editor.rs
+++ b/lapce-ui/src/editor.rs
@@ -9,7 +9,7 @@ use druid::{
     Widget, WidgetId,
 };
 use lapce_core::{
-    buffer::DiffLines,
+    buffer::{rope_text::RopeText, DiffLines},
     command::{EditCommand, FocusCommand},
     cursor::{ColPosition, CursorMode},
     mode::{Mode, VisualMode},

--- a/lapce-ui/src/editor/gutter.rs
+++ b/lapce-ui/src/editor/gutter.rs
@@ -4,7 +4,7 @@ use druid::{
     LifeCycleCtx, PaintCtx, Point, Rect, RenderContext, Size, Target, UpdateCtx,
     Widget, WidgetId,
 };
-use lapce_core::buffer::DiffLines;
+use lapce_core::buffer::{rope_text::RopeText, DiffLines};
 use lapce_data::document::BufferContent;
 use lapce_data::history::DocumentHistory;
 use lapce_data::{

--- a/lapce-ui/src/editor/view.rs
+++ b/lapce-ui/src/editor/view.rs
@@ -11,7 +11,10 @@ use druid::{
     SingleUse, Size, Target, TimerToken, Vec2, Widget, WidgetExt, WidgetId,
     WidgetPod,
 };
-use lapce_core::command::{EditCommand, FocusCommand};
+use lapce_core::{
+    buffer::rope_text::RopeText,
+    command::{EditCommand, FocusCommand},
+};
 use lapce_data::{
     command::{
         CommandExecuted, CommandKind, EnsureVisiblePosition, LapceCommand,

--- a/lapce-ui/src/plugin.rs
+++ b/lapce-ui/src/plugin.rs
@@ -10,7 +10,7 @@ use druid::{
     FontWeight, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Point, Rect,
     RenderContext, Size, Target, TimerToken, UpdateCtx, Widget, WidgetExt, WidgetId,
 };
-use lapce_core::command::FocusCommand;
+use lapce_core::{buffer::rope_text::RopeText, command::FocusCommand};
 use lapce_data::{
     command::{CommandKind, LapceUICommand, LAPCE_COMMAND, LAPCE_UI_COMMAND},
     config::{LapceConfig, LapceIcons, LapceTheme},

--- a/lapce-ui/src/settings.rs
+++ b/lapce-ui/src/settings.rs
@@ -15,6 +15,7 @@ use druid::{
 use inflector::Inflector;
 use itertools::Itertools;
 use lapce_core::{
+    buffer::rope_text::RopeText,
     command::{EditCommand, MoveCommand},
     mode::Mode,
 };

--- a/lapce-ui/src/tab.rs
+++ b/lapce-ui/src/tab.rs
@@ -10,6 +10,7 @@ use druid::{
 };
 use itertools::Itertools;
 use lapce_core::{
+    buffer::rope_text::RopeText,
     command::FocusCommand,
     cursor::{Cursor, CursorMode},
     language::LapceLanguage,

--- a/lapce-ui/src/title.rs
+++ b/lapce-ui/src/title.rs
@@ -9,7 +9,7 @@ use druid::{
     RenderContext, Size, Target, TimerToken, Widget, WidgetExt, WidgetId, WidgetPod,
     WindowConfig, WindowState,
 };
-use lapce_core::{command::FocusCommand, meta};
+use lapce_core::{buffer::rope_text::RopeText, command::FocusCommand, meta};
 use lapce_data::{
     command::{
         CommandKind, LapceCommand, LapceUICommand, LapceWorkbenchCommand,


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR turns `RopeText` into a general trait that can be implemented on multiple different types.  
This helps avoid redeclaring a massive number of wrapper functions.

- This does not implement the trait on `Rope`, since `Rope` has various functions with the same name as the trait functions but with alternative behavior.
  - There are now two wrappers for `Rope`, similar to what `RopeText` was before, but simpler to implement since they can share logic.
  - We could just modify our fork of `Rope` to remove/rename the conflicting functions, but it doesn't matter much.
- I also did the imports for lapce-data/lapce-app as needed; even though we aren't using that, we don't want to get distracted by the errors


This works less well than I hoped, as `EditorViewData` can't implement `RopeText` itself, but I think it is still an overall improvement.