### PR TITLE
ci: use stable alpine release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
         uses: jirutka/setup-alpine@v1
         with:
           arch: ${{ matrix.platform }}
-          branch: edge
+          branch: v3.18
           packages: ${{ env.PACKAGES }}
           shell-name: alpine-target.sh
 
@@ -186,7 +186,7 @@ jobs:
         uses: jirutka/setup-alpine@v1
         with:
           arch: x86_64
-          branch: edge
+          branch: v3.18
           packages: ${{ env.PACKAGES }}
           volumes: ${{ steps.alpine-target.outputs.root-path }}:${{ env.CROSS_SYSROOT }}
           shell-name: alpine.sh


### PR DESCRIPTION
caused by https://git.alpinelinux.org/aports/commit/?id=cab9b787b39387f0b3d30d218b0739c3e21aefb8
should be fixed in rust at some point https://github.com/rust-lang/rust/pull/106246
