### PR TITLE
create_dir_all when saving

### DIFF
--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -1589,7 +1589,7 @@ impl Document {
                 }
             });
 
-            self.common.proxy.save(rev, path, move |result| {
+            self.common.proxy.save(rev, path, true, move |result| {
                 send(result);
             })
         }

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -2211,6 +2211,7 @@ impl MainSplitData {
                     path,
                     rev,
                     content,
+                    true,
                     Box::new(move |result| {
                         send(result);
                     }),

--- a/lapce-proxy/src/buffer.rs
+++ b/lapce-proxy/src/buffer.rs
@@ -57,7 +57,7 @@ impl Buffer {
         }
     }
 
-    pub fn save(&mut self, rev: u64) -> Result<()> {
+    pub fn save(&mut self, rev: u64, create_parents: bool) -> Result<()> {
         if self.read_only {
             return Err(anyhow!("can't save to read only file"));
         }
@@ -83,6 +83,12 @@ impl Buffer {
         let bak_file_path = &path.with_extension(bak_extension);
         if !new_file {
             fs::copy(&path, bak_file_path)?;
+        }
+
+        if create_parents {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
         }
 
         let mut f = fs::OpenOptions::new()

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -730,10 +730,14 @@ impl ProxyHandler for Dispatcher {
                     proxy_rpc.handle_response(id, result);
                 });
             }
-            Save { rev, path } => {
+            Save {
+                rev,
+                path,
+                create_parents,
+            } => {
                 let buffer = self.buffers.get_mut(&path).unwrap();
                 let result = buffer
-                    .save(rev)
+                    .save(rev, create_parents)
                     .map(|_r| {
                         self.catalog_rpc
                             .did_save_text_document(&path, buffer.rope.clone());
@@ -750,12 +754,13 @@ impl ProxyHandler for Dispatcher {
                 path,
                 rev,
                 content,
+                create_parents,
             } => {
                 let mut buffer = Buffer::new(buffer_id, path.clone());
                 buffer.rope = Rope::from(content);
                 buffer.rev = rev;
                 let result = buffer
-                    .save(rev)
+                    .save(rev, create_parents)
                     .map(|_| ProxyResponse::Success {})
                     .map_err(|e| RpcError {
                         code: 0,

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -148,12 +148,16 @@ pub enum ProxyRequest {
     Save {
         rev: u64,
         path: PathBuf,
+        /// Whether to create the parent directories if they do not exist.
+        create_parents: bool,
     },
     SaveBufferAs {
         buffer_id: BufferId,
         path: PathBuf,
         rev: u64,
         content: String,
+        /// Whether to create the parent directories if they do not exist.
+        create_parents: bool,
     },
     CreateFile {
         path: PathBuf,
@@ -668,6 +672,7 @@ impl ProxyRpcHandler {
         path: PathBuf,
         rev: u64,
         content: String,
+        create_parents: bool,
         f: impl ProxyCallback + 'static,
     ) {
         self.request_async(
@@ -676,6 +681,7 @@ impl ProxyRpcHandler {
                 path,
                 rev,
                 content,
+                create_parents,
             },
             f,
         );
@@ -700,8 +706,21 @@ impl ProxyRpcHandler {
         );
     }
 
-    pub fn save(&self, rev: u64, path: PathBuf, f: impl ProxyCallback + 'static) {
-        self.request_async(ProxyRequest::Save { rev, path }, f);
+    pub fn save(
+        &self,
+        rev: u64,
+        path: PathBuf,
+        create_parents: bool,
+        f: impl ProxyCallback + 'static,
+    ) {
+        self.request_async(
+            ProxyRequest::Save {
+                rev,
+                path,
+                create_parents,
+            },
+            f,
+        );
     }
 
     pub fn get_files(&self, f: impl ProxyCallback + 'static) {


### PR DESCRIPTION
~~- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users~~

On some operations we can end up with a file opened that has no actual directory. The prime case is when you do `Run and Debug`, it opens `.lapce/run.toml` and fills it out if the file is empty. However, we can't actually *save* the file if we did not already have a `.lapce` folder.  
  
This makes the default behavior of saving create all parent directories (though it can be configured via a flag on the `Save` commands, if we ever want to put that as a setting).