### PR TITLE
Update building-from-source.md

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -12,7 +12,7 @@ sudo apt install clang libxkbcommon-x11-dev pkg-config libvulkan-dev libwayland-
 ```
 #### Fedora
 ```sh
-sudo dnf install clang libxkbcommon-x11-devel libxcb-devel vulkan-loader-devel wayland-devel
+sudo dnf install clang libxkbcommon-x11-devel libxcb-devel vulkan-loader-devel wayland-devel perl-File-Compare perl-FindBin
 ```
 #### Void Linux
 ```sh


### PR DESCRIPTION
## Lapce Version

0.2.8 

## System information

Fedora running on WSL2 as well as a clean install of Fedora running in a VM

## Describe the bug
The source fails to compile when running "cargo build --release" using the standard instructions for building from source. 

## Additional information
Based on the error logs, the compilation was failing due to two modules not being found during compilation.
Once I had installed the perl-FindBin and perl-File-Compare modules using the standard `sudo dnf install` the compilation completed without issue.
`sudo dnf install perl-File-Compare perl-FindBin`

I found this on Fedora running on WSL2 , and recreated it with a fresh install of Fedora (fully updated) with only Git (via dnf install) and rustup installed (using 
`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 per the Rust documentation here https://forge.rust-lang.org/infra/other-installation-methods.html)

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users