### PR TITLE
Fix invalid unicode filenames not being displayed

### DIFF
--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -1931,14 +1931,16 @@ fn editor_breadcrumbs(
                                     .to_path_buf();
                             }
                             path.ancestors()
-                                .collect::<Vec<_>>()
-                                .iter()
-                                .rev()
                                 .filter_map(|path| {
-                                    Some(path.file_name()?.to_str()?.to_string())
+                                    Some(
+                                        path.file_name()?
+                                            .to_string_lossy()
+                                            .into_owned(),
+                                    )
                                 })
                                 .collect::<Vec<_>>()
                                 .into_iter()
+                                .rev()
                                 .enumerate()
                         },
                         |(i, section)| (*i, section.to_string()),

--- a/lapce-app/src/editor_tab.rs
+++ b/lapce-app/src/editor_tab.rs
@@ -241,9 +241,8 @@ impl EditorTabChild {
                             color.cloned(),
                             path.file_name()
                                 .unwrap_or_default()
-                                .to_str()
-                                .unwrap_or_default()
-                                .to_string(),
+                                .to_string_lossy()
+                                .into_owned(),
                             confirmed,
                             is_pritine,
                         )
@@ -295,8 +294,7 @@ impl EditorTabChild {
                                 "{} (Diff)",
                                 path.file_name()
                                     .unwrap_or_default()
-                                    .to_str()
-                                    .unwrap_or_default()
+                                    .to_string_lossy()
                             ),
                             is_pritine,
                         )


### PR DESCRIPTION
Fix filenames containing invalid unicode not being displayed in the breadcrumbs, open editors list or tab titles.

Previously the tab and open editors list would have blank titles if the filename was not invalid unicode, and any directories or filenames containing invalid unicode were omitted from the breadcrumbs.