### PR TITLE
Fix Horizontal scroll bar not automatically hidden when no text is out of bounds.

### DIFF
--- a/lapce-ui/src/scroll.rs
+++ b/lapce-ui/src/scroll.rs
@@ -330,7 +330,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for ClipBox<T, W> {
         bc.debug_check("ClipBox");
 
         let content_size = self.child.layout(ctx, bc, data, env);
-        
+
         // Check if the content size is smaller than the viewport size.
         if content_size.width <= self.port.rect.width() {
             self.constrain_horizontal = false;


### PR DESCRIPTION
- [ ] Fix horizontal scroll bar not automatically hidden when no text is out of bounds.

to commit #2446 