### PR TITLE
Dispatch cmd properly

### DIFF
--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -39,7 +39,7 @@ use crate::{
     id::WindowTabId,
     keypress::{condition::Condition, KeyPressData, KeyPressFocus},
     main_split::{MainSplitData, SplitData, SplitDirection},
-    palette::{kind::PaletteKind, PaletteData},
+    palette::{kind::PaletteKind, PaletteData, PaletteStatus},
     panel::{
         data::{default_panel_order, PanelData},
         kind::PanelKind,
@@ -420,9 +420,18 @@ impl WindowTabData {
             CommandKind::Workbench(command) => {
                 self.run_workbench_command(command, cmd.data);
             }
-            CommandKind::Edit(_) => {}
-            CommandKind::Move(_) => {}
-            CommandKind::Focus(_) => {}
+            CommandKind::Focus(_) | CommandKind::Edit(_) | CommandKind::Move(_) => {
+                if self.palette.status.get_untracked() != PaletteStatus::Inactive {
+                    self.palette.run_command(&cmd, None, Modifiers::default());
+                } else if let Some(editor_data) =
+                    self.main_split.active_editor.get_untracked()
+                {
+                    let editor_data = editor_data.get_untracked();
+                    editor_data.run_command(&cmd, None, Modifiers::default());
+                } else {
+                    // TODO: dispatch to current focused view?
+                }
+            }
             CommandKind::MotionMode(_) => {}
             CommandKind::MultiSelection(_) => {}
         }


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This dispatches focus commands properly.  
For example, using "Save" in the palette would not work due to this not being hooked up. Now that the command is sent to the right place, the palette command works properly.  

I tried to roughly imitate the logic in [lapce-data/data.rs](https://github.com/lapce/lapce/blob/b89c76931b5665742c5d0ae648e636cc9732b400/lapce-data/src/data.rs#L2187). I'm not certain of what general way to send a focus command to the current `focus` would be.  