### PR TITLE
Add libxkbcommon-x11-devel as a dependency in lapce.spec

### DIFF
--- a/lapce.spec
+++ b/lapce.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/lapce/lapce
 VCS:            {{{ git_dir_vcs }}}
 Source:        	{{{ git_dir_pack }}}
 
-BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel perl-lib perl-File-Compare mold clang
+BuildRequires:  cargo perl-FindBin cairo-devel cairo-gobject-devel atk-devel gdk-pixbuf2-devel pango-devel gtk3-devel perl-lib perl-File-Compare mold clang libxkbcommon-x11-devel
 
 %description
 Lapce is written in pure Rust with a UI in Druid (which is also written in Rust).


### PR DESCRIPTION
Fixes build on Fedora and other rpm-based distros.