### PR TITLE
Terminal font height setting

### DIFF
--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -19,7 +19,7 @@ use self::{
     color::LapceColor,
     color_theme::{ColorThemeConfig, ThemeColor, ThemeColorPreference},
     core::CoreConfig,
-    editor::EditorConfig,
+    editor::{EditorConfig, SCALE_OR_SIZE_LIMIT},
     icon::LapceIcons,
     icon_theme::IconThemeConfig,
     svg::SvgStore,
@@ -613,8 +613,17 @@ impl LapceConfig {
     }
 
     pub fn terminal_line_height(&self) -> usize {
-        if self.terminal.line_height > 0 {
-            self.terminal.line_height
+        let font_size = self.terminal_font_size();
+
+        if self.terminal.line_height > 0.0 {
+            let line_height = if self.terminal.line_height < SCALE_OR_SIZE_LIMIT {
+                self.terminal.line_height * font_size as f64
+            } else {
+                self.terminal.line_height
+            };
+
+            // Prevent overlapping lines
+            (line_height.round() as usize).max(font_size)
         } else {
             self.editor.line_height()
         }

--- a/lapce-app/src/config/editor.rs
+++ b/lapce-app/src/config/editor.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use structdesc::FieldNames;
 
+pub const SCALE_OR_SIZE_LIMIT: f64 = 5.0;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub enum ClickMode {
     #[default]
@@ -165,8 +167,6 @@ impl EditorConfig {
     }
 
     pub fn line_height(&self) -> usize {
-        const SCALE_OR_SIZE_LIMIT: f64 = 5.0;
-
         let line_height = if self.line_height < SCALE_OR_SIZE_LIMIT {
             self.line_height * self.font_size as f64
         } else {

--- a/lapce-app/src/config/terminal.rs
+++ b/lapce-app/src/config/terminal.rs
@@ -18,7 +18,7 @@ pub struct TerminalConfig {
     #[field_names(
         desc = "Set the terminal line height, If 0, it uses editor line height"
     )]
-    pub line_height: usize,
+    pub line_height: f64,
     #[field_names(desc = "Profiles available in terminal pane")]
     pub profiles: HashMap<String, TerminalProfile>,
     #[field_names(desc = "Default profile for each platform")]

--- a/lapce-app/src/terminal/view.rs
+++ b/lapce-app/src/terminal/view.rs
@@ -7,10 +7,7 @@ use alacritty_terminal::{
 use floem::{
     cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout, Weight},
     id::Id,
-    peniko::{
-        kurbo::{Point, Rect, Size},
-        Color,
-    },
+    peniko::kurbo::{Point, Rect, Size},
     reactive::{create_effect, ReadSignal},
     view::{ChangeFlags, View},
     Renderer,
@@ -294,12 +291,7 @@ impl View for TerminalView {
             }
 
             if term_bg != bg {
-                let term_fg = *config.get_color(LapceColor::TERMINAL_FOREGROUND);
-                if check_contrast(&fg, &bg) && term_fg == fg {
-                    fg = term_bg;
-                };
-                let width = char_width * 1.1;
-                let rect = Size::new(width, line_height)
+                let rect = Size::new(char_width, line_height)
                     .to_rect()
                     .with_origin(Point::new(x, y));
                 cx.fill(&rect, bg, 0.0);
@@ -411,35 +403,4 @@ impl View for TerminalView {
         //     }
         // }
     }
-}
-
-/// Check the contrast of two colors and determines if the contrast should be changed
-/// according to WCAG standart
-fn check_contrast(fg: &Color, bg: &Color) -> bool {
-    const WCAG_MINIMUM_RATIO: f64 = 4.5;
-
-    fn luminance(color: &Color) -> f64 {
-        let [lum_r, lum_g, lum_b] = [color.r, color.g, color.b].map(|color| {
-            let proportion = color as f64 / 255.0;
-
-            if proportion <= 0.03928 {
-                proportion / 12.92
-            } else {
-                ((proportion + 0.055) / 1.055).powf(2.4)
-            }
-        });
-
-        0.2126 * lum_r + 0.7152 * lum_g + 0.0722 * lum_b
-    }
-
-    let lum_fg = luminance(fg);
-    let lum_bg = luminance(bg);
-
-    let ratio = if lum_fg < lum_bg {
-        (lum_fg + 0.05) / (lum_bg + 0.05)
-    } else {
-        (lum_bg + 0.05) / (lum_fg + 0.05)
-    };
-
-    ratio < WCAG_MINIMUM_RATIO
 }


### PR DESCRIPTION
The terminal font height settings are different then the editor settings. This PR changes the calculation of the terminal font height so the setting now behaves the same as setting the editor font height.

This PR also adds a contrast checker for the terminal, which switches the foreground color to the terminal background color if the contrast is bad.

![dark theme](https://github.com/lapce/lapce/assets/47316908/dc380c3d-079a-4743-93ee-ebeae8c27a0d)

![light theme](https://github.com/lapce/lapce/assets/47316908/91b8e909-5c88-4cdb-8a5b-e0da6ba6140d)


- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users