### PR TITLE
Vim motion multi-line yank and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 - [#2425](https://github.com/lapce/lapce/pull/2425): Reimplement completion lens
 - [#2498](https://github.com/lapce/lapce/pull/2498): Show Lapce as an option when doing "Open With..." on Linux
+- [#2549](https://github.com/lapce/lapce/pull/2549): Implement multi-line vim-motion yank and delete (`3dd`, `2yy`, etc.)
 
 ### Bug Fixes
 

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -339,30 +339,24 @@ impl EditorData {
         cmd: &MotionModeCommand,
         count: Option<usize>,
     ) -> CommandExecuted {
+        let count = count.unwrap_or(1);
         let motion_mode = match cmd {
-            MotionModeCommand::MotionModeDelete => MotionMode::Delete,
+            MotionModeCommand::MotionModeDelete => MotionMode::Delete { count },
             MotionModeCommand::MotionModeIndent => MotionMode::Indent,
             MotionModeCommand::MotionModeOutdent => MotionMode::Outdent,
-            MotionModeCommand::MotionModeYank => MotionMode::Yank,
+            MotionModeCommand::MotionModeYank => MotionMode::Yank { count },
         };
         let mut cursor = self.cursor.get_untracked();
         let mut register = self.common.register.get_untracked();
 
-        let mut executed = CommandExecuted::No;
         self.view.doc.update(|doc| {
-            executed = movement::do_motion_mode(
-                doc,
-                &mut cursor,
-                motion_mode,
-                &mut register,
-                count.unwrap_or(1),
-            );
+            movement::do_motion_mode(doc, &mut cursor, motion_mode, &mut register);
         });
 
         self.cursor.set(cursor);
         self.common.register.set(register);
 
-        executed
+        CommandExecuted::Yes
     }
 
     fn run_multi_selection_command(

--- a/lapce-app/src/editor/movement.rs
+++ b/lapce-app/src/editor/movement.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 
+use crate::command::CommandExecuted;
 use lapce_core::{
     buffer::rope_text::RopeText,
     command::MultiSelectionCommand,
@@ -450,6 +451,7 @@ pub fn move_cursor(
                         end,
                         movement.is_vertical(),
                         register,
+                        count,
                     );
                     doc.apply_deltas(&deltas);
                 });
@@ -710,7 +712,8 @@ pub fn do_motion_mode(
     cursor: &mut Cursor,
     motion_mode: MotionMode,
     register: &mut Register,
-) {
+    count: usize,
+) -> CommandExecuted {
     if let Some(m) = &cursor.motion_mode {
         if m == &motion_mode {
             let offset = cursor.offset();
@@ -722,12 +725,15 @@ pub fn do_motion_mode(
                 offset,
                 true,
                 register,
+                count,
             );
             doc.apply_deltas(&deltas);
         }
         cursor.motion_mode = None;
+        CommandExecuted::Yes
     } else {
         cursor.motion_mode = Some(motion_mode);
+        CommandExecuted::No
     }
 }
 

--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -250,24 +250,19 @@ impl KeyPressData {
                 self.pending_keypress.update(|pending_keypress| {
                     pending_keypress.clear();
                 });
-                let count = self.count.get();
-                if CommandExecuted::Yes
-                    == self.run_command(&command, count, mods, focus)
-                {
-                    self.count.set(None);
-                };
+                let count = self.count.try_update(|count| count.take()).unwrap();
+                self.run_command(&command, count, mods, focus);
                 return true;
             }
             KeymapMatch::Multiple(commands) => {
                 self.pending_keypress.update(|pending_keypress| {
                     pending_keypress.clear();
                 });
-                let count = self.count.get();
+                let count = self.count.try_update(|count| count.take()).unwrap();
                 for command in commands {
                     if self.run_command(&command, count, mods, focus)
                         == CommandExecuted::Yes
                     {
-                        self.count.set(None);
                         return true;
                     }
                 }

--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -250,19 +250,24 @@ impl KeyPressData {
                 self.pending_keypress.update(|pending_keypress| {
                     pending_keypress.clear();
                 });
-                let count = self.count.try_update(|count| count.take()).unwrap();
-                self.run_command(&command, count, mods, focus);
+                let count = self.count.get();
+                if CommandExecuted::Yes
+                    == self.run_command(&command, count, mods, focus)
+                {
+                    self.count.set(None);
+                };
                 return true;
             }
             KeymapMatch::Multiple(commands) => {
                 self.pending_keypress.update(|pending_keypress| {
                     pending_keypress.clear();
                 });
-                let count = self.count.try_update(|count| count.take()).unwrap();
+                let count = self.count.get();
                 for command in commands {
                     if self.run_command(&command, count, mods, focus)
                         == CommandExecuted::Yes
                     {
+                        self.count.set(None);
                         return true;
                     }
                 }

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -423,7 +423,6 @@ impl Editor {
         deltas
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn execute_motion_mode(
         cursor: &mut Cursor,
         buffer: &mut Buffer,
@@ -432,11 +431,10 @@ impl Editor {
         end: usize,
         is_vertical: bool,
         register: &mut Register,
-        count: usize,
     ) -> Vec<(RopeDelta, InvalLines, SyntaxEdit)> {
         let mut deltas = Vec::new();
         match motion_mode {
-            MotionMode::Delete => {
+            MotionMode::Delete { count } => {
                 let start_line = buffer.line_of_offset(start.min(end));
                 let start = buffer.offset_of_line(start_line);
                 let end = buffer.offset_of_line(start_line + count);
@@ -457,7 +455,7 @@ impl Editor {
                 cursor.apply_delta(&delta);
                 deltas.push((delta, inval_lines, edits));
             }
-            MotionMode::Yank => {
+            MotionMode::Yank { count } => {
                 let start_line = buffer.line_of_offset(start.min(end));
                 let start = buffer.offset_of_line(start_line);
                 let end = buffer.offset_of_line(start_line + count);

--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -423,6 +423,7 @@ impl Editor {
         deltas
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn execute_motion_mode(
         cursor: &mut Cursor,
         buffer: &mut Buffer,
@@ -431,12 +432,14 @@ impl Editor {
         end: usize,
         is_vertical: bool,
         register: &mut Register,
+        count: usize,
     ) -> Vec<(RopeDelta, InvalLines, SyntaxEdit)> {
         let mut deltas = Vec::new();
         match motion_mode {
             MotionMode::Delete => {
-                let (start, end) =
-                    format_start_end(buffer, start, end, is_vertical, false);
+                let start_line = buffer.line_of_offset(start.min(end));
+                let start = buffer.offset_of_line(start_line);
+                let end = buffer.offset_of_line(start_line + count);
                 register.add(
                     RegisterKind::Delete,
                     RegisterData {
@@ -455,8 +458,9 @@ impl Editor {
                 deltas.push((delta, inval_lines, edits));
             }
             MotionMode::Yank => {
-                let (start, end) =
-                    format_start_end(buffer, start, end, is_vertical, false);
+                let start_line = buffer.line_of_offset(start.min(end));
+                let start = buffer.offset_of_line(start_line);
+                let end = buffer.offset_of_line(start_line + count);
                 register.add(
                     RegisterKind::Yank,
                     RegisterData {

--- a/lapce-core/src/mode.rs
+++ b/lapce-core/src/mode.rs
@@ -6,8 +6,8 @@ use tracing::warn;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MotionMode {
-    Delete,
-    Yank,
+    Delete { count: usize },
+    Yank { count: usize },
     Indent,
     Outdent,
 }


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Adds multi-line yank and delete for vim-motions, `3yy`, `5dd` f.e. 

Achieved by only taking the count from the keypress state if the command was indeed executed, and only marks the command as executed when a change is committed. 

The behavior of something like `3dj` is the same as the previous behaviour on `dj`.

I made an exception to the clippy too many args on one function, I could pack that into a struct, tuple, or whatever, depending on if that's preferred.  