### PR TITLE
Added navigation keybindings

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -218,6 +218,18 @@ command = "right"
 mode = "i"
 
 [[keymaps]]
+key = "ctrl+p"
+command = "up"
+when = "!list_focus"
+mode = "i"
+
+[[keymaps]]
+key = "ctrl+n"
+command = "down"
+when = "!list_focus"
+mode = "i"
+
+[[keymaps]]
 key = "right"
 command = "right"
 mode = "inv"


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Added keybindings that are often used in macOS systems or the emacs editor to navigate UP or DOWN via `CTRL+P` and `CTRL+N` respectively.

I made sure to ignore these keybindings in case the `list_focus` mode is enabled, so the navigation in this mode is not overwritten by the added keybindings.

Please let me know if I need to make any modifications or improvements. 