### PR TITLE
Add UI inspector command

### DIFF
--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -163,6 +163,10 @@ pub enum LapceWorkbenchCommand {
     #[strum(message = "Reveal Active File in File Explorer")]
     RevealActiveFileInFileExplorer,
 
+    #[strum(serialize = "open_ui_inspector")]
+    #[strum(message = "Open Internal UI Inspector")]
+    OpenUIInspector,
+
     #[strum(serialize = "change_color_theme")]
     #[strum(message = "Change Color Theme")]
     ChangeColorTheme,

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -1129,6 +1129,9 @@ impl WindowTabData {
             FocusTerminal => {
                 self.common.focus.set(Focus::Panel(PanelKind::Terminal));
             }
+            OpenUIInspector => {
+                self.common.view_id.get().inspect();
+            }
 
             // ==== Source Control ====
             SourceControlInit => {

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -1130,7 +1130,7 @@ impl WindowTabData {
                 self.common.focus.set(Focus::Panel(PanelKind::Terminal));
             }
             OpenUIInspector => {
-                self.common.view_id.get().inspect();
+                self.common.view_id.get_untracked().inspect();
             }
 
             // ==== Source Control ====


### PR DESCRIPTION
This adds a command to open the Floem Inspector, which can be handy to investigate performance and layout issues.