### PR TITLE
Send diagnostics capabilities for LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bug Fixes
 
+- [#2650](https://github.com/lapce/lapce/pull/2650): Inform language servers that Lapce supports LSP diagnostics
+
 ## 0.2.8
 
 ### Features/Changes

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -50,9 +50,10 @@ use lsp_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverClientCapabilities,
     HoverParams, InlayHint, InlayHintClientCapabilities, InlayHintParams, Location,
     MarkupKind, MessageActionItemCapabilities, ParameterInformationSettings,
-    PartialResultParams, Position, PrepareRenameResponse, Range, ReferenceContext,
-    ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
-    SemanticTokens, SemanticTokensClientCapabilities, SemanticTokensParams,
+    PartialResultParams, Position, PrepareRenameResponse,
+    PublishDiagnosticsClientCapabilities, Range, ReferenceContext, ReferenceParams,
+    RenameParams, SelectionRange, SelectionRangeParams, SemanticTokens,
+    SemanticTokensClientCapabilities, SemanticTokensParams,
     ShowMessageRequestClientCapabilities, SignatureHelp,
     SignatureHelpClientCapabilities, SignatureHelpParams,
     SignatureInformationSettings, SymbolInformation, TextDocumentClientCapabilities,
@@ -1318,6 +1319,10 @@ fn client_capabilities() -> ClientCapabilities {
             definition: Some(GotoCapability {
                 ..Default::default()
             }),
+            publish_diagnostics: Some(PublishDiagnosticsClientCapabilities {
+                ..Default::default()
+            }),
+
             ..Default::default()
         }),
         window: Some(WindowClientCapabilities {


### PR DESCRIPTION
Previously, Lapce was not sending the right LSP capabilities, leading to language servers like the Zig Language Server to not send any diagnostics.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users