### PR TITLE
Send lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "psp-types"
 version = "0.1.0"
-source = "git+https://github.com/lapce/psp-types#b55d2c5c1f9aae89a4f369db5151fe1756d34c08"
+source = "git+https://github.com/lapce/psp-types#66c0091282778dfc00c8f820b6bdebce07271d28"
 dependencies = [
  "lsp-types",
  "serde",

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -88,7 +88,7 @@ pub struct Plugin {
 }
 
 impl PluginServerHandler for Plugin {
-    fn method_registered(&mut self, method: &'static str) -> bool {
+    fn method_registered(&mut self, method: &str) -> bool {
         self.host.method_registered(method)
     }
 
@@ -114,6 +114,9 @@ impl PluginServerHandler for Plugin {
             }
             Shutdown => {
                 self.shutdown();
+            }
+            SpawnedPluginLoaded { plugin_id } => {
+                self.host.handle_spawned_plugin_loaded(plugin_id);
             }
         }
     }
@@ -437,7 +440,7 @@ pub fn start_volt(
     let mut store = wasmtime::Store::new(&engine, wasi);
 
     let (io_tx, io_rx) = crossbeam_channel::unbounded();
-    let rpc = PluginServerRpcHandler::new(meta.id(), io_tx);
+    let rpc = PluginServerRpcHandler::new(meta.id(), None, None, io_tx);
 
     let local_rpc = rpc.clone();
     let local_stdin = stdin.clone();

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use crossbeam_channel::Sender;
 use jsonrpc_lite::{Id, Params};
 use lapce_core::directory::Directory;
 use lapce_rpc::{
@@ -35,7 +34,7 @@ use super::{
     client_capabilities,
     psp::{
         handle_plugin_server_message, PluginHandlerNotification, PluginHostHandler,
-        PluginServerHandler, PluginServerRpc, RpcCallback,
+        PluginServerHandler, PluginServerRpc, ResponseSender, RpcCallback,
     },
     volt_icon, PluginCatalogRpcHandler,
 };
@@ -128,9 +127,9 @@ impl PluginServerHandler for Plugin {
         id: Id,
         method: String,
         params: Params,
-        chan: Sender<Result<serde_json::Value, RpcError>>,
+        resp: ResponseSender,
     ) {
-        self.host.handle_request(id, method, params, chan);
+        self.host.handle_request(id, method, params, resp);
     }
 
     fn handle_did_save_text_document(
@@ -502,6 +501,7 @@ pub fn start_volt(
                         }),
                 )
                 .collect(),
+            plugin_rpc.core_rpc.clone(),
             rpc.clone(),
             plugin_rpc.clone(),
         ),


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This is messier than I would like in variety of ways.  
- Had to switch to `Cow<'static, str>` because the method `String` we get from the plugin is obviously not going to live for `'static`.  
- Have to pass around check everywhere. We don't have a way to keep track of whether we have the capabilities for arbitrary LSP commands, so I just default to no checks when the plugin sends to the LSP.  
- Extended ServerNotification to be pretty close to ServerRequest.
  - It has a callback so I can be 'honest' about when it is sent.
- I made `send_request` and `send_notification` `pub(crate)`. I could make a wrapper function for the specific case so they're not `pub(crate)`?
- I dislike `ResponseSender`.
  - I can't just use `ResponseHandler` because the callback wouldn't be cloneable.
  - I think it is a more readable api than just passing around a channel though.
- You can optionally pass in the plugin that spawned the lsp client when starting it.
- You can also optionally pass in the lsp client's own id. This makes it simple to keep track of which language servers the plugin has started, since you don't have to communicate back across the thread.
- This keeps the notification based version of `startLspServer` so that plugins do not break. Ideally we'll slowly switch out existing plugins to just upgrade their `lapce-plugin-rust` version and then can completely remove it as a notification.

psp-types pr: https://github.com/lapce/psp-types/pull/5
lapce-plugin-rust pr: https://github.com/lapce/lapce-plugin-rust/pull/23