### PR TITLE
Use Listener for commands

### DIFF
--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -256,12 +256,12 @@ fn editor_tab_header(
                         move || {
                             let editor_tab_id =
                                 editor_tab.with_untracked(|t| t.editor_tab_id);
-                            internal_command.set(Some(
+                            internal_command.send(
                                 InternalCommand::EditorTabChildClose {
                                     editor_tab_id,
                                     child: child_for_close.clone(),
                                 },
-                            ));
+                            );
                         },
                         || false,
                         || false,
@@ -393,10 +393,10 @@ fn editor_tab_header(
                 move || {
                     let editor_tab_id =
                         editor_tab.with_untracked(|t| t.editor_tab_id);
-                    internal_command.set(Some(InternalCommand::Split {
+                    internal_command.send(InternalCommand::Split {
                         direction: SplitDirection::Vertical,
                         editor_tab_id,
-                    }));
+                    });
                 },
                 || false,
                 || false,
@@ -408,9 +408,8 @@ fn editor_tab_header(
                 move || {
                     let editor_tab_id =
                         editor_tab.with_untracked(|t| t.editor_tab_id);
-                    internal_command.set(Some(InternalCommand::EditorTabClose {
-                        editor_tab_id,
-                    }));
+                    internal_command
+                        .send(InternalCommand::EditorTabClose { editor_tab_id });
                 },
                 || false,
                 || false,
@@ -530,8 +529,7 @@ fn editor_tab(
             focus.set(Focus::Workbench);
         }
         let editor_tab_id = editor_tab.with_untracked(|t| t.editor_tab_id);
-        internal_command
-            .set(Some(InternalCommand::FocusEditorTab { editor_tab_id }));
+        internal_command.send(InternalCommand::FocusEditorTab { editor_tab_id });
         false
     })
     .style(|| Style::BASE.flex_col().size_pct(100.0, 100.0))
@@ -2010,8 +2008,7 @@ fn window_tab(window_tab_data: Arc<WindowTabData>) -> impl View {
     let update_in_progress = window_tab_data.update_in_progress;
     let config = window_tab_data.common.config;
     let workspace = window_tab_data.workspace.clone();
-    let set_workbench_command =
-        window_tab_data.common.workbench_command.write_only();
+    let workbench_command = window_tab_data.common.workbench_command;
     let main_split = window_tab_data.main_split.clone();
 
     let view = stack(|| {
@@ -2022,7 +2019,7 @@ fn window_tab(window_tab_data: Arc<WindowTabData>) -> impl View {
                         workspace,
                         main_split,
                         source_control,
-                        set_workbench_command,
+                        workbench_command,
                         latest_release,
                         update_in_progress,
                         config,

--- a/lapce-app/src/code_action.rs
+++ b/lapce-app/src/code_action.rs
@@ -199,10 +199,10 @@ impl CodeActionData {
         if let Some(item) = self.filtered_items.get(self.active.get_untracked()) {
             self.common
                 .internal_command
-                .set(Some(InternalCommand::RunCodeAction {
+                .send(InternalCommand::RunCodeAction {
                     plugin_id: item.plugin_id,
                     action: item.item.clone(),
-                }));
+                });
         }
         self.cancel();
     }

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -352,13 +352,13 @@ impl EditorData {
             if let Some(path) = path {
                 let offset = self.cursor.with_untracked(|c| c.offset());
                 let scroll_offset = self.viewport.get_untracked().origin().to_vec2();
-                self.common.internal_command.set(Some(
+                self.common.internal_command.send(
                     InternalCommand::SaveJumpLocation {
                         path,
                         offset,
                         scroll_offset,
                     },
-                ));
+                );
             }
         }
         self.last_movement.set(movement.clone());
@@ -412,79 +412,75 @@ impl EditorData {
         match cmd {
             FocusCommand::SplitVertical => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
-                    self.common
-                        .internal_command
-                        .set(Some(InternalCommand::Split {
-                            direction: SplitDirection::Vertical,
-                            editor_tab_id,
-                        }));
+                    self.common.internal_command.send(InternalCommand::Split {
+                        direction: SplitDirection::Vertical,
+                        editor_tab_id,
+                    });
                 }
             }
             FocusCommand::SplitHorizontal => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
-                    self.common
-                        .internal_command
-                        .set(Some(InternalCommand::Split {
-                            direction: SplitDirection::Horizontal,
-                            editor_tab_id,
-                        }));
+                    self.common.internal_command.send(InternalCommand::Split {
+                        direction: SplitDirection::Horizontal,
+                        editor_tab_id,
+                    });
                 }
             }
             FocusCommand::SplitRight => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
-                    self.common.internal_command.set(Some(
-                        InternalCommand::SplitMove {
+                    self.common
+                        .internal_command
+                        .send(InternalCommand::SplitMove {
                             direction: SplitMoveDirection::Right,
                             editor_tab_id,
-                        },
-                    ));
+                        });
                 }
             }
             FocusCommand::SplitLeft => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
-                    self.common.internal_command.set(Some(
-                        InternalCommand::SplitMove {
+                    self.common
+                        .internal_command
+                        .send(InternalCommand::SplitMove {
                             direction: SplitMoveDirection::Left,
                             editor_tab_id,
-                        },
-                    ));
+                        });
                 }
             }
             FocusCommand::SplitUp => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
-                    self.common.internal_command.set(Some(
-                        InternalCommand::SplitMove {
+                    self.common
+                        .internal_command
+                        .send(InternalCommand::SplitMove {
                             direction: SplitMoveDirection::Up,
                             editor_tab_id,
-                        },
-                    ));
+                        });
                 }
             }
             FocusCommand::SplitDown => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
-                    self.common.internal_command.set(Some(
-                        InternalCommand::SplitMove {
+                    self.common
+                        .internal_command
+                        .send(InternalCommand::SplitMove {
                             direction: SplitMoveDirection::Down,
                             editor_tab_id,
-                        },
-                    ));
+                        });
                 }
             }
             FocusCommand::SplitExchange => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
                     self.common
                         .internal_command
-                        .set(Some(InternalCommand::SplitExchange { editor_tab_id }));
+                        .send(InternalCommand::SplitExchange { editor_tab_id });
                 }
             }
             FocusCommand::SplitClose => {
                 if let Some(editor_tab_id) = self.editor_tab_id {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::EditorTabChildClose {
                             editor_tab_id,
                             child: EditorTabChild::Editor(self.editor_id),
                         },
-                    ));
+                    );
                 }
             }
             FocusCommand::PageUp => {
@@ -730,10 +726,10 @@ impl EditorData {
             match d {
                 DefinitionOrReferece::Location(location) => {
                     internal_command
-                        .set(Some(InternalCommand::JumpToLocation { location }));
+                        .send(InternalCommand::JumpToLocation { location });
                 }
                 DefinitionOrReferece::References(locations) => {
-                    internal_command.set(Some(InternalCommand::PaletteReferences {
+                    internal_command.send(InternalCommand::PaletteReferences {
                         references: locations
                             .into_iter()
                             .map(|l| EditorLocation {
@@ -746,7 +742,7 @@ impl EditorData {
                                 same_editor_tab: false,
                             })
                             .collect(),
-                    }));
+                    });
                 }
             }
         });
@@ -1491,13 +1487,13 @@ impl EditorData {
             .with_untracked(|doc| doc.code_actions.get(&offset).cloned());
         if let Some(code_actions) = code_actions {
             if !code_actions.1.is_empty() {
-                self.common.internal_command.set(Some(
+                self.common.internal_command.send(
                     InternalCommand::ShowCodeActions {
                         offset,
                         mouse_click,
                         code_actions,
                     },
-                ));
+                );
             }
         }
     }
@@ -1578,11 +1574,9 @@ impl EditorData {
             )
         });
         self.common.find.whole_words.set(true);
-        self.common
-            .internal_command
-            .set(Some(InternalCommand::Search {
-                pattern: Some(word),
-            }));
+        self.common.internal_command.send(InternalCommand::Search {
+            pattern: Some(word),
+        });
         let next = self.common.find.next(buffer.text(), offset, false, true);
 
         if let Some((start, _end)) = next {
@@ -1713,12 +1707,12 @@ impl EditorData {
                         doc.buffer().slice_to_cow(start..end).to_string()
                     })
                 });
-                internal_command.set(Some(InternalCommand::StartRename {
+                internal_command.send(InternalCommand::StartRename {
                     path: local_path.clone(),
                     placeholder,
                     start,
                     position,
-                }));
+                });
             }
         });
         self.common
@@ -1783,7 +1777,7 @@ impl EditorData {
 
         self.common
             .internal_command
-            .set(Some(InternalCommand::Search { pattern }));
+            .send(InternalCommand::Search { pattern });
         self.common.find.visual.set(true);
         self.find_focus.set(true);
         self.common.find.replace_focus.set(false);
@@ -1793,7 +1787,7 @@ impl EditorData {
         if let Some(editor_tab_id) = self.editor_tab_id {
             self.common
                 .internal_command
-                .set(Some(InternalCommand::FocusEditorTab { editor_tab_id }));
+                .send(InternalCommand::FocusEditorTab { editor_tab_id });
         }
         self.common.focus.set(Focus::Workbench);
         self.find_focus.set(false);
@@ -1941,21 +1935,21 @@ impl KeyPressFocus for EditorData {
                 | CommandKind::Move(_)
                 | CommandKind::MultiSelection(_) => {
                     if self.common.find.replace_focus.get_untracked() {
-                        self.common.internal_command.set(Some(
+                        self.common.internal_command.send(
                             InternalCommand::ReplaceEditorCommand {
                                 command: command.clone(),
                                 count,
                                 mods,
                             },
-                        ));
+                        );
                     } else {
-                        self.common.internal_command.set(Some(
+                        self.common.internal_command.send(
                             InternalCommand::FindEditorCommand {
                                 command: command.clone(),
                                 count,
                                 mods,
                             },
-                        ));
+                        );
                     }
                     return CommandExecuted::Yes;
                 }
@@ -1999,13 +1993,13 @@ impl KeyPressFocus for EditorData {
         {
             // find/relace editor receive char
             if self.common.find.replace_focus.get_untracked() {
-                self.common.internal_command.set(Some(
+                self.common.internal_command.send(
                     InternalCommand::ReplaceEditorReceiveChar { s: c.to_string() },
-                ));
+                );
             } else {
-                self.common.internal_command.set(Some(
+                self.common.internal_command.send(
                     InternalCommand::FindEditorReceiveChar { s: c.to_string() },
-                ));
+                );
             }
         } else {
             // normal editor receive char

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -1655,7 +1655,7 @@ fn find_view(
                 editor
                     .common
                     .internal_command
-                    .set(Some(InternalCommand::FocusEditorTab { editor_tab_id }));
+                    .send(InternalCommand::FocusEditorTab { editor_tab_id });
             }
             true
         })

--- a/lapce-app/src/file_explorer/node.rs
+++ b/lapce-app/src/file_explorer/node.rs
@@ -11,7 +11,7 @@ use floem::{
 use indexmap::IndexMap;
 use lapce_rpc::proxy::{ProxyResponse, ProxyRpcHandler};
 
-use crate::command::InternalCommand;
+use crate::{command::InternalCommand, listener::Listener};
 
 #[derive(Clone)]
 pub struct FileNode {
@@ -24,7 +24,7 @@ pub struct FileNode {
     pub children_open_count: RwSignal<usize>,
     pub all_files: RwSignal<im::HashMap<PathBuf, FileNode>>,
     pub line_height: Memo<f64>,
-    pub internal_command: RwSignal<Option<InternalCommand>>,
+    pub internal_command: Listener<InternalCommand>,
 }
 
 impl VirtualListVector<(PathBuf, FileNode)> for FileNode {
@@ -60,9 +60,9 @@ impl FileNode {
         if self.is_dir {
             self.toggle_expand(proxy)
         } else {
-            self.internal_command.set(Some(InternalCommand::OpenFile {
+            self.internal_command.send(InternalCommand::OpenFile {
                 path: self.path.clone(),
-            }))
+            })
         }
     }
 

--- a/lapce-app/src/lib.rs
+++ b/lapce-app/src/lib.rs
@@ -14,6 +14,7 @@ pub mod focus_text;
 pub mod global_search;
 pub mod id;
 pub mod keypress;
+pub mod listener;
 pub mod main_split;
 pub mod palette;
 pub mod panel;

--- a/lapce-app/src/listener.rs
+++ b/lapce-app/src/listener.rs
@@ -1,0 +1,67 @@
+use floem::reactive::{
+    create_effect, create_rw_signal, RwSignal, Scope, SignalGet, SignalSet,
+};
+
+/// A signal listener that receives 'events' from the outside and runs the callback.  
+/// This is implemented using effects and normal rw signals. This should be used when it doesn't  
+/// make sense to think of it as 'storing' a value, like an `RwSignal` would typically be used for.
+///  
+/// Copied/Cloned listeners refer to the same listener.
+#[derive(Debug)]
+pub struct Listener<T: 'static> {
+    val: RwSignal<Option<T>>,
+}
+impl<T: Clone + 'static> Listener<T> {
+    pub fn new(cx: Scope, on_val: impl Fn(T) + 'static) -> Listener<T> {
+        let val = create_rw_signal(cx, None);
+
+        let listener = Listener { val };
+        listener.listen(cx, on_val);
+
+        listener
+    }
+
+    /// Construct a listener when you already have a signal.  
+    pub fn new_with(
+        cx: Scope,
+        val: RwSignal<Option<T>>,
+        on_val: impl Fn(T) + 'static,
+    ) -> Listener<T> {
+        let listener = Listener { val };
+        listener.listen(cx, on_val);
+
+        listener
+    }
+
+    /// Construct a listener when you can't yet give it a callback.  
+    /// Call `listen` to set a callback.
+    pub fn new_empty(cx: Scope) -> Listener<T> {
+        let val = create_rw_signal(cx, None);
+        Listener { val }
+    }
+
+    /// Listen for values sent to this listener.  
+    pub fn listen(self, cx: Scope, on_val: impl Fn(T) + 'static) {
+        let val = self.val;
+
+        create_effect(cx, move |_| {
+            // TODO(minor): Signals could have a `take` method to avoid cloning.
+            if let Some(cmd) = val.get() {
+                on_val(cmd);
+            }
+        });
+    }
+
+    /// Send a value to the listener.
+    pub fn send(&self, v: T) {
+        self.val.set(Some(v));
+    }
+}
+impl<T: 'static> Copy for Listener<T> {}
+impl<T: 'static> Clone for Listener<T> {
+    fn clone(&self) -> Self {
+        Listener {
+            val: self.val.clone(),
+        }
+    }
+}

--- a/lapce-app/src/palette.rs
+++ b/lapce-app/src/palette.rs
@@ -713,7 +713,7 @@ impl PaletteData {
                 let path = path.join(".lapce").join("run.toml");
                 self.common
                     .internal_command
-                    .set(Some(InternalCommand::OpenFile { path }));
+                    .send(InternalCommand::OpenFile { path });
             }
         }
         let executed_run_configs = self.executed_run_configs.borrow();
@@ -808,11 +808,11 @@ impl PaletteData {
         if let Some(item) = items.get(index) {
             match &item.content {
                 PaletteItemContent::File { full_path, .. } => {
-                    self.common.internal_command.set(Some(
-                        InternalCommand::OpenFile {
+                    self.common
+                        .internal_command
+                        .send(InternalCommand::OpenFile {
                             path: full_path.to_owned(),
-                        },
-                    ));
+                        });
                 }
                 PaletteItemContent::Line { line, .. } => {
                     let editor = self.main_split.active_editor.get_untracked();
@@ -827,7 +827,7 @@ impl PaletteData {
                         Some(path) => path,
                         None => return,
                     };
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::JumpToLocation {
                             location: EditorLocation {
                                 path,
@@ -837,35 +837,35 @@ impl PaletteData {
                                 same_editor_tab: false,
                             },
                         },
-                    ));
+                    );
                 }
                 PaletteItemContent::Command { cmd } => {
-                    self.common.lapce_command.set(Some(cmd.clone()));
+                    self.common.lapce_command.send(cmd.clone());
                 }
                 PaletteItemContent::Workspace { workspace } => {
-                    self.common.window_command.set(Some(
-                        WindowCommand::SetWorkspace {
+                    self.common
+                        .window_command
+                        .send(WindowCommand::SetWorkspace {
                             workspace: workspace.clone(),
-                        },
-                    ));
+                        });
                 }
                 PaletteItemContent::Reference { location, .. } => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::JumpToLocation {
                             location: location.clone(),
                         },
-                    ));
+                    );
                 }
                 PaletteItemContent::SshHost { host } => {
-                    self.common.window_command.set(Some(
-                        WindowCommand::SetWorkspace {
+                    self.common
+                        .window_command
+                        .send(WindowCommand::SetWorkspace {
                             workspace: LapceWorkspace {
                                 kind: LapceWorkspaceType::RemoteSSH(host.clone()),
                                 path: None,
                                 last_open: 0,
                             },
-                        },
-                    ));
+                        });
                 }
                 PaletteItemContent::DocumentSymbol { range, .. } => {
                     let editor = self.main_split.active_editor.get_untracked();
@@ -880,7 +880,7 @@ impl PaletteData {
                         Some(path) => path,
                         None => return,
                     };
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::JumpToLocation {
                             location: EditorLocation {
                                 path,
@@ -892,50 +892,50 @@ impl PaletteData {
                                 same_editor_tab: false,
                             },
                         },
-                    ));
+                    );
                 }
                 PaletteItemContent::WorkspaceSymbol { location, .. } => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::JumpToLocation {
                             location: location.clone(),
                         },
-                    ));
+                    );
                 }
                 PaletteItemContent::RunAndDebug { mode, config } => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::RunAndDebug {
                             mode: *mode,
                             config: config.clone(),
                         },
-                    ));
+                    );
                 }
                 PaletteItemContent::ColorTheme { name } => self
                     .common
                     .internal_command
-                    .set(Some(InternalCommand::SetColorTheme {
+                    .send(InternalCommand::SetColorTheme {
                         name: name.clone(),
                         save: true,
-                    })),
+                    }),
                 PaletteItemContent::IconTheme { name } => self
                     .common
                     .internal_command
-                    .set(Some(InternalCommand::SetIconTheme {
+                    .send(InternalCommand::SetIconTheme {
                         name: name.clone(),
                         save: true,
-                    })),
+                    }),
             }
         } else if self.kind.get_untracked() == PaletteKind::SshHost {
             let input = self.input.with_untracked(|input| input.input.clone());
             let ssh = SshHost::from_string(&input);
             self.common
                 .window_command
-                .set(Some(WindowCommand::SetWorkspace {
+                .send(WindowCommand::SetWorkspace {
                     workspace: LapceWorkspace {
                         kind: LapceWorkspaceType::RemoteSSH(ssh),
                         path: None,
                         last_open: 0,
                     },
-                }));
+                });
         }
     }
 
@@ -1038,17 +1038,17 @@ impl PaletteData {
                 PaletteItemContent::ColorTheme { name } => self
                     .common
                     .internal_command
-                    .set(Some(InternalCommand::SetColorTheme {
+                    .send(InternalCommand::SetColorTheme {
                         name: name.clone(),
                         save: false,
-                    })),
+                    }),
                 PaletteItemContent::IconTheme { name } => self
                     .common
                     .internal_command
-                    .set(Some(InternalCommand::SetIconTheme {
+                    .send(InternalCommand::SetIconTheme {
                         name: name.clone(),
                         save: false,
-                    })),
+                    }),
             }
         }
     }
@@ -1061,7 +1061,7 @@ impl PaletteData {
             // TODO(minor): We don't really need to reload the *entire config* here!
             self.common
                 .internal_command
-                .set(Some(InternalCommand::ReloadConfig));
+                .send(InternalCommand::ReloadConfig);
         }
 
         self.close();

--- a/lapce-app/src/panel/debug_view.rs
+++ b/lapce-app/src/panel/debug_view.rs
@@ -21,6 +21,7 @@ use crate::{
     config::{color::LapceColor, icon::LapceIcons, LapceConfig},
     debug::{RunDebugMode, StackTraceData},
     editor::location::{EditorLocation, EditorPosition},
+    listener::Listener,
     terminal::panel::TerminalPanelData,
     window_tab::WindowTabData,
 };
@@ -296,7 +297,7 @@ fn debug_stack_frames(
     thread_id: ThreadId,
     stack_trace: StackTraceData,
     stopped: RwSignal<bool>,
-    internal_command: RwSignal<Option<InternalCommand>>,
+    internal_command: Listener<InternalCommand>,
     config: ReadSignal<Arc<LapceConfig>>,
 ) -> impl View {
     let expanded = stack_trace.expanded;
@@ -374,22 +375,20 @@ fn debug_stack_frames(
                     })
                     .on_click(move |_| {
                         if let Some(path) = full_path.clone() {
-                            internal_command.set(Some(
-                                InternalCommand::JumpToLocation {
-                                    location: EditorLocation {
-                                        path,
-                                        position: Some(EditorPosition::Position(
-                                            lsp_types::Position {
-                                                line: line as u32,
-                                                character: col as u32,
-                                            },
-                                        )),
-                                        scroll_offset: None,
-                                        ignore_unconfirmed: false,
-                                        same_editor_tab: false,
-                                    },
+                            internal_command.send(InternalCommand::JumpToLocation {
+                                location: EditorLocation {
+                                    path,
+                                    position: Some(EditorPosition::Position(
+                                        lsp_types::Position {
+                                            line: line as u32,
+                                            character: col as u32,
+                                        },
+                                    )),
+                                    scroll_offset: None,
+                                    ignore_unconfirmed: false,
+                                    same_editor_tab: false,
                                 },
-                            ));
+                            });
                         }
                         true
                     })
@@ -423,7 +422,7 @@ fn debug_stack_frames(
 
 fn debug_stack_traces(
     terminal: TerminalPanelData,
-    internal_command: RwSignal<Option<InternalCommand>>,
+    internal_command: Listener<InternalCommand>,
     config: ReadSignal<Arc<LapceConfig>>,
 ) -> impl View {
     container(move || {

--- a/lapce-app/src/panel/global_search_view.rs
+++ b/lapce-app/src/panel/global_search_view.rs
@@ -2,9 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use floem::{
     event::EventListener,
-    reactive::{
-        ReadSignal, RwSignal, SignalGet, SignalGetUntracked, SignalSet, SignalUpdate,
-    },
+    reactive::{ReadSignal, SignalGet, SignalGetUntracked, SignalSet, SignalUpdate},
     style::{CursorStyle, Style},
     view::View,
     views::{
@@ -21,6 +19,7 @@ use crate::{
     editor::location::{EditorLocation, EditorPosition},
     focus_text::focus_text,
     global_search::{GlobalSearchData, SearchMatchData},
+    listener::Listener,
     text_input::text_input,
     window_tab::{Focus, WindowTabData},
     workspace::LapceWorkspace,
@@ -121,7 +120,7 @@ pub fn global_search_panel(
 fn search_result(
     workspace: Arc<LapceWorkspace>,
     global_search_data: GlobalSearchData,
-    internal_command: RwSignal<Option<InternalCommand>>,
+    internal_command: Listener<InternalCommand>,
     config: ReadSignal<Arc<LapceConfig>>,
 ) -> impl View {
     let ui_line_height = global_search_data.common.ui_line_height;
@@ -315,7 +314,7 @@ fn search_result(
                                             .margin_left_px(10.0 + icon_size + 6.0)
                                     })
                                     .on_click(move |_| {
-                                        internal_command.set(Some(
+                                        internal_command.send(
                                             InternalCommand::JumpToLocation {
                                                 location: EditorLocation {
                                                     path: path.clone(),
@@ -330,7 +329,7 @@ fn search_result(
                                                     same_editor_tab: false,
                                                 },
                                             },
-                                        ));
+                                        );
                                         true
                                     })
                                     .hover_style(move || {

--- a/lapce-app/src/rename.rs
+++ b/lapce-app/src/rename.rs
@@ -139,7 +139,7 @@ impl RenameData {
             let send = create_ext_action(self.common.scope, move |result| {
                 if let Ok(ProxyResponse::Rename { edit }) = result {
                     internal_command
-                        .set(Some(InternalCommand::ApplyWorkspaceEdit { edit }));
+                        .send(InternalCommand::ApplyWorkspaceEdit { edit });
                 }
             });
             self.common.proxy.rename(

--- a/lapce-app/src/terminal/data.rs
+++ b/lapce-app/src/terminal/data.rs
@@ -218,39 +218,39 @@ impl KeyPressFocus for TerminalData {
                     ));
                 }
                 FocusCommand::SplitVertical => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::SplitTerminal {
                             term_id: self.term_id,
                         },
-                    ));
+                    );
                 }
                 FocusCommand::SplitHorizontal => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::SplitTerminal {
                             term_id: self.term_id,
                         },
-                    ));
+                    );
                 }
                 FocusCommand::SplitLeft => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::SplitTerminalPrevious {
                             term_id: self.term_id,
                         },
-                    ));
+                    );
                 }
                 FocusCommand::SplitRight => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::SplitTerminalNext {
                             term_id: self.term_id,
                         },
-                    ));
+                    );
                 }
                 FocusCommand::SplitExchange => {
-                    self.common.internal_command.set(Some(
+                    self.common.internal_command.send(
                         InternalCommand::SplitTerminalExchange {
                             term_id: self.term_id,
                         },
-                    ));
+                    );
                 }
                 FocusCommand::SearchForward => {
                     // if let Some(search_string) = self.find.search_string.as_ref() {


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Uses the listener ~~from https://github.com/lapce/floem/pull/55~~ for command receiving.  
This simplifies some of the code, removing the need to use `Some` in all the locations, and makes it more obvious what the command fields are for.  


~~The CI build will fail since this needs to be updated to point at the right commit!~~