### PR TITLE
Custom terminal shell config now accepts quoted paths with spaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features/Changes
 - [#2425](https://github.com/lapce/lapce/pull/2425): Reimplement completion lens
+- [#2522](https://github.com/lapce/lapce/pull/2522): Custom shell paths can now have spaces if the path is quoted.
 
 ### Bug Fixes
 

--- a/lapce-app/src/config/terminal.rs
+++ b/lapce-app/src/config/terminal.rs
@@ -19,7 +19,9 @@ pub struct TerminalConfig {
         desc = "Set the terminal line height, If 0, it uses editor line height"
     )]
     pub line_height: usize,
-    #[field_names(desc = "Set the terminal Shell")]
+    #[field_names(
+        desc = "Set the terminal Shell. Put double quotes around the path if there is a space in it."
+    )]
     pub shell: String,
 
     #[serde(skip)]


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

The custom terminal shell option will now accept commands like `"C:\Program Files\Git\bin\bash.exe" -i` and correctly execute them.

Fixes #1155.