### PR TITLE
Fix delete_line not deleting leading whitespace

### DIFF
--- a/lapce-core/src/editor.rs
+++ b/lapce-core/src/editor.rs
@@ -1253,7 +1253,7 @@ impl Editor {
                     selection.min_offset(),
                     selection.max_offset(),
                     true,
-                    true,
+                    false,
                     1,
                 );
                 let selection = Selection::region(start, end);


### PR DESCRIPTION
Fix `delete_line` not deleting leading whitespace on the first deleted line.

Fixes #2406.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users