### PR TITLE
Add explicit static lifetime to consts

### DIFF
--- a/lapce-app/src/about.rs
+++ b/lapce-app/src/about.rs
@@ -21,11 +21,11 @@ use crate::{
 struct AboutUri {}
 
 impl AboutUri {
-    const LAPCE: &str = "https://lapce.dev";
-    const GITHUB: &str = "https://github.com/lapce/lapce";
-    const MATRIX: &str = "https://matrix.to/#/#lapce-editor:matrix.org";
-    const DISCORD: &str = "https://discord.gg/n8tGJ6Rn6D";
-    const CODICONS: &str = "https://github.com/microsoft/vscode-codicons";
+    const LAPCE: &'static str = "https://lapce.dev";
+    const GITHUB: &'static str = "https://github.com/lapce/lapce";
+    const MATRIX: &'static str = "https://matrix.to/#/#lapce-editor:matrix.org";
+    const DISCORD: &'static str = "https://discord.gg/n8tGJ6Rn6D";
+    const CODICONS: &'static str = "https://github.com/microsoft/vscode-codicons";
 }
 
 #[derive(Clone)]

--- a/lapce-app/src/config/color.rs
+++ b/lapce-app/src/config/color.rs
@@ -18,139 +18,157 @@ pub enum LoadThemeError {
 pub struct LapceColor {}
 
 impl LapceColor {
-    pub const LAPCE_WARN: &str = "lapce.warn";
-    pub const LAPCE_ERROR: &str = "lapce.error";
-    pub const LAPCE_DROPDOWN_SHADOW: &str = "lapce.dropdown_shadow";
-    pub const LAPCE_BORDER: &str = "lapce.border";
-    pub const LAPCE_SCROLL_BAR: &str = "lapce.scroll_bar";
+    pub const LAPCE_WARN: &'static str = "lapce.warn";
+    pub const LAPCE_ERROR: &'static str = "lapce.error";
+    pub const LAPCE_DROPDOWN_SHADOW: &'static str = "lapce.dropdown_shadow";
+    pub const LAPCE_BORDER: &'static str = "lapce.border";
+    pub const LAPCE_SCROLL_BAR: &'static str = "lapce.scroll_bar";
 
-    pub const LAPCE_BUTTON_PRIMARY_BACKGROUND: &str =
+    pub const LAPCE_BUTTON_PRIMARY_BACKGROUND: &'static str =
         "lapce.button.primary.background";
-    pub const LAPCE_BUTTON_PRIMARY_FOREGROUND: &str =
+    pub const LAPCE_BUTTON_PRIMARY_FOREGROUND: &'static str =
         "lapce.button.primary.foreground";
 
-    pub const LAPCE_TAB_ACTIVE_BACKGROUND: &str = "lapce.tab.active.background";
-    pub const LAPCE_TAB_ACTIVE_FOREGROUND: &str = "lapce.tab.active.foreground";
-    pub const LAPCE_TAB_ACTIVE_UNDERLINE: &str = "lapce.tab.active.underline";
+    pub const LAPCE_TAB_ACTIVE_BACKGROUND: &'static str =
+        "lapce.tab.active.background";
+    pub const LAPCE_TAB_ACTIVE_FOREGROUND: &'static str =
+        "lapce.tab.active.foreground";
+    pub const LAPCE_TAB_ACTIVE_UNDERLINE: &'static str =
+        "lapce.tab.active.underline";
 
-    pub const LAPCE_TAB_INACTIVE_BACKGROUND: &str = "lapce.tab.inactive.background";
-    pub const LAPCE_TAB_INACTIVE_FOREGROUND: &str = "lapce.tab.inactive.foreground";
-    pub const LAPCE_TAB_INACTIVE_UNDERLINE: &str = "lapce.tab.inactive.underline";
+    pub const LAPCE_TAB_INACTIVE_BACKGROUND: &'static str =
+        "lapce.tab.inactive.background";
+    pub const LAPCE_TAB_INACTIVE_FOREGROUND: &'static str =
+        "lapce.tab.inactive.foreground";
+    pub const LAPCE_TAB_INACTIVE_UNDERLINE: &'static str =
+        "lapce.tab.inactive.underline";
 
-    pub const LAPCE_TAB_SEPARATOR: &str = "lapce.tab.separator";
+    pub const LAPCE_TAB_SEPARATOR: &'static str = "lapce.tab.separator";
 
-    pub const LAPCE_ICON_ACTIVE: &str = "lapce.icon.active";
-    pub const LAPCE_ICON_INACTIVE: &str = "lapce.icon.inactive";
+    pub const LAPCE_ICON_ACTIVE: &'static str = "lapce.icon.active";
+    pub const LAPCE_ICON_INACTIVE: &'static str = "lapce.icon.inactive";
 
-    pub const LAPCE_REMOTE_ICON: &str = "lapce.remote.icon";
-    pub const LAPCE_REMOTE_LOCAL: &str = "lapce.remote.local";
-    pub const LAPCE_REMOTE_CONNECTED: &str = "lapce.remote.connected";
-    pub const LAPCE_REMOTE_CONNECTING: &str = "lapce.remote.connecting";
-    pub const LAPCE_REMOTE_DISCONNECTED: &str = "lapce.remote.disconnected";
+    pub const LAPCE_REMOTE_ICON: &'static str = "lapce.remote.icon";
+    pub const LAPCE_REMOTE_LOCAL: &'static str = "lapce.remote.local";
+    pub const LAPCE_REMOTE_CONNECTED: &'static str = "lapce.remote.connected";
+    pub const LAPCE_REMOTE_CONNECTING: &'static str = "lapce.remote.connecting";
+    pub const LAPCE_REMOTE_DISCONNECTED: &'static str = "lapce.remote.disconnected";
 
-    pub const LAPCE_PLUGIN_NAME: &str = "lapce.plugin.name";
-    pub const LAPCE_PLUGIN_DESCRIPTION: &str = "lapce.plugin.description";
-    pub const LAPCE_PLUGIN_AUTHOR: &str = "lapce.plugin.author";
+    pub const LAPCE_PLUGIN_NAME: &'static str = "lapce.plugin.name";
+    pub const LAPCE_PLUGIN_DESCRIPTION: &'static str = "lapce.plugin.description";
+    pub const LAPCE_PLUGIN_AUTHOR: &'static str = "lapce.plugin.author";
 
-    pub const EDITOR_BACKGROUND: &str = "editor.background";
-    pub const EDITOR_FOREGROUND: &str = "editor.foreground";
-    pub const EDITOR_DIM: &str = "editor.dim";
-    pub const EDITOR_FOCUS: &str = "editor.focus";
-    pub const EDITOR_CARET: &str = "editor.caret";
-    pub const EDITOR_SELECTION: &str = "editor.selection";
-    pub const EDITOR_DEBUG_BREAK_LINE: &str = "editor.debug_break_line";
-    pub const EDITOR_CURRENT_LINE: &str = "editor.current_line";
-    pub const EDITOR_LINK: &str = "editor.link";
-    pub const EDITOR_VISIBLE_WHITESPACE: &str = "editor.visible_whitespace";
-    pub const EDITOR_INDENT_GUIDE: &str = "editor.indent_guide";
-    pub const EDITOR_DRAG_DROP_BACKGROUND: &str = "editor.drag_drop_background";
-    pub const EDITOR_STICKY_HEADER_BACKGROUND: &str =
+    pub const EDITOR_BACKGROUND: &'static str = "editor.background";
+    pub const EDITOR_FOREGROUND: &'static str = "editor.foreground";
+    pub const EDITOR_DIM: &'static str = "editor.dim";
+    pub const EDITOR_FOCUS: &'static str = "editor.focus";
+    pub const EDITOR_CARET: &'static str = "editor.caret";
+    pub const EDITOR_SELECTION: &'static str = "editor.selection";
+    pub const EDITOR_DEBUG_BREAK_LINE: &'static str = "editor.debug_break_line";
+    pub const EDITOR_CURRENT_LINE: &'static str = "editor.current_line";
+    pub const EDITOR_LINK: &'static str = "editor.link";
+    pub const EDITOR_VISIBLE_WHITESPACE: &'static str = "editor.visible_whitespace";
+    pub const EDITOR_INDENT_GUIDE: &'static str = "editor.indent_guide";
+    pub const EDITOR_DRAG_DROP_BACKGROUND: &'static str =
+        "editor.drag_drop_background";
+    pub const EDITOR_STICKY_HEADER_BACKGROUND: &'static str =
         "editor.sticky_header_background";
-    pub const EDITOR_DRAG_DROP_TAB_BACKGROUND: &str =
+    pub const EDITOR_DRAG_DROP_TAB_BACKGROUND: &'static str =
         "editor.drag_drop_tab_background";
 
-    pub const INLAY_HINT_FOREGROUND: &str = "inlay_hint.foreground";
-    pub const INLAY_HINT_BACKGROUND: &str = "inlay_hint.background";
+    pub const INLAY_HINT_FOREGROUND: &'static str = "inlay_hint.foreground";
+    pub const INLAY_HINT_BACKGROUND: &'static str = "inlay_hint.background";
 
-    pub const ERROR_LENS_ERROR_FOREGROUND: &str = "error_lens.error.foreground";
-    pub const ERROR_LENS_ERROR_BACKGROUND: &str = "error_lens.error.background";
-    pub const ERROR_LENS_WARNING_FOREGROUND: &str = "error_lens.warning.foreground";
-    pub const ERROR_LENS_WARNING_BACKGROUND: &str = "error_lens.warning.background";
-    pub const ERROR_LENS_OTHER_FOREGROUND: &str = "error_lens.other.foreground";
-    pub const ERROR_LENS_OTHER_BACKGROUND: &str = "error_lens.other.background";
+    pub const ERROR_LENS_ERROR_FOREGROUND: &'static str =
+        "error_lens.error.foreground";
+    pub const ERROR_LENS_ERROR_BACKGROUND: &'static str =
+        "error_lens.error.background";
+    pub const ERROR_LENS_WARNING_FOREGROUND: &'static str =
+        "error_lens.warning.foreground";
+    pub const ERROR_LENS_WARNING_BACKGROUND: &'static str =
+        "error_lens.warning.background";
+    pub const ERROR_LENS_OTHER_FOREGROUND: &'static str =
+        "error_lens.other.foreground";
+    pub const ERROR_LENS_OTHER_BACKGROUND: &'static str =
+        "error_lens.other.background";
 
-    pub const COMPLETION_LENS_FOREGROUND: &str = "completion_lens.foreground";
+    pub const COMPLETION_LENS_FOREGROUND: &'static str =
+        "completion_lens.foreground";
 
-    pub const SOURCE_CONTROL_ADDED: &str = "source_control.added";
-    pub const SOURCE_CONTROL_REMOVED: &str = "source_control.removed";
-    pub const SOURCE_CONTROL_MODIFIED: &str = "source_control.modified";
+    pub const SOURCE_CONTROL_ADDED: &'static str = "source_control.added";
+    pub const SOURCE_CONTROL_REMOVED: &'static str = "source_control.removed";
+    pub const SOURCE_CONTROL_MODIFIED: &'static str = "source_control.modified";
 
-    pub const TERMINAL_CURSOR: &str = "terminal.cursor";
-    pub const TERMINAL_BACKGROUND: &str = "terminal.background";
-    pub const TERMINAL_FOREGROUND: &str = "terminal.foreground";
-    pub const TERMINAL_RED: &str = "terminal.red";
-    pub const TERMINAL_BLUE: &str = "terminal.blue";
-    pub const TERMINAL_GREEN: &str = "terminal.green";
-    pub const TERMINAL_YELLOW: &str = "terminal.yellow";
-    pub const TERMINAL_BLACK: &str = "terminal.black";
-    pub const TERMINAL_WHITE: &str = "terminal.white";
-    pub const TERMINAL_CYAN: &str = "terminal.cyan";
-    pub const TERMINAL_MAGENTA: &str = "terminal.magenta";
+    pub const TERMINAL_CURSOR: &'static str = "terminal.cursor";
+    pub const TERMINAL_BACKGROUND: &'static str = "terminal.background";
+    pub const TERMINAL_FOREGROUND: &'static str = "terminal.foreground";
+    pub const TERMINAL_RED: &'static str = "terminal.red";
+    pub const TERMINAL_BLUE: &'static str = "terminal.blue";
+    pub const TERMINAL_GREEN: &'static str = "terminal.green";
+    pub const TERMINAL_YELLOW: &'static str = "terminal.yellow";
+    pub const TERMINAL_BLACK: &'static str = "terminal.black";
+    pub const TERMINAL_WHITE: &'static str = "terminal.white";
+    pub const TERMINAL_CYAN: &'static str = "terminal.cyan";
+    pub const TERMINAL_MAGENTA: &'static str = "terminal.magenta";
 
-    pub const TERMINAL_BRIGHT_RED: &str = "terminal.bright_red";
-    pub const TERMINAL_BRIGHT_BLUE: &str = "terminal.bright_blue";
-    pub const TERMINAL_BRIGHT_GREEN: &str = "terminal.bright_green";
-    pub const TERMINAL_BRIGHT_YELLOW: &str = "terminal.bright_yellow";
-    pub const TERMINAL_BRIGHT_BLACK: &str = "terminal.bright_black";
-    pub const TERMINAL_BRIGHT_WHITE: &str = "terminal.bright_white";
-    pub const TERMINAL_BRIGHT_CYAN: &str = "terminal.bright_cyan";
-    pub const TERMINAL_BRIGHT_MAGENTA: &str = "terminal.bright_magenta";
+    pub const TERMINAL_BRIGHT_RED: &'static str = "terminal.bright_red";
+    pub const TERMINAL_BRIGHT_BLUE: &'static str = "terminal.bright_blue";
+    pub const TERMINAL_BRIGHT_GREEN: &'static str = "terminal.bright_green";
+    pub const TERMINAL_BRIGHT_YELLOW: &'static str = "terminal.bright_yellow";
+    pub const TERMINAL_BRIGHT_BLACK: &'static str = "terminal.bright_black";
+    pub const TERMINAL_BRIGHT_WHITE: &'static str = "terminal.bright_white";
+    pub const TERMINAL_BRIGHT_CYAN: &'static str = "terminal.bright_cyan";
+    pub const TERMINAL_BRIGHT_MAGENTA: &'static str = "terminal.bright_magenta";
 
-    pub const PALETTE_BACKGROUND: &str = "palette.background";
-    pub const PALETTE_FOREGROUND: &str = "palette.foreground";
-    pub const PALETTE_CURRENT_BACKGROUND: &str = "palette.current.background";
-    pub const PALETTE_CURRENT_FOREGROUND: &str = "palette.current.foreground";
+    pub const PALETTE_BACKGROUND: &'static str = "palette.background";
+    pub const PALETTE_FOREGROUND: &'static str = "palette.foreground";
+    pub const PALETTE_CURRENT_BACKGROUND: &'static str =
+        "palette.current.background";
+    pub const PALETTE_CURRENT_FOREGROUND: &'static str =
+        "palette.current.foreground";
 
-    pub const COMPLETION_BACKGROUND: &str = "completion.background";
-    pub const COMPLETION_CURRENT: &str = "completion.current";
+    pub const COMPLETION_BACKGROUND: &'static str = "completion.background";
+    pub const COMPLETION_CURRENT: &'static str = "completion.current";
 
-    pub const HOVER_BACKGROUND: &str = "hover.background";
+    pub const HOVER_BACKGROUND: &'static str = "hover.background";
 
-    pub const ACTIVITY_BACKGROUND: &str = "activity.background";
-    pub const ACTIVITY_CURRENT: &str = "activity.current";
+    pub const ACTIVITY_BACKGROUND: &'static str = "activity.background";
+    pub const ACTIVITY_CURRENT: &'static str = "activity.current";
 
-    pub const DEBUG_BREAKPOINT: &str = "debug.breakpoint";
-    pub const DEBUG_BREAKPOINT_HOVER: &str = "debug.breakpoint.hover";
+    pub const DEBUG_BREAKPOINT: &'static str = "debug.breakpoint";
+    pub const DEBUG_BREAKPOINT_HOVER: &'static str = "debug.breakpoint.hover";
 
-    pub const PANEL_BACKGROUND: &str = "panel.background";
-    pub const PANEL_FOREGROUND: &str = "panel.foreground";
-    pub const PANEL_FOREGROUND_DIM: &str = "panel.foreground.dim";
-    pub const PANEL_CURRENT_BACKGROUND: &str = "panel.current.background";
-    pub const PANEL_CURRENT_FOREGROUND: &str = "panel.current.foreground";
-    pub const PANEL_CURRENT_FOREGROUND_DIM: &str = "panel.current.foreground.dim";
-    pub const PANEL_HOVERED_BACKGROUND: &str = "panel.hovered.background";
-    pub const PANEL_HOVERED_ACTIVE_BACKGROUND: &str =
+    pub const PANEL_BACKGROUND: &'static str = "panel.background";
+    pub const PANEL_FOREGROUND: &'static str = "panel.foreground";
+    pub const PANEL_FOREGROUND_DIM: &'static str = "panel.foreground.dim";
+    pub const PANEL_CURRENT_BACKGROUND: &'static str = "panel.current.background";
+    pub const PANEL_CURRENT_FOREGROUND: &'static str = "panel.current.foreground";
+    pub const PANEL_CURRENT_FOREGROUND_DIM: &'static str =
+        "panel.current.foreground.dim";
+    pub const PANEL_HOVERED_BACKGROUND: &'static str = "panel.hovered.background";
+    pub const PANEL_HOVERED_ACTIVE_BACKGROUND: &'static str =
         "panel.hovered.active.background";
-    pub const PANEL_HOVERED_FOREGROUND: &str = "panel.hovered.foreground";
-    pub const PANEL_HOVERED_FOREGROUND_DIM: &str = "panel.hovered.foreground.dim";
+    pub const PANEL_HOVERED_FOREGROUND: &'static str = "panel.hovered.foreground";
+    pub const PANEL_HOVERED_FOREGROUND_DIM: &'static str =
+        "panel.hovered.foreground.dim";
 
-    pub const STATUS_BACKGROUND: &str = "status.background";
-    pub const STATUS_FOREGROUND: &str = "status.foreground";
-    pub const STATUS_MODAL_NORMAL_BACKGROUND: &str =
+    pub const STATUS_BACKGROUND: &'static str = "status.background";
+    pub const STATUS_FOREGROUND: &'static str = "status.foreground";
+    pub const STATUS_MODAL_NORMAL_BACKGROUND: &'static str =
         "status.modal.normal.background";
-    pub const STATUS_MODAL_NORMAL_FOREGROUND: &str =
+    pub const STATUS_MODAL_NORMAL_FOREGROUND: &'static str =
         "status.modal.normal.foreground";
-    pub const STATUS_MODAL_INSERT_BACKGROUND: &str =
+    pub const STATUS_MODAL_INSERT_BACKGROUND: &'static str =
         "status.modal.insert.background";
-    pub const STATUS_MODAL_INSERT_FOREGROUND: &str =
+    pub const STATUS_MODAL_INSERT_FOREGROUND: &'static str =
         "status.modal.insert.foreground";
-    pub const STATUS_MODAL_VISUAL_BACKGROUND: &str =
+    pub const STATUS_MODAL_VISUAL_BACKGROUND: &'static str =
         "status.modal.visual.background";
-    pub const STATUS_MODAL_VISUAL_FOREGROUND: &str =
+    pub const STATUS_MODAL_VISUAL_FOREGROUND: &'static str =
         "status.modal.visual.foreground";
-    pub const STATUS_MODAL_TERMINAL_BACKGROUND: &str =
+    pub const STATUS_MODAL_TERMINAL_BACKGROUND: &'static str =
         "status.modal.terminal.background";
-    pub const STATUS_MODAL_TERMINAL_FOREGROUND: &str =
+    pub const STATUS_MODAL_TERMINAL_FOREGROUND: &'static str =
         "status.modal.terminal.foreground";
 
     pub const MARKDOWN_BLOCKQUOTE: &'static str = "markdown.blockquote";

--- a/lapce-app/src/config/icon.rs
+++ b/lapce-app/src/config/icon.rs
@@ -1,91 +1,91 @@
 pub struct LapceIcons {}
 
 impl LapceIcons {
-    pub const WINDOW_CLOSE: &str = "window.close";
-    pub const WINDOW_RESTORE: &str = "window.restore";
-    pub const WINDOW_MAXIMIZE: &str = "window.maximize";
-    pub const WINDOW_MINIMIZE: &str = "window.minimize";
+    pub const WINDOW_CLOSE: &'static str = "window.close";
+    pub const WINDOW_RESTORE: &'static str = "window.restore";
+    pub const WINDOW_MAXIMIZE: &'static str = "window.maximize";
+    pub const WINDOW_MINIMIZE: &'static str = "window.minimize";
 
-    pub const LOGO: &str = "logo";
-    pub const MENU: &str = "menu";
-    pub const LINK: &str = "link";
-    pub const ERROR: &str = "error";
-    pub const ADD: &str = "add";
-    pub const CLOSE: &str = "close";
-    pub const REMOTE: &str = "remote";
-    pub const PROBLEM: &str = "error";
-    pub const DEBUG: &str = "debug";
-    pub const DEBUG_ALT: &str = "debug_alt";
-    pub const DEBUG_BREAKPOINT: &str = "debug_breakpoint";
-    pub const DEBUG_SMALL: &str = "debug_small";
-    pub const DEBUG_RESTART: &str = "debug_restart";
-    pub const DEBUG_CONTINUE: &str = "debug_continue";
-    pub const DEBUG_STEP_OVER: &str = "debug_step_over";
-    pub const DEBUG_STEP_INTO: &str = "debug_step_into";
-    pub const DEBUG_STEP_OUT: &str = "debug_step_out";
-    pub const DEBUG_PAUSE: &str = "debug_pause";
-    pub const DEBUG_STOP: &str = "debug_stop";
-    pub const DEBUG_CONSOLE: &str = "debug_console";
-    pub const DEBUG_DISCONNECT: &str = "debug_disconnect";
-    pub const START: &str = "start";
-    pub const RUN_ERRORS: &str = "run_errors";
-    pub const UNSAVED: &str = "unsaved";
-    pub const WARNING: &str = "warning";
-    pub const TERMINAL: &str = "terminal";
-    pub const SETTINGS: &str = "settings";
-    pub const LIGHTBULB: &str = "lightbulb";
-    pub const EXTENSIONS: &str = "extensions";
-    pub const KEYBOARD: &str = "keyboard";
-    pub const BREADCRUMB_SEPARATOR: &str = "breadcrumb_separator";
-    pub const SYMBOL_COLOR: &str = "symbol_color";
+    pub const LOGO: &'static str = "logo";
+    pub const MENU: &'static str = "menu";
+    pub const LINK: &'static str = "link";
+    pub const ERROR: &'static str = "error";
+    pub const ADD: &'static str = "add";
+    pub const CLOSE: &'static str = "close";
+    pub const REMOTE: &'static str = "remote";
+    pub const PROBLEM: &'static str = "error";
+    pub const DEBUG: &'static str = "debug";
+    pub const DEBUG_ALT: &'static str = "debug_alt";
+    pub const DEBUG_BREAKPOINT: &'static str = "debug_breakpoint";
+    pub const DEBUG_SMALL: &'static str = "debug_small";
+    pub const DEBUG_RESTART: &'static str = "debug_restart";
+    pub const DEBUG_CONTINUE: &'static str = "debug_continue";
+    pub const DEBUG_STEP_OVER: &'static str = "debug_step_over";
+    pub const DEBUG_STEP_INTO: &'static str = "debug_step_into";
+    pub const DEBUG_STEP_OUT: &'static str = "debug_step_out";
+    pub const DEBUG_PAUSE: &'static str = "debug_pause";
+    pub const DEBUG_STOP: &'static str = "debug_stop";
+    pub const DEBUG_CONSOLE: &'static str = "debug_console";
+    pub const DEBUG_DISCONNECT: &'static str = "debug_disconnect";
+    pub const START: &'static str = "start";
+    pub const RUN_ERRORS: &'static str = "run_errors";
+    pub const UNSAVED: &'static str = "unsaved";
+    pub const WARNING: &'static str = "warning";
+    pub const TERMINAL: &'static str = "terminal";
+    pub const SETTINGS: &'static str = "settings";
+    pub const LIGHTBULB: &'static str = "lightbulb";
+    pub const EXTENSIONS: &'static str = "extensions";
+    pub const KEYBOARD: &'static str = "keyboard";
+    pub const BREADCRUMB_SEPARATOR: &'static str = "breadcrumb_separator";
+    pub const SYMBOL_COLOR: &'static str = "symbol_color";
 
-    pub const FILE: &str = "file";
-    pub const FILE_EXPLORER: &str = "file_explorer";
-    pub const FILE_PICKER_UP: &str = "file_picker_up";
+    pub const FILE: &'static str = "file";
+    pub const FILE_EXPLORER: &'static str = "file_explorer";
+    pub const FILE_PICKER_UP: &'static str = "file_picker_up";
 
-    pub const IMAGE_LOADING: &str = "image_loading";
-    pub const IMAGE_ERROR: &str = "image_error";
+    pub const IMAGE_LOADING: &'static str = "image_loading";
+    pub const IMAGE_ERROR: &'static str = "image_error";
 
-    pub const SCM: &str = "scm.icon";
-    pub const SCM_DIFF_MODIFIED: &str = "scm.diff.modified";
-    pub const SCM_DIFF_ADDED: &str = "scm.diff.added";
-    pub const SCM_DIFF_REMOVED: &str = "scm.diff.removed";
-    pub const SCM_DIFF_RENAMED: &str = "scm.diff.renamed";
-    pub const SCM_CHANGE_ADD: &str = "scm.change.add";
-    pub const SCM_CHANGE_REMOVE: &str = "scm.change.remove";
+    pub const SCM: &'static str = "scm.icon";
+    pub const SCM_DIFF_MODIFIED: &'static str = "scm.diff.modified";
+    pub const SCM_DIFF_ADDED: &'static str = "scm.diff.added";
+    pub const SCM_DIFF_REMOVED: &'static str = "scm.diff.removed";
+    pub const SCM_DIFF_RENAMED: &'static str = "scm.diff.renamed";
+    pub const SCM_CHANGE_ADD: &'static str = "scm.change.add";
+    pub const SCM_CHANGE_REMOVE: &'static str = "scm.change.remove";
 
-    pub const FOLD: &str = "fold";
-    pub const FOLD_UP: &str = "fold.up";
-    pub const FOLD_DOWN: &str = "fold.down";
+    pub const FOLD: &'static str = "fold";
+    pub const FOLD_UP: &'static str = "fold.up";
+    pub const FOLD_DOWN: &'static str = "fold.down";
 
-    pub const PALETTE_MENU: &str = "palette.menu";
+    pub const PALETTE_MENU: &'static str = "palette.menu";
 
-    pub const DROPDOWN_ARROW: &str = "dropdown.arrow";
+    pub const DROPDOWN_ARROW: &'static str = "dropdown.arrow";
 
-    pub const LOCATION_BACKWARD: &str = "location.backward";
-    pub const LOCATION_FORWARD: &str = "location.forward";
+    pub const LOCATION_BACKWARD: &'static str = "location.backward";
+    pub const LOCATION_FORWARD: &'static str = "location.forward";
 
-    pub const ITEM_OPENED: &str = "item.opened";
-    pub const ITEM_CLOSED: &str = "item.closed";
+    pub const ITEM_OPENED: &'static str = "item.opened";
+    pub const ITEM_CLOSED: &'static str = "item.closed";
 
-    pub const DIRECTORY_CLOSED: &str = "directory.closed";
-    pub const DIRECTORY_OPENED: &str = "directory.opened";
+    pub const DIRECTORY_CLOSED: &'static str = "directory.closed";
+    pub const DIRECTORY_OPENED: &'static str = "directory.opened";
 
-    pub const PANEL_RESTORE: &str = "panel.restore";
-    pub const PANEL_MAXIMISE: &str = "panel.maximise";
+    pub const PANEL_RESTORE: &'static str = "panel.restore";
+    pub const PANEL_MAXIMISE: &'static str = "panel.maximise";
 
-    pub const SPLIT_HORIZONTAL: &str = "split.horizontal";
+    pub const SPLIT_HORIZONTAL: &'static str = "split.horizontal";
 
-    pub const TAB_PREVIOUS: &str = "tab.previous";
-    pub const TAB_NEXT: &str = "tab.next";
+    pub const TAB_PREVIOUS: &'static str = "tab.previous";
+    pub const TAB_NEXT: &'static str = "tab.next";
 
-    pub const SIDEBAR_LEFT: &str = "sidebar.left.on";
-    pub const SIDEBAR_LEFT_OFF: &str = "sidebar.left.off";
-    pub const SIDEBAR_RIGHT: &str = "sidebar.right.on";
-    pub const SIDEBAR_RIGHT_OFF: &str = "sidebar.right.off";
+    pub const SIDEBAR_LEFT: &'static str = "sidebar.left.on";
+    pub const SIDEBAR_LEFT_OFF: &'static str = "sidebar.left.off";
+    pub const SIDEBAR_RIGHT: &'static str = "sidebar.right.on";
+    pub const SIDEBAR_RIGHT_OFF: &'static str = "sidebar.right.off";
 
-    pub const LAYOUT_PANEL: &str = "layout.panel.on";
-    pub const LAYOUT_PANEL_OFF: &str = "layout.panel.off";
+    pub const LAYOUT_PANEL: &'static str = "layout.panel.on";
+    pub const LAYOUT_PANEL_OFF: &'static str = "layout.panel.off";
 
     pub const SEARCH: &'static str = "search.icon";
     pub const SEARCH_CLEAR: &'static str = "search.clear";
@@ -97,52 +97,65 @@ impl LapceIcons {
     pub const SEARCH_REPLACE: &'static str = "search.replace";
     pub const SEARCH_REPLACE_ALL: &'static str = "search.replace_all";
 
-    pub const FILE_TYPE_CODE: &str = "file-code";
-    pub const FILE_TYPE_MEDIA: &str = "file-media";
-    pub const FILE_TYPE_BINARY: &str = "file-binary";
-    pub const FILE_TYPE_ARCHIVE: &str = "file-zip";
-    pub const FILE_TYPE_SUBMODULE: &str = "file-submodule";
-    pub const FILE_TYPE_SYMLINK_FILE: &str = "file-symlink-file";
-    pub const FILE_TYPE_SYMLINK_DIRECTORY: &str = "file-symlink-directory";
+    pub const FILE_TYPE_CODE: &'static str = "file-code";
+    pub const FILE_TYPE_MEDIA: &'static str = "file-media";
+    pub const FILE_TYPE_BINARY: &'static str = "file-binary";
+    pub const FILE_TYPE_ARCHIVE: &'static str = "file-zip";
+    pub const FILE_TYPE_SUBMODULE: &'static str = "file-submodule";
+    pub const FILE_TYPE_SYMLINK_FILE: &'static str = "file-symlink-file";
+    pub const FILE_TYPE_SYMLINK_DIRECTORY: &'static str = "file-symlink-directory";
 
-    pub const SYMBOL_KIND_ARRAY: &str = "symbol_kind.array";
-    pub const SYMBOL_KIND_BOOLEAN: &str = "symbol_kind.boolean";
-    pub const SYMBOL_KIND_CLASS: &str = "symbol_kind.class";
-    pub const SYMBOL_KIND_CONSTANT: &str = "symbol_kind.constant";
-    pub const SYMBOL_KIND_ENUM_MEMBER: &str = "symbol_kind.enum_member";
-    pub const SYMBOL_KIND_ENUM: &str = "symbol_kind.enum";
-    pub const SYMBOL_KIND_EVENT: &str = "symbol_kind.event";
-    pub const SYMBOL_KIND_FIELD: &str = "symbol_kind.field";
-    pub const SYMBOL_KIND_FILE: &str = "symbol_kind.file";
-    pub const SYMBOL_KIND_FUNCTION: &str = "symbol_kind.function";
-    pub const SYMBOL_KIND_INTERFACE: &str = "symbol_kind.interface";
-    pub const SYMBOL_KIND_KEY: &str = "symbol_kind.key";
-    pub const SYMBOL_KIND_METHOD: &str = "symbol_kind.method";
-    pub const SYMBOL_KIND_NAMESPACE: &str = "symbol_kind.namespace";
-    pub const SYMBOL_KIND_NUMBER: &str = "symbol_kind.number";
-    pub const SYMBOL_KIND_OBJECT: &str = "symbol_kind.namespace";
-    pub const SYMBOL_KIND_OPERATOR: &str = "symbol_kind.operator";
-    pub const SYMBOL_KIND_PROPERTY: &str = "symbol_kind.property";
-    pub const SYMBOL_KIND_STRING: &str = "symbol_kind.string";
-    pub const SYMBOL_KIND_STRUCT: &str = "symbol_kind.struct";
-    pub const SYMBOL_KIND_TYPE_PARAMETER: &str = "symbol_kind.type_parameter";
-    pub const SYMBOL_KIND_VARIABLE: &str = "symbol_kind.variable";
+    pub const SYMBOL_KIND_ARRAY: &'static str = "symbol_kind.array";
+    pub const SYMBOL_KIND_BOOLEAN: &'static str = "symbol_kind.boolean";
+    pub const SYMBOL_KIND_CLASS: &'static str = "symbol_kind.class";
+    pub const SYMBOL_KIND_CONSTANT: &'static str = "symbol_kind.constant";
+    pub const SYMBOL_KIND_ENUM_MEMBER: &'static str = "symbol_kind.enum_member";
+    pub const SYMBOL_KIND_ENUM: &'static str = "symbol_kind.enum";
+    pub const SYMBOL_KIND_EVENT: &'static str = "symbol_kind.event";
+    pub const SYMBOL_KIND_FIELD: &'static str = "symbol_kind.field";
+    pub const SYMBOL_KIND_FILE: &'static str = "symbol_kind.file";
+    pub const SYMBOL_KIND_FUNCTION: &'static str = "symbol_kind.function";
+    pub const SYMBOL_KIND_INTERFACE: &'static str = "symbol_kind.interface";
+    pub const SYMBOL_KIND_KEY: &'static str = "symbol_kind.key";
+    pub const SYMBOL_KIND_METHOD: &'static str = "symbol_kind.method";
+    pub const SYMBOL_KIND_NAMESPACE: &'static str = "symbol_kind.namespace";
+    pub const SYMBOL_KIND_NUMBER: &'static str = "symbol_kind.number";
+    pub const SYMBOL_KIND_OBJECT: &'static str = "symbol_kind.namespace";
+    pub const SYMBOL_KIND_OPERATOR: &'static str = "symbol_kind.operator";
+    pub const SYMBOL_KIND_PROPERTY: &'static str = "symbol_kind.property";
+    pub const SYMBOL_KIND_STRING: &'static str = "symbol_kind.string";
+    pub const SYMBOL_KIND_STRUCT: &'static str = "symbol_kind.struct";
+    pub const SYMBOL_KIND_TYPE_PARAMETER: &'static str =
+        "symbol_kind.type_parameter";
+    pub const SYMBOL_KIND_VARIABLE: &'static str = "symbol_kind.variable";
 
-    pub const COMPLETION_ITEM_KIND_CLASS: &str = "completion_item_kind.class";
-    pub const COMPLETION_ITEM_KIND_CONSTANT: &str = "completion_item_kind.constant";
-    pub const COMPLETION_ITEM_KIND_ENUM_MEMBER: &str =
+    pub const COMPLETION_ITEM_KIND_CLASS: &'static str =
+        "completion_item_kind.class";
+    pub const COMPLETION_ITEM_KIND_CONSTANT: &'static str =
+        "completion_item_kind.constant";
+    pub const COMPLETION_ITEM_KIND_ENUM_MEMBER: &'static str =
         "completion_item_kind.enum_member";
-    pub const COMPLETION_ITEM_KIND_ENUM: &str = "completion_item_kind.enum";
-    pub const COMPLETION_ITEM_KIND_FIELD: &str = "completion_item_kind.field";
-    pub const COMPLETION_ITEM_KIND_FUNCTION: &str = "completion_item_kind.function";
-    pub const COMPLETION_ITEM_KIND_INTERFACE: &str =
+    pub const COMPLETION_ITEM_KIND_ENUM: &'static str = "completion_item_kind.enum";
+    pub const COMPLETION_ITEM_KIND_FIELD: &'static str =
+        "completion_item_kind.field";
+    pub const COMPLETION_ITEM_KIND_FUNCTION: &'static str =
+        "completion_item_kind.function";
+    pub const COMPLETION_ITEM_KIND_INTERFACE: &'static str =
         "completion_item_kind.interface";
-    pub const COMPLETION_ITEM_KIND_KEYWORD: &str = "completion_item_kind.keyword";
-    pub const COMPLETION_ITEM_KIND_METHOD: &str = "completion_item_kind.method";
-    pub const COMPLETION_ITEM_KIND_MODULE: &str = "completion_item_kind.module";
-    pub const COMPLETION_ITEM_KIND_PROPERTY: &str = "completion_item_kind.property";
-    pub const COMPLETION_ITEM_KIND_SNIPPET: &str = "completion_item_kind.snippet";
-    pub const COMPLETION_ITEM_KIND_STRING: &str = "completion_item_kind.string";
-    pub const COMPLETION_ITEM_KIND_STRUCT: &str = "completion_item_kind.struct";
-    pub const COMPLETION_ITEM_KIND_VARIABLE: &str = "completion_item_kind.variable";
+    pub const COMPLETION_ITEM_KIND_KEYWORD: &'static str =
+        "completion_item_kind.keyword";
+    pub const COMPLETION_ITEM_KIND_METHOD: &'static str =
+        "completion_item_kind.method";
+    pub const COMPLETION_ITEM_KIND_MODULE: &'static str =
+        "completion_item_kind.module";
+    pub const COMPLETION_ITEM_KIND_PROPERTY: &'static str =
+        "completion_item_kind.property";
+    pub const COMPLETION_ITEM_KIND_SNIPPET: &'static str =
+        "completion_item_kind.snippet";
+    pub const COMPLETION_ITEM_KIND_STRING: &'static str =
+        "completion_item_kind.string";
+    pub const COMPLETION_ITEM_KIND_STRUCT: &'static str =
+        "completion_item_kind.struct";
+    pub const COMPLETION_ITEM_KIND_VARIABLE: &'static str =
+        "completion_item_kind.variable";
 }

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -1518,12 +1518,12 @@ const LANGUAGES: &[SyntaxProperties] = &[
 ];
 
 impl LapceLanguage {
-    const HIGHLIGHTS_QUERIES_FILE_NAME: &str = "highlights.scm";
-    const HIGHLIGHTS_INJECTIONS_FILE_NAME: &str = "injections.scm";
+    const HIGHLIGHTS_QUERIES_FILE_NAME: &'static str = "highlights.scm";
+    const HIGHLIGHTS_INJECTIONS_FILE_NAME: &'static str = "injections.scm";
     #[cfg(unix)]
-    const SYSTEM_GRAMMARS_DIRECTORY: &str = "/usr/lib";
+    const SYSTEM_GRAMMARS_DIRECTORY: &'static str = "/usr/lib";
     #[cfg(unix)]
-    const SYSTEM_QUERIES_DIRECTORY: &str = "/usr/share/tree-sitter/grammars";
+    const SYSTEM_QUERIES_DIRECTORY: &'static str = "/usr/share/tree-sitter/grammars";
 
     pub fn from_path(path: &Path) -> LapceLanguage {
         Self::from_path_raw(path).unwrap_or(LapceLanguage::Plaintext)


### PR DESCRIPTION
This removes 219 warnings with Rust 1.74.0.
All changes are from `cargo fix`.
See https://github.com/rust-lang/rust/issues/115010

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users