### PR TITLE
Show Lapce as an option when doing "Open With..." on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features/Changes
 - [#2425](https://github.com/lapce/lapce/pull/2425): Reimplement completion lens
+- [#2498](https://github.com/lapce/lapce/pull/2498): Show Lapce as an option when doing "Open With..." on Linux
 
 ### Bug Fixes
 

--- a/extra/linux/dev.lapce.lapce.desktop
+++ b/extra/linux/dev.lapce.lapce.desktop
@@ -9,7 +9,7 @@ GenericName=Code Editor
 StartupWMClass=lapce
 
 Icon=dev.lapce.lapce
-Exec=lapce
+Exec=lapce %F
 Terminal=false
 MimeType=text/plain;inode/directory;
 Actions=new-window;


### PR DESCRIPTION
Fixes #2494, it seems that there needs to be a `%F` to be able to use Lapce as an option.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users