### PR TITLE
Re-implemented "About Lapce" popup.

### DIFF
--- a/lapce-app/src/about.rs
+++ b/lapce-app/src/about.rs
@@ -1,0 +1,212 @@
+use std::sync::Arc;
+
+use floem::{
+    event::EventListener,
+    peniko::Color,
+    reactive::{
+        create_rw_signal, RwSignal, Scope, SignalGet, SignalGetUntracked, SignalSet,
+    },
+    style::{CursorStyle, Display, Position, Style},
+    view::View,
+    views::{container, label, stack, svg, Decorators},
+};
+use lapce_core::{command::FocusCommand, meta::VERSION, mode::Mode};
+
+use crate::{
+    command::{CommandExecuted, CommandKind},
+    config::color::LapceColor,
+    keypress::KeyPressFocus,
+    web_link::web_link,
+    window_tab::{Focus, WindowTabData},
+};
+
+struct AboutUri {}
+
+impl AboutUri {
+    const LAPCE: &str = "https://lapce.dev";
+    const GITHUB: &str = "https://github.com/lapce/lapce";
+    const MATRIX: &str = "https://matrix.to/#/#lapce-editor:matrix.org";
+    const DISCORD: &str = "https://discord.gg/n8tGJ6Rn6D";
+    const CODICONS: &str = "https://github.com/microsoft/vscode-codicons";
+}
+
+#[derive(Clone)]
+pub struct AboutData {
+    pub visible: RwSignal<bool>,
+    pub focus: RwSignal<Focus>,
+}
+
+impl AboutData {
+    pub fn new(cx: Scope, focus: RwSignal<Focus>) -> Self {
+        let visible = create_rw_signal(cx, false);
+
+        Self { visible, focus }
+    }
+
+    pub fn open(&self) {
+        self.visible.set(true);
+        self.focus.set(Focus::AboutPopup);
+    }
+
+    pub fn close(&self) {
+        self.visible.set(false);
+        self.focus.set(Focus::Workbench);
+    }
+}
+
+impl KeyPressFocus for AboutData {
+    fn get_mode(&self) -> Mode {
+        Mode::Visual
+    }
+
+    fn check_condition(
+        &self,
+        _condition: crate::keypress::condition::Condition,
+    ) -> bool {
+        self.visible.get_untracked()
+    }
+
+    fn run_command(
+        &self,
+        command: &crate::command::LapceCommand,
+        _count: Option<usize>,
+        _mods: floem::glazier::Modifiers,
+    ) -> crate::command::CommandExecuted {
+        match &command.kind {
+            CommandKind::Workbench(_) => {}
+            CommandKind::Edit(_) => {}
+            CommandKind::Move(_) => {}
+            CommandKind::Focus(cmd) => {
+                if cmd == &FocusCommand::ModalClose {
+                    self.close();
+                }
+            }
+            CommandKind::MotionMode(_) => {}
+            CommandKind::MultiSelection(_) => {}
+        }
+        CommandExecuted::Yes
+    }
+
+    fn receive_char(&self, _c: &str) {}
+
+    fn focus_only(&self) -> bool {
+        true
+    }
+}
+
+pub fn about_popup(window_tab_data: Arc<WindowTabData>) -> impl View {
+    let about_data = window_tab_data.about_data.clone();
+    let config = window_tab_data.common.config;
+    let internal_command = window_tab_data.common.internal_command;
+    let logo_size = 100.0;
+
+    exclusive_popup(window_tab_data, about_data.visible, move || {
+        stack(move || {
+            (
+                svg(move || (*config.get()).logo_svg()).style(move || {
+                    Style::BASE.size_px(logo_size, logo_size).color(
+                        *config.get().get_color(LapceColor::EDITOR_FOREGROUND),
+                    )
+                }),
+                label(|| "Lapce".to_string()).style(move || {
+                    Style::BASE.font_bold().color(
+                        *config.get().get_color(LapceColor::EDITOR_FOREGROUND),
+                    )
+                }),
+                label(|| format!("Version: {}", VERSION)).style(move || {
+                    Style::BASE
+                        .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                }),
+                label(|| "Links".to_string()).style(move || {
+                    Style::BASE
+                        .font_bold()
+                        .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                        .margin_top_px(20.0)
+                }),
+                web_link(
+                    || "Website".to_string(),
+                    || AboutUri::LAPCE.to_string(),
+                    move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                    internal_command,
+                ),
+                web_link(
+                    || "GitHub".to_string(),
+                    || AboutUri::GITHUB.to_string(),
+                    move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                    internal_command,
+                ),
+                web_link(
+                    || "Discord".to_string(),
+                    || AboutUri::DISCORD.to_string(),
+                    move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                    internal_command,
+                ),
+                web_link(
+                    || "Matrix".to_string(),
+                    || AboutUri::MATRIX.to_string(),
+                    move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                    internal_command,
+                ),
+                label(|| "Attributions".to_string()).style(move || {
+                    Style::BASE
+                        .font_bold()
+                        .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                        .margin_top_px(20.0)
+                }),
+                web_link(
+                    || "Codicons (CC-BY-4.0)".to_string(),
+                    || AboutUri::CODICONS.to_string(),
+                    move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                    internal_command,
+                ),
+            )
+        })
+        .style(|| Style::BASE.flex_col().items_center())
+    })
+}
+
+fn exclusive_popup<V: View>(
+    window_tab_data: Arc<WindowTabData>,
+    visibility: RwSignal<bool>,
+    content: impl FnOnce() -> V,
+) -> impl View {
+    let config = window_tab_data.common.config;
+
+    container(move || {
+        container(move || {
+            container(content)
+                .style(move || {
+                    let config = config.get();
+                    Style::BASE
+                        .padding_vert_px(25.0)
+                        .padding_horiz_px(50.0)
+                        .border(1.0)
+                        .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                        .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                })
+                .on_event(EventListener::PointerDown, move |_| true)
+        })
+        .style(move || Style::BASE.flex_grow(1.0).flex_row().items_center())
+        .hover_style(move || Style::BASE.cursor(CursorStyle::Default))
+    })
+    .on_event(EventListener::PointerDown, move |_| {
+        window_tab_data.about_data.close();
+        true
+    })
+    // Prevent things behind the grayed out area from being hovered.
+    .on_event(EventListener::PointerMove, move |_| true)
+    .style(move || {
+        Style::BASE
+            .display(if visibility.get() {
+                Display::Flex
+            } else {
+                Display::None
+            })
+            .position(Position::Absolute)
+            .size_pct(100.0, 100.0)
+            .flex_col()
+            .items_center()
+            .background(Color::rgba(0.0, 0.0, 0.0, 0.5))
+    })
+    .hover_style(move || Style::BASE.cursor(CursorStyle::Pointer))
+}

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -49,6 +49,7 @@ use tracing::{error, metadata::LevelFilter, trace};
 use tracing_subscriber::{filter::FilterFn, reload::Handle};
 
 use crate::{
+    about,
     code_action::CodeActionStatus,
     command::{InternalCommand, WindowCommand},
     config::{
@@ -2496,6 +2497,7 @@ fn window_tab(window_tab_data: Arc<WindowTabData>) -> impl View {
             code_action(window_tab_data.clone()),
             rename(window_tab_data.clone()),
             palette(window_tab_data.clone()),
+            about::about_popup(window_tab_data.clone()),
         )
     })
     .style(move || {

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -601,6 +601,9 @@ pub enum InternalCommand {
     UpdateLogLevel {
         level: tracing_subscriber::filter::LevelFilter,
     },
+    OpenWebUri {
+        uri: String,
+    },
 }
 
 #[derive(Clone)]

--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -577,6 +577,10 @@ impl LapceConfig {
         Some(self.ui_svg(kind_str))
     }
 
+    pub fn logo_svg(&self) -> String {
+        self.svg_store.read().logo_svg()
+    }
+
     /// List of the color themes that are available by their display names.
     pub fn color_theme_list(&self) -> im::Vector<String> {
         self.color_theme_list.clone()

--- a/lapce-app/src/lib.rs
+++ b/lapce-app/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod about;
 pub mod app;
 pub mod code_action;
 pub mod command;
@@ -31,6 +32,7 @@ pub mod text_input;
 pub mod title;
 pub mod update;
 pub mod wave;
+pub mod web_link;
 pub mod window;
 pub mod window_tab;
 pub mod workspace;

--- a/lapce-app/src/title.rs
+++ b/lapce-app/src/title.rs
@@ -349,7 +349,13 @@ fn right(
                                         MenuItem::new("No update available")
                                             .enabled(false)
                                     },
-                                ),
+                                )
+                                .separator()
+                                .entry(MenuItem::new("About Lapce").action(
+                                    move || {
+                                        workbench_command.send(LapceWorkbenchCommand::ShowAbout)
+                                    }
+                                )),
                             Point::ZERO,
                         );
                     },

--- a/lapce-app/src/web_link.rs
+++ b/lapce-app/src/web_link.rs
@@ -1,0 +1,23 @@
+use floem::{
+    peniko::Color,
+    style::{CursorStyle, Style},
+    view::View,
+    views::{label, Decorators},
+};
+
+use crate::{command::InternalCommand, listener::Listener};
+
+pub fn web_link(
+    text: impl Fn() -> String + 'static,
+    uri: impl Fn() -> String + 'static,
+    color: impl Fn() -> Color + 'static,
+    internal_command: Listener<InternalCommand>,
+) -> impl View {
+    label(text)
+        .on_click(move |_| {
+            internal_command.send(InternalCommand::OpenWebUri { uri: uri() });
+            true
+        })
+        .style(move || Style::BASE.color(color()))
+        .hover_style(move || Style::BASE.cursor(CursorStyle::Pointer))
+}


### PR DESCRIPTION
Implemented the "about lapce" popup for the floem ui. Progress for #2417.

Opening the popup greys out the rest of the editor, just like in the druid version. Clicking anywhere on the greyed-out area, or pressing the "close modal" key closes the popup.

![about](https://github.com/lapce/lapce/assets/7442115/c63fa7af-9646-4d72-b941-51b4a56bae89)

