### PR TITLE
Don't mark nonexistent files as read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 
 ### Bug Fixes
+- [#2754](https://github.com/lapce/lapce/pull/2754): Don't mark nonexistent files as read only (fix saving new files)
 
 ## 0.3.0
 

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -28,6 +28,7 @@ use lsp_types::{
     DocumentChanges, OneOf, Position, TextEdit, Url, WorkspaceEdit,
 };
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::{
     alert::AlertButton,
@@ -2188,7 +2189,9 @@ impl MainSplitData {
                 let send = {
                     let path = path.clone();
                     create_ext_action(self.scope, move |result| {
-                        if let Ok(_r) = result {
+                        if let Err(err) = result {
+                            warn!("Failed to save as a file: {:?}", err);
+                        } else {
                             let syntax = Syntax::init(&path);
                             doc.content.set(DocContent::File {
                                 path: path.clone(),


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Fixes #2753 

When a `Buffer` in proxy is created it tries reading the file's contents, but it would mark the buffer as read-only if it failed. This would disallow saving.
  
This PR just makes it so that if the error is simply 'not found' then the `Buffer` is not marked as read-only.   
(Also it adds a log for errors on saving, which seems useful to have)  
  
An alternative method that could instead be used would be to have a separate proxy command for instantiating a new file which then manually sets `read_only = false`, but I think this method fits better. We should probably err on the side of letting users try to save files usually, even if the filesystem refuses.