### PR TITLE
Add support for highlighting enclosing brackets

### DIFF
--- a/lapce-core/src/syntax/mod.rs
+++ b/lapce-core/src/syntax/mod.rs
@@ -791,10 +791,6 @@ impl Syntax {
         &self,
         offset: usize,
     ) -> Option<(usize, usize)> {
-        // If there is no text then the document can't have any bytes
-        if self.text.is_empty() {
-            return None;
-        }
         if offset >= self.text.len() {
             return None;
         }
@@ -807,11 +803,13 @@ impl Syntax {
             if start >= self.text.len() {
                 return None;
             }
-            let c = self.text.byte_at(start) as char;
-            if c == '(' {
-                let end = self.find_matching_pair(start)?;
-                if end >= offset && start < offset {
-                    return Some((start, end));
+            if start < offset {
+                let c = self.text.byte_at(start) as char;
+                if c == '(' {
+                    let end = self.find_matching_pair(start)?;
+                    if end >= offset && start < offset {
+                        return Some((start, end));
+                    }
                 }
             }
             if let Some(sibling) = node.prev_sibling() {
@@ -825,10 +823,6 @@ impl Syntax {
     }
 
     pub fn find_enclosing_pair(&self, offset: usize) -> Option<(usize, usize)> {
-        // If there is no text then the document can't have any bytes
-        if self.text.is_empty() {
-            return None;
-        }
         if offset >= self.text.len() {
             return None;
         }
@@ -841,11 +835,13 @@ impl Syntax {
             if start >= self.text.len() {
                 return None;
             }
-            let c = self.text.byte_at(start) as char;
-            if matching_pair_direction(c) == Some(true) {
-                let end = self.find_matching_pair(start)?;
-                if end >= offset {
-                    return Some((start, end));
+            if start < offset {
+                let c = self.text.byte_at(start) as char;
+                if matching_pair_direction(c) == Some(true) {
+                    let end = self.find_matching_pair(start)?;
+                    if end >= offset {
+                        return Some((start, end));
+                    }
                 }
             }
             if let Some(sibling) = node.prev_sibling() {

--- a/lapce-core/src/word.rs
+++ b/lapce-core/src/word.rs
@@ -428,7 +428,7 @@ impl<'a> WordCursor<'a> {
             if matching_pair_direction(c) == Some(true) {
                 let opening_bracket_offset = self.inner.pos();
                 if let Some(closing_bracket_offset) = self.match_pairs() {
-                    if (opening_bracket_offset..closing_bracket_offset)
+                    if (opening_bracket_offset..=closing_bracket_offset)
                         .contains(&old_offset)
                     {
                         return Some((
@@ -689,13 +689,18 @@ mod test {
     fn find_pair_should_return_next_pair() {
         let text = "violets {are (blue)    }";
         let rope = Rope::from(text);
+
         let mut cursor = WordCursor::new(&rope, 11);
         let positions = cursor.find_enclosing_pair();
         assert_eq!(positions, Some((8, 23)));
 
         let mut cursor = WordCursor::new(&rope, 20);
         let positions = cursor.find_enclosing_pair();
-        assert_eq!(positions, Some((8, 23)))
+        assert_eq!(positions, Some((8, 23)));
+
+        let mut cursor = WordCursor::new(&rope, 18);
+        let positions = cursor.find_enclosing_pair();
+        assert_eq!(positions, Some((13, 18)));
     }
 
     #[test]


### PR DESCRIPTION
Highlight enclosing brackets when `highlight_matching_brackets` is enabled.

Draw lines delineating the enclosing scope when `highlight_scope_lines` is enabled.

Currently only draws the highlights and scope lines for one cursor, even if there are multiple cursors.

Currently doesn't draw highlights or scope lines on the sticky header.

Relates to #2417.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users