### PR TITLE
Switch clipboard functionality to a maintained crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
 
 [[package]]
+name = "arboard"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac57f2b058a76363e357c056e4f74f1945bf734d37b8b3ef49066c4787dde0fc"
+dependencies = [
+ "clipboard-win 4.5.0",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "parking_lot 0.12.1",
+ "thiserror",
+ "winapi",
+ "x11rb 0.10.1",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,7 +795,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
 dependencies = [
- "clipboard-win",
+ "clipboard-win 2.2.0",
  "objc",
  "objc-foundation",
  "objc_id",
@@ -791,6 +808,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
  "winapi",
 ]
 
@@ -1488,6 +1516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2000,16 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2812,11 +2860,11 @@ dependencies = [
  "Inflector",
  "alacritty_terminal",
  "anyhow",
+ "arboard",
  "base64",
  "bytemuck",
  "chrono",
  "clap",
- "clipboard",
  "config",
  "crossbeam-channel",
  "directories",
@@ -4894,7 +4942,7 @@ dependencies = [
  "wayland-sys 0.30.1",
  "web-sys",
  "windows-sys 0.48.0",
- "x11rb",
+ "x11rb 0.12.0",
 ]
 
 [[package]]
@@ -4942,6 +4990,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "stretto"
@@ -7178,7 +7232,7 @@ dependencies = [
  "web-time",
  "windows-sys 0.48.0",
  "x11-dl",
- "x11rb",
+ "x11rb 0.12.0",
  "xkbcommon-dl",
 ]
 
@@ -7262,19 +7316,41 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
+dependencies = [
+ "gethostname 0.2.3",
+ "nix 0.24.2",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol 0.10.0",
+]
+
+[[package]]
+name = "x11rb"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
 dependencies = [
  "as-raw-xcb-connection",
- "gethostname",
+ "gethostname 0.3.0",
  "libc",
  "libloading 0.7.3",
  "nix 0.26.4",
  "once_cell",
  "winapi",
  "winapi-wsapoll",
- "x11rb-protocol",
+ "x11rb-protocol 0.12.0",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
+dependencies = [
+ "nix 0.24.2",
 ]
 
 [[package]]

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -51,7 +51,6 @@ sled = "0.34.7"
 bytemuck = "1.14.0"
 tokio = { version = "1.21", features = ["full"] }
 futures = "0.3.26"
-clipboard = "0.5.0"
 floem = { git = "https://github.com/lapce/floem", rev = "4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56" }
 # floem = { path = "../../workspaces/floem" }
 config = { version = "0.13.2", default-features = false, features = ["toml"] }
@@ -59,6 +58,7 @@ structdesc = { git = "https://github.com/lapce/structdesc" }
 base64 = "0.21.5"
 sha2 = "0.10.6"
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+arboard = { version = "3.2.1", default-features = false }
 
 [target.'cfg(target_os="macos")'.dependencies]
 fs_extra = "1.2.0"

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -1,6 +1,7 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
+    ops::DerefMut,
     path::{Path, PathBuf},
     rc::Rc,
     sync::{atomic, Arc},
@@ -437,7 +438,7 @@ impl Document {
             return Vec::new();
         }
 
-        let mut clipboard = SystemClipboard::new();
+        let mut clipboard = self.common.clipboard.lock();
         let old_cursor = cursor.mode.clone();
         let deltas = self.syntax.with_untracked(|syntax| {
             self.buffer
@@ -447,7 +448,7 @@ impl Document {
                         buffer,
                         cmd,
                         syntax,
-                        &mut clipboard,
+                        clipboard.deref_mut(),
                         modal,
                         register,
                         smart_tab,

--- a/lapce-app/src/terminal/data.rs
+++ b/lapce-app/src/terminal/data.rs
@@ -30,7 +30,6 @@ use super::{
 use crate::{
     command::{CommandExecuted, CommandKind, InternalCommand},
     debug::RunDebugProcess,
-    doc::SystemClipboard,
     keypress::{condition::Condition, KeyPressFocus},
     window_tab::CommonData,
     workspace::LapceWorkspace,
@@ -157,7 +156,6 @@ impl KeyPressFocus for TerminalData {
                     term.selection = None;
                 }
                 EditCommand::ClipboardCopy => {
-                    let mut clipboard = SystemClipboard::new();
                     if matches!(self.mode.get_untracked(), Mode::Visual(_)) {
                         self.mode.set(Mode::Normal);
                     }
@@ -165,6 +163,7 @@ impl KeyPressFocus for TerminalData {
                     let mut raw = raw.write();
                     let term = &mut raw.term;
                     if let Some(content) = term.selection_to_string() {
+                        let mut clipboard = self.common.clipboard.lock();
                         clipboard.put_string(content);
                     }
                     if self.mode.get_untracked() != Mode::Terminal {
@@ -172,7 +171,6 @@ impl KeyPressFocus for TerminalData {
                     }
                 }
                 EditCommand::ClipboardPaste => {
-                    let mut clipboard = SystemClipboard::new();
                     let mut check_bracketed_paste: bool = false;
                     if self.mode.get_untracked() == Mode::Terminal {
                         let raw = self.raw.get_untracked();
@@ -183,6 +181,7 @@ impl KeyPressFocus for TerminalData {
                             check_bracketed_paste = true;
                         }
                     }
+                    let mut clipboard = self.common.clipboard.lock();
                     if let Some(s) = clipboard.get_string() {
                         if check_bracketed_paste {
                             self.receive_char("\x1b[200~");

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -33,6 +33,7 @@ use lapce_rpc::{
     terminal::TermId,
 };
 use lsp_types::{ProgressParams, ProgressToken, ShowMessageParams};
+use parking_lot::Mutex;
 use serde_json::Value;
 use tracing::{debug, error};
 
@@ -48,7 +49,7 @@ use crate::{
     config::LapceConfig,
     db::LapceDb,
     debug::{DapData, LapceBreakpoint, RunDebugMode, RunDebugProcess},
-    doc::{DocContent, EditorDiagnostic},
+    doc::{DocContent, EditorDiagnostic, SystemClipboard},
     editor::location::{EditorLocation, EditorPosition},
     editor_tab::EditorTabChild,
     file_explorer::data::FileExplorerData,
@@ -135,6 +136,7 @@ pub struct CommonData {
     // the current focused view which will receive keyboard events
     pub keyboard_focus: RwSignal<Option<floem::id::Id>>,
     pub window_common: Rc<WindowCommonData>,
+    pub clipboard: Rc<Mutex<SystemClipboard>>,
 }
 
 #[derive(Clone)]
@@ -316,6 +318,8 @@ impl WindowTabData {
             text_layout.size().height
         });
 
+        let clipboard = Rc::new(Mutex::new(SystemClipboard::new()));
+
         let common = Rc::new(CommonData {
             workspace: workspace.clone(),
             scope: cx,
@@ -342,6 +346,7 @@ impl WindowTabData {
             breakpoints: cx.create_rw_signal(BTreeMap::new()),
             keyboard_focus: cx.create_rw_signal(None),
             window_common: window_common.clone(),
+            clipboard,
         });
 
         let main_split = MainSplitData::new(cx, common.clone());


### PR DESCRIPTION
Switch from crate clipboard to arboard

This avoids a dependency via x11-clipboard to an old version of xcb,
v0.3. Problems and annoyances with xcb v0.3 include

- safety: https://github.com/aweinstock314/rust-clipboard/issues/90
- build script depends on python
- won't build in a sandbox, as it writes to the source directory

See also https://github.com/aweinstock314/rust-clipboard/issues/91

---

initialize SystemClipboard only once

The `x11-clipboard` crate starts a new thread on every `new` call,
previously triggered on every copy to clipboard operation, and these
threads seem to stick around.

This will also help migrating away from the
`clipboard`/`x11-clipboard` crates.

---

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users