### PR TITLE
fix: drop unused "which" dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,6 @@ dependencies = [
  "wasi-experimental-http-wasmtime",
  "wasmtime",
  "wasmtime-wasi",
- "which",
  "zstd",
 ]
 
@@ -6226,17 +6225,6 @@ dependencies = [
  "bitflags 2.4.0",
  "js-sys",
  "web-sys",
-]
-
-[[package]]
-name = "which"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -46,9 +46,6 @@ locale_config = "0.3.0"
 mio = "0.6.20"
 jsonrpc-lite = "0.6.0"
 
-# finding terminal shell
-which = "4.2.5"
-
 # git
 git2 = { version = "0.17.2", features = ["vendored-openssl"] }
 


### PR DESCRIPTION
Dependency was removed as part of terminal profiles feature, since we don't have to figure out the binary path anymore