### PR TITLE
Popout menus now appear beneath their buttons, instead of at (0, 0)

### DIFF
--- a/lapce-app/src/panel/plugin_view.rs
+++ b/lapce-app/src/panel/plugin_view.rs
@@ -1,7 +1,6 @@
 use std::{ops::Range, sync::Arc};
 
 use floem::{
-    action::show_context_menu,
     event::EventListener,
     menu::{Menu, MenuItem},
     peniko::kurbo::{Point, Rect, Size},
@@ -116,10 +115,10 @@ fn installed_view(plugin: PluginData) -> impl View {
     let disabled = plugin.disabled;
     let workspace_disabled = plugin.workspace_disabled;
 
-    let plugin_controls = {
-        move |plugin: PluginData, volt: VoltInfo, meta: VoltMetadata| {
-            let volt_id = volt.id();
-            let menu =
+    let plugin_controls =
+        {
+            move |plugin: PluginData, volt: VoltInfo, meta: VoltMetadata| {
+                let volt_id = volt.id();
                 Menu::new("")
                     .entry(MenuItem::new("Reload Plugin").action({
                         let plugin = plugin.clone();
@@ -186,10 +185,9 @@ fn installed_view(plugin: PluginData) -> impl View {
                         move || {
                             plugin.uninstall_volt(meta.clone());
                         }
-                    }));
-            show_context_menu(menu, Point::ZERO);
-        }
-    };
+                    }))
+            }
+        };
 
     let view_fn = move |volt: InstalledVoltData, plugin: PluginData| {
         let meta = volt.meta.get_untracked();
@@ -245,6 +243,13 @@ fn installed_view(plugin: PluginData) -> impl View {
                                 }),
                                 clickable_icon(
                                     || LapceIcons::SETTINGS,
+                                    || {},
+                                    || false,
+                                    || false,
+                                    config,
+                                )
+                                .style(|| Style::BASE.padding_left_px(6.0))
+                                .popout_menu(
                                     move || {
                                         plugin_controls(
                                             plugin.clone(),
@@ -252,11 +257,7 @@ fn installed_view(plugin: PluginData) -> impl View {
                                             local_meta.clone(),
                                         )
                                     },
-                                    || false,
-                                    || false,
-                                    config,
-                                )
-                                .style(|| Style::BASE.padding_left_px(6.0)),
+                                ),
                             )
                         })
                         .style(|| Style::BASE.width_pct(100.0).items_center()),

--- a/lapce-app/src/title.rs
+++ b/lapce-app/src/title.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
 use floem::{
-    action::show_context_menu,
     event::EventListener,
     menu::{Menu, MenuItem},
-    peniko::{kurbo::Point, Color},
+    peniko::Color,
     reactive::{create_memo, Memo, ReadSignal, RwSignal},
     style::{AlignItems, CursorStyle, Dimension, JustifyContent, Style},
     view::View,
@@ -60,7 +59,7 @@ fn left(
                     },
                 )
             })
-            .on_click(move |_| {
+            .popout_menu(move || {
                 #[allow(unused_mut)]
                 let mut menu = Menu::new("").entry(
                     MenuItem::new("Connect to SSH Host").action(move || {
@@ -77,8 +76,7 @@ fn left(
                         },
                     ));
                 }
-                show_context_menu(menu, Point::ZERO);
-                true
+                menu
             })
             .hover_style(move || {
                 Style::BASE.cursor(CursorStyle::Pointer).background(
@@ -168,26 +166,20 @@ fn middle(
     let open_folder = move || {
         clickable_icon(
             || LapceIcons::PALETTE_MENU,
-            move || {
-                show_context_menu(
-                    Menu::new("")
-                        .entry(MenuItem::new("Open Folder").action(move || {
-                            workbench_command
-                                .send(LapceWorkbenchCommand::OpenFolder);
-                        }))
-                        .entry(MenuItem::new("Open Recent Workspace").action(
-                            move || {
-                                workbench_command
-                                    .send(LapceWorkbenchCommand::PaletteWorkspace);
-                            },
-                        )),
-                    Point::ZERO,
-                );
-            },
+            move || {},
             || false,
             || false,
             config,
         )
+        .popout_menu(move || {
+            Menu::new("")
+                .entry(MenuItem::new("Open Folder").action(move || {
+                    workbench_command.send(LapceWorkbenchCommand::OpenFolder);
+                }))
+                .entry(MenuItem::new("Open Recent Workspace").action(move || {
+                    workbench_command.send(LapceWorkbenchCommand::PaletteWorkspace);
+                }))
+        })
     };
 
     stack(move || {
@@ -305,65 +297,50 @@ fn right(
             (
                 clickable_icon(
                     || LapceIcons::SETTINGS,
-                    move || {
-                        show_context_menu(
-                            Menu::new("")
-                                .entry(MenuItem::new("Command Palette").action(
-                                    move || {
-                                        workbench_command.send(
-                                            LapceWorkbenchCommand::PaletteCommand,
-                                        )
-                                    },
-                                ))
-                                .separator()
-                                .entry(MenuItem::new("Open Settings").action(
-                                    move || {
-                                        workbench_command.send(
-                                            LapceWorkbenchCommand::OpenSettings,
-                                        )
-                                    },
-                                ))
-                                .entry(MenuItem::new("Open Keyboard Shortcuts").action(
-                                    move || {
-                                        workbench_command.send(
-                                            LapceWorkbenchCommand::OpenKeyboardShortcuts,
-                                        )
-                                    },
-                                ))
-                                .separator()
-                                .entry(
-                                    if let Some(v) = latest_version.get_untracked() {
-                                        if update_in_progress.get_untracked() {
-                                            MenuItem::new(format!(
-                                                "Update in progress ({v})"
-                                            ))
-                                            .enabled(false)
-                                        } else {
-                                            MenuItem::new(format!(
-                                                "Restart to update ({v})"
-                                            ))
-                                            .action(move || {
-                                                workbench_command.send(LapceWorkbenchCommand::RestartToUpdate)
-                                            })
-                                        }
-                                    } else {
-                                        MenuItem::new("No update available")
-                                            .enabled(false)
-                                    },
-                                )
-                                .separator()
-                                .entry(MenuItem::new("About Lapce").action(
-                                    move || {
-                                        workbench_command.send(LapceWorkbenchCommand::ShowAbout)
-                                    }
-                                )),
-                            Point::ZERO,
-                        );
-                    },
+                    || {},
                     || false,
                     || false,
                     config,
-                ),
+                )
+                .popout_menu(move || {
+                    Menu::new("")
+                        .entry(MenuItem::new("Command Palette").action(move || {
+                            workbench_command
+                                .send(LapceWorkbenchCommand::PaletteCommand)
+                        }))
+                        .separator()
+                        .entry(MenuItem::new("Open Settings").action(move || {
+                            workbench_command
+                                .send(LapceWorkbenchCommand::OpenSettings)
+                        }))
+                        .entry(MenuItem::new("Open Keyboard Shortcuts").action(
+                            move || {
+                                workbench_command.send(
+                                    LapceWorkbenchCommand::OpenKeyboardShortcuts,
+                                )
+                            },
+                        ))
+                        .separator()
+                        .entry(if let Some(v) = latest_version.get_untracked() {
+                            if update_in_progress.get_untracked() {
+                                MenuItem::new(format!("Update in progress ({v})"))
+                                    .enabled(false)
+                            } else {
+                                MenuItem::new(format!("Restart to update ({v})"))
+                                    .action(move || {
+                                        workbench_command.send(
+                                            LapceWorkbenchCommand::RestartToUpdate,
+                                        )
+                                    })
+                            }
+                        } else {
+                            MenuItem::new("No update available").enabled(false)
+                        })
+                        .separator()
+                        .entry(MenuItem::new("About Lapce").action(move || {
+                            workbench_command.send(LapceWorkbenchCommand::ShowAbout)
+                        }))
+                }),
                 container(|| {
                     label(|| "1".to_string()).style(move || {
                         let config = config.get();


### PR DESCRIPTION
Like so:
![afbeelding](https://github.com/lapce/lapce/assets/7442115/4fc3c5ce-0eb3-4542-bb1e-b37b0c1fd8f9)
