### PR TITLE
Reworked cursor rendering, fixing several bugs

### DIFF
--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -65,6 +65,9 @@ pub mod movement;
 pub mod view;
 pub mod view_data;
 
+const CHAR_WIDTH: f64 = 7.5;
+const FONT_SIZE: usize = 12;
+
 #[derive(Clone, Debug)]
 pub enum InlineFindDirection {
     Left,
@@ -1113,7 +1116,7 @@ impl EditorData {
         clear_completion_lens(self.view.doc.get_untracked());
     }
 
-    /// Update the displayed autocompletion box  
+    /// Update the displayed autocompletion box
     /// Sends a request to the LSP for completion information
     fn update_completion(&self, display_if_empty_input: bool) {
         if self.get_mode() != Mode::Insert {

--- a/lapce-app/src/editor/view_data.rs
+++ b/lapce-app/src/editor/view_data.rs
@@ -25,7 +25,7 @@ use crate::{
     find::{Find, FindResult},
 };
 
-use super::diff::DiffInfo;
+use super::{diff::DiffInfo, FONT_SIZE};
 
 #[derive(Clone)]
 pub struct LineExtraStyle {
@@ -53,7 +53,7 @@ pub struct TextLayoutCache {
     /// the cache.
     config_id: u64,
     cache_rev: u64,
-    /// (Font Size -> (Line Number -> Text Layout))  
+    /// (Font Size -> (Line Number -> Text Layout))
     /// Different font-sizes are cached separately, which is useful for features like code lens
     /// where the text becomes small but you may wish to revert quickly.
     pub layouts: HashMap<usize, HashMap<usize, Arc<TextLayoutLine>>>,
@@ -104,10 +104,10 @@ impl EditorViewKind {
 }
 
 // TODO(minor): Should this go in another file? It doesn't really need to be with the drawing code for editor views
-/// Data specific to the rendering of a view.  
+/// Data specific to the rendering of a view.
 /// This has various helper methods that may dispatch to the held [`Document`] signal, but are
 /// untracked by default. If you need your signal to depend on the document,
-/// then you should call [`EditorViewData::track_doc`].  
+/// then you should call [`EditorViewData::track_doc`].
 /// Note: This should be cheap to clone.
 #[derive(Clone)]
 pub struct EditorViewData {
@@ -134,7 +134,7 @@ impl VirtualListVector<DocLine> for EditorViewData {
                 rev: self.rev(),
                 style_rev: self.cache_rev(),
                 line,
-                text: self.get_text_layout(line, 12),
+                text: self.get_text_layout(line, FONT_SIZE),
             })
             .collect::<Vec<_>>();
         lines.into_iter()
@@ -170,7 +170,7 @@ impl EditorViewData {
         doc.buffer.with_untracked(|b| b.text().clone())
     }
 
-    /// Return a [`RopeTextVal`] wrapper.  
+    /// Return a [`RopeTextVal`] wrapper.
     /// Unfortunately, we can't implement [`RopeText`] directly on [`EditorViewData`] due to
     /// it not having a reference to the rope.
     pub fn rope_text(&self) -> RopeTextVal {
@@ -232,7 +232,7 @@ impl EditorViewData {
         self.doc.with_untracked(|doc| doc.line_phantom_text(line))
     }
 
-    /// Get the text layout for the given line.  
+    /// Get the text layout for the given line.
     /// If the text layout is not cached, it will be created and cached.
     pub fn get_text_layout(
         &self,
@@ -627,7 +627,7 @@ impl EditorViewData {
         })
     }
 
-    /// Get the offset of a particular point within the editor.  
+    /// Get the offset of a particular point within the editor.
     /// The boolean indicates whether the point is inside the text or not
     /// Points outside of vertical bounds will return the last line.
     /// Points outside of horizontal bounds will return the last column on the line.
@@ -637,7 +637,7 @@ impl EditorViewData {
     }
 
     /// Get the (line, col) of a particular point within the editor.
-    /// The boolean indicates whether the point is within the text bounds.  
+    /// The boolean indicates whether the point is within the text bounds.
     /// Points outside of vertical bounds will return the last line.
     /// Points outside of horizontal bounds will return the last column on the line.
     pub fn line_col_of_point(
@@ -699,7 +699,7 @@ impl EditorViewData {
         }
     }
 
-    /// Advance to the right in the manner of the given mode.  
+    /// Advance to the right in the manner of the given mode.
     /// This is not the same as the [`Movement::Right`] command.
     pub fn move_right(&self, offset: usize, mode: Mode, count: usize) -> usize {
         self.doc.with_untracked(|doc| {
@@ -744,7 +744,7 @@ impl EditorViewData {
         })
     }
 
-    /// Find the offset of the matching pair character.  
+    /// Find the offset of the matching pair character.
     /// This is intended for use by the [`Movement::MatchPairs`] command.
     pub fn find_matching_pair(&self, offset: usize) -> usize {
         // This needs the doc's syntax, but it isn't cheap to clone

--- a/lapce-app/src/panel/source_control_view.rs
+++ b/lapce-app/src/panel/source_control_view.rs
@@ -4,7 +4,7 @@ use floem::{
     action::show_context_menu,
     event::{Event, EventListener},
     menu::{Menu, MenuItem},
-    peniko::kurbo::{Point, Rect, Size},
+    peniko::kurbo::Rect,
     reactive::{create_memo, create_rw_signal},
     style::{CursorStyle, Style},
     view::View,
@@ -17,7 +17,7 @@ use super::{kind::PanelKind, position::PanelPosition, view::panel_header};
 use crate::{
     command::{CommandKind, InternalCommand, LapceCommand, LapceWorkbenchCommand},
     config::{color::LapceColor, icon::LapceIcons},
-    editor::view::{cursor_caret, editor_view, CursorRender},
+    editor::view::{cursor_caret, editor_view, LineRegion},
     settings::checkbox,
     source_control::SourceControlData,
     window_tab::{Focus, WindowTabData},
@@ -113,18 +113,16 @@ pub fn source_control_panel(
                     let editor_view = editor.view.clone();
                     editor_view.doc.track();
                     editor_view.kind.track();
-                    let caret =
+                    let LineRegion { x, width, line } =
                         cursor_caret(&editor_view, offset, !cursor.is_insert());
                     let config = config.get_untracked();
                     let line_height = config.editor.line_height();
-                    if let CursorRender::Caret { x, width, line } = caret {
-                        Size::new(width, line_height as f64)
-                            .to_rect()
-                            .with_origin(Point::new(x, (line * line_height) as f64))
-                            .inflate(30.0, 10.0)
-                    } else {
-                        Rect::ZERO
-                    }
+
+                    Rect::from_origin_size(
+                        (x, (line * line_height) as f64),
+                        (width, line_height as f64),
+                    )
+                    .inflate(30.0, 10.0)
                 })
                 .style(|s| s.absolute().size_pct(100.0, 100.0))
             })


### PR DESCRIPTION
* Block cursors were rendered with a fixed width, rather than the width of the current character, when after an inlay hint and using a variable width font.

* In visual normal mode, the selection highlight didn't extend past the end of the current line when the cursor was past the end of the line.

* In visual normal mode, if there was an inlay hint after the end of the current line and the cursor was past the end of the line, the cursor was rendered after the inlay hint.

* In visual normal and block modes, when selecting backwards to the first character after an inlay hint, the selection highlight extended leftward of the cursor to include the inlay hint.

* When there were multiple cursors on the same line, only one was rendered.

* The selection highlight for visual block mode excluded the rightmost column when selecting right and up or left and down.

* When in visual block mode, when the cursor was to the left of the anchor column of the selection and past the end of the line, the cursor wasn't rendered.