### PR TITLE
Reimplement various workbench commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,6 +3204,7 @@ dependencies = [
  "lsp-types",
  "notify",
  "once_cell",
+ "open",
  "parking_lot 0.11.2",
  "rayon",
  "regex",

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -36,6 +36,7 @@ smallvec.workspace = true
 include_dir.workspace = true
 regex.workspace = true
 Inflector = "0.11.4"
+open = "3.0.2"
 unicode-width = "0.1.10"
 fuzzy-matcher = "0.3.7"
 sled = "0.34.7"

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -1469,7 +1469,9 @@ fn palette_item(
         PaletteItemContent::Command { .. }
         | PaletteItemContent::Line { .. }
         | PaletteItemContent::Workspace { .. }
-        | PaletteItemContent::SshHost { .. } => {
+        | PaletteItemContent::SshHost { .. }
+        | PaletteItemContent::ColorTheme { .. }
+        | PaletteItemContent::IconTheme { .. } => {
             let text = item.filter_text;
             let indices = item.indices;
             container_box(move || {

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -329,12 +329,15 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "toggle_panel_visual")]
     TogglePanelVisual,
 
+    #[strum(message = "Toggle Left Panel")]
     #[strum(serialize = "toggle_panel_left_visual")]
     TogglePanelLeftVisual,
 
+    #[strum(message = "Toggle Right Panel")]
     #[strum(serialize = "toggle_panel_right_visual")]
     TogglePanelRightVisual,
 
+    #[strum(message = "Toggle Bottom Panel")]
     #[strum(serialize = "toggle_panel_bottom_visual")]
     TogglePanelBottomVisual,
 
@@ -425,11 +428,11 @@ pub enum LapceWorkbenchCommand {
     ChangeFileLanguage,
 
     #[strum(serialize = "next_editor_tab")]
-    #[strum(message = "Next editor tab")]
+    #[strum(message = "Next Editor Tab")]
     NextEditorTab,
 
     #[strum(serialize = "previous_editor_tab")]
-    #[strum(message = "Previous editor tab")]
+    #[strum(message = "Previous Editor Tab")]
     PreviousEditorTab,
 
     #[strum(serialize = "toggle_inlay_hints")]
@@ -484,6 +487,7 @@ pub enum LapceWorkbenchCommand {
 
 #[derive(Clone, Debug)]
 pub enum InternalCommand {
+    ReloadConfig,
     OpenFile {
         path: PathBuf,
     },
@@ -574,6 +578,17 @@ pub enum InternalCommand {
     },
     FocusEditorTab {
         editor_tab_id: EditorTabId,
+    },
+
+    SetColorTheme {
+        name: String,
+        /// Whether to save the theme to the config file
+        save: bool,
+    },
+    SetIconTheme {
+        name: String,
+        /// Whether to save the theme to the config file
+        save: bool,
     },
 }
 

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -1526,7 +1526,7 @@ impl EditorData {
         }
     }
 
-    fn save(&self, exit: bool, allow_formatting: bool) {
+    pub fn save(&self, exit: bool, allow_formatting: bool) {
         let (rev, is_pristine, content) = self.doc.with_untracked(|doc| {
             (doc.rev(), doc.buffer().is_pristine(), doc.content.clone())
         });

--- a/lapce-app/src/palette/item.rs
+++ b/lapce-app/src/palette/item.rs
@@ -57,4 +57,10 @@ pub enum PaletteItemContent {
         mode: RunDebugMode,
         config: RunDebugConfig,
     },
+    ColorTheme {
+        name: String,
+    },
+    IconTheme {
+        name: String,
+    },
 }

--- a/lapce-app/src/palette/kind.rs
+++ b/lapce-app/src/palette/kind.rs
@@ -9,6 +9,8 @@ pub enum PaletteKind {
     WorkspaceSymbol,
     SshHost,
     RunAndDebug,
+    ColorTheme,
+    IconTheme,
 }
 
 impl PaletteKind {
@@ -23,8 +25,8 @@ impl PaletteKind {
             PaletteKind::Command => ":",
             PaletteKind::File
             | PaletteKind::Reference
-            // | PaletteKind::ColorTheme
-            // | PaletteKind::IconTheme
+            | PaletteKind::ColorTheme
+            | PaletteKind::IconTheme
             | PaletteKind::SshHost
             | PaletteKind::RunAndDebug
             // | PaletteKind::Language 
@@ -59,8 +61,8 @@ impl PaletteKind {
         match self {
             PaletteKind::File
             | PaletteKind::Reference
-            // | PaletteKind::ColorTheme
-            // | PaletteKind::IconTheme
+            | PaletteKind::ColorTheme
+            | PaletteKind::IconTheme
             // | PaletteKind::Language
             | PaletteKind::RunAndDebug
             | PaletteKind::SshHost

--- a/lapce-app/src/panel/data.rs
+++ b/lapce-app/src/panel/data.rs
@@ -239,6 +239,8 @@ impl PanelData {
         }
     }
 
+    /// Get the active panel kind at that position, if any.  
+    /// `tracked` decides whether it should track the signal or not.
     pub fn active_panel_at_position(
         &self,
         position: &PanelPosition,


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR's focus is reimplementing a variety of the missing workbench commands.  

- `OpenFile`
- `RevealActiveFileInFileExplorer`
- `ChangeColorTheme` / `ChangeIconTheme`
  - This required some minor changes in how palette works.
  - It also changes the config to sort the theme names, which will make the ordering consistent between palette and settings dropdown
- `Open{Settings,Logs}{File,Directory}` / `OpenKeyboardShortcutsFile` / `Open{Proxy,Themes,Plugins}Directory`
  - We don't have the keyboard shortcuts menu reimplemented, so `OpenKeyboardShortcuts` is not implemented.
- `SaveAll`
- `TogglePanel{Left,Right,Bottom}Visual`
- `SourceControlInit`, I'd wait on the others until there's a panel
  
Other:
- Modifies `config` color/icon theme lists to be `im::Vector` to make them cheaper to clone. This is what they were previously.
- Fixes a bug where `terminal.indexed_colors` would not be initialized if `resolve_theme` was called.