### PR TITLE
Allow binding mouse buttons to commands

### DIFF
--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -415,6 +415,8 @@ impl AppData {
         let window_scale = window_data.window_scale;
         let window_id = window_data.window_id;
         let app_command = window_data.app_command;
+        // The KeyDown and PointerDown event handlers both need ownership of a WindowData object.
+        let key_down_window_data = window_data.clone();
         stack(|| {
             (
                 workspace_tab_header(window_data.clone()),
@@ -426,7 +428,15 @@ impl AppData {
         .keyboard_navigatable()
         .on_event(EventListener::KeyDown, move |event| {
             if let Event::KeyDown(key_event) = event {
-                window_data.key_down(key_event);
+                key_down_window_data.key_down(key_event);
+                true
+            } else {
+                false
+            }
+        })
+        .on_event(EventListener::PointerDown, move |event| {
+            if let Event::PointerDown(pointer_event) = event {
+                window_data.key_down(pointer_event);
                 true
             } else {
                 false

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -8,7 +8,7 @@ use std::{
 use floem::{
     action::{exec_after, save_as},
     ext_event::create_ext_action,
-    glazier::{FileDialogOptions, FileInfo, KeyEvent, Modifiers},
+    glazier::{FileDialogOptions, FileInfo, Modifiers},
     peniko::kurbo::{Point, Rect, Vec2},
     reactive::{Memo, RwSignal, Scope},
 };
@@ -38,7 +38,7 @@ use crate::{
         EditorTabChild, EditorTabChildSource, EditorTabData, EditorTabInfo,
     },
     id::{DiffEditorId, EditorId, EditorTabId, KeymapId, SettingsId, SplitId},
-    keypress::KeyPressData,
+    keypress::{EventRef, KeyPressData},
     window_tab::{CommonData, Focus, WindowTabData},
 };
 
@@ -323,9 +323,9 @@ impl MainSplitData {
         }
     }
 
-    pub fn key_down(
+    pub fn key_down<'a>(
         &self,
-        key_event: &KeyEvent,
+        event: impl Into<EventRef<'a>>,
         keypress: &KeyPressData,
     ) -> Option<()> {
         let active_editor_tab = self.active_editor_tab.get_untracked()?;
@@ -341,7 +341,7 @@ impl MainSplitData {
                     .editors
                     .with_untracked(|editors| editors.get(&editor_id).copied())?;
                 let editor = editor.get_untracked();
-                keypress.key_down(key_event, &editor);
+                keypress.key_down(event, &editor);
                 editor.get_code_actions();
             }
             EditorTabChild::DiffEditor(diff_editor_id) => {
@@ -354,7 +354,7 @@ impl MainSplitData {
                 } else {
                     diff_editor.left.get_untracked()
                 };
-                keypress.key_down(key_event, &editor);
+                keypress.key_down(event, &editor);
                 editor.get_code_actions();
             }
             EditorTabChild::Settings(_) => {

--- a/lapce-app/src/window.rs
+++ b/lapce-app/src/window.rs
@@ -1,7 +1,6 @@
 use std::{rc::Rc, sync::Arc};
 
 use floem::{
-    glazier::KeyEvent,
     id::WindowId,
     peniko::kurbo::{Point, Size},
     reactive::{use_context, Memo, ReadSignal, RwSignal, Scope},
@@ -10,8 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     app::AppCommand, command::WindowCommand, config::LapceConfig, db::LapceDb,
-    listener::Listener, update::ReleaseInfo, window_tab::WindowTabData,
-    workspace::LapceWorkspace,
+    keypress::EventRef, listener::Listener, update::ReleaseInfo,
+    window_tab::WindowTabData, workspace::LapceWorkspace,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -273,7 +272,7 @@ impl WindowData {
         self.app_command.send(AppCommand::SaveApp);
     }
 
-    pub fn key_down(&self, key_event: &KeyEvent) {
+    pub fn key_down<'a>(&self, event: impl Into<EventRef<'a>> + Copy) {
         let active = self.active.get_untracked();
         let window_tab = self.window_tabs.with_untracked(|window_tabs| {
             window_tabs
@@ -282,7 +281,7 @@ impl WindowData {
                 .cloned()
         });
         if let Some((_, window_tab)) = window_tab {
-            window_tab.key_down(key_event);
+            window_tab.key_down(event);
         }
     }
 

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -5,7 +5,7 @@ use floem::{
     action::open_file,
     cosmic_text::{Attrs, AttrsList, FamilyOwned, LineHeightValue, TextLayout},
     ext_event::{create_ext_action, create_signal_from_channel},
-    glazier::{FileDialogOptions, KeyEvent, Modifiers, TimerToken},
+    glazier::{FileDialogOptions, Modifiers, TimerToken},
     peniko::kurbo::{Point, Rect, Vec2},
     reactive::{use_context, Memo, ReadSignal, RwSignal, Scope, WriteSignal},
 };
@@ -42,7 +42,7 @@ use crate::{
     global_search::GlobalSearchData,
     hover::HoverData,
     id::WindowTabId,
-    keypress::{condition::Condition, KeyPressData, KeyPressFocus},
+    keypress::{condition::Condition, EventRef, KeyPressData, KeyPressFocus},
     listener::Listener,
     main_split::{MainSplitData, SplitData, SplitDirection},
     palette::{kind::PaletteKind, PaletteData, PaletteStatus},
@@ -1434,54 +1434,52 @@ impl WindowTabData {
         }
     }
 
-    pub fn key_down(&self, key_event: &KeyEvent) {
+    pub fn key_down<'a>(&self, event: impl Into<EventRef<'a>> + Copy) {
         if self.alert_data.active.get_untracked() {
             return;
         }
         let focus = self.common.focus.get_untracked();
         let keypress = self.common.keypress.get_untracked();
         let executed = match focus {
-            Focus::Workbench => {
-                self.main_split.key_down(key_event, &keypress).is_some()
-            }
+            Focus::Workbench => self.main_split.key_down(event, &keypress).is_some(),
             Focus::Palette => {
-                keypress.key_down(key_event, &self.palette);
+                keypress.key_down(event, &self.palette);
                 true
             }
             Focus::CodeAction => {
                 let code_action = self.code_action.get_untracked();
-                keypress.key_down(key_event, &code_action);
+                keypress.key_down(event, &code_action);
                 true
             }
             Focus::Rename => {
-                keypress.key_down(key_event, &self.rename);
+                keypress.key_down(event, &self.rename);
                 true
             }
             Focus::AboutPopup => {
-                keypress.key_down(key_event, &self.about_data);
+                keypress.key_down(event, &self.about_data);
                 true
             }
             Focus::Panel(PanelKind::Terminal) => {
-                self.terminal.key_down(key_event, &keypress);
+                self.terminal.key_down(event, &keypress);
                 true
             }
             Focus::Panel(PanelKind::Search) => {
-                keypress.key_down(key_event, &self.global_search);
+                keypress.key_down(event, &self.global_search);
                 true
             }
             Focus::Panel(PanelKind::Plugin) => {
-                keypress.key_down(key_event, &self.plugin);
+                keypress.key_down(event, &self.plugin);
                 true
             }
             Focus::Panel(PanelKind::SourceControl) => {
-                keypress.key_down(key_event, &self.source_control);
+                keypress.key_down(event, &self.source_control);
                 true
             }
             _ => false,
         };
 
         if !executed {
-            keypress.key_down(key_event, self);
+            keypress.key_down(event, self);
         }
     }
 


### PR DESCRIPTION
Allows specifying bindings that use `mouseforward`, `mouseback` and `mousemiddle`.

Does not allow specifying bindings that use the primary two mouse buttons.

Closes #2572.

I haven't added an entry to `CHANGELOG.md`, but can do if you'd like.