### PR TITLE
bump floem and use floem::Clipboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,24 +773,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "clipboard"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
-dependencies = [
- "clipboard-win",
- "objc",
- "objc-foundation",
- "objc_id",
- "x11-clipboard",
-]
-
-[[package]]
 name = "clipboard-win"
-version = "2.2.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+checksum = "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342"
 dependencies = [
+ "lazy-bytes-cast",
  "winapi",
 ]
 
@@ -887,6 +875,20 @@ dependencies = [
  "pathdiff",
  "serde",
  "toml 0.5.9",
+]
+
+[[package]]
+name = "copypasta"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d35364349bf9e9e1c3a035ddcb00d188d23a3c40c50244c03c27a99fc6a65ae"
+dependencies = [
+ "clipboard-win",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "smithay-clipboard",
+ "x11-clipboard",
 ]
 
 [[package]]
@@ -1596,10 +1598,10 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 [[package]]
 name = "floem"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56#4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56"
+source = "git+https://github.com/lapce/floem?rev=e96d11d223bbfe866773d42b99b208f19efaeb58#e96d11d223bbfe866773d42b99b208f19efaeb58"
 dependencies = [
  "bitflags 2.4.0",
- "clipboard",
+ "copypasta",
  "crossbeam-channel",
  "educe",
  "floem_reactive",
@@ -1626,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "floem_reactive"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56#4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56"
+source = "git+https://github.com/lapce/floem?rev=e96d11d223bbfe866773d42b99b208f19efaeb58#e96d11d223bbfe866773d42b99b208f19efaeb58"
 dependencies = [
  "smallvec",
 ]
@@ -1634,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "floem_renderer"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56#4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56"
+source = "git+https://github.com/lapce/floem?rev=e96d11d223bbfe866773d42b99b208f19efaeb58#e96d11d223bbfe866773d42b99b208f19efaeb58"
 dependencies = [
  "cosmic-text",
  "image",
@@ -1645,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "floem_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56#4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56"
+source = "git+https://github.com/lapce/floem?rev=e96d11d223bbfe866773d42b99b208f19efaeb58#e96d11d223bbfe866773d42b99b208f19efaeb58"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1662,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "floem_vger"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56#4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56"
+source = "git+https://github.com/lapce/floem?rev=e96d11d223bbfe866773d42b99b208f19efaeb58#e96d11d223bbfe866773d42b99b208f19efaeb58"
 dependencies = [
  "anyhow",
  "floem_renderer",
@@ -2816,7 +2818,6 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap",
- "clipboard",
  "config",
  "crossbeam-channel",
  "directories",
@@ -2981,6 +2982,12 @@ dependencies = [
  "serde",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "lazy-bytes-cast"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b"
 
 [[package]]
 name = "lazy_static"
@@ -4834,6 +4841,17 @@ dependencies = [
  "wayland-protocols-wlr",
  "wayland-scanner 0.31.0",
  "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb62b280ce5a5cba847669933a0948d00904cf83845c944eae96a4738cea1a6"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit",
+ "wayland-backend 0.3.2",
 ]
 
 [[package]]
@@ -7242,11 +7260,11 @@ dependencies = [
 
 [[package]]
 name = "x11-clipboard"
-version = "0.3.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
+checksum = "b41aca1115b1f195f21c541c5efb423470848d48143127d0f07f8b90c27440df"
 dependencies = [
- "xcb",
+ "x11rb",
 ]
 
 [[package]]
@@ -7293,16 +7311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "xcb"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -51,8 +51,7 @@ sled = "0.34.7"
 bytemuck = "1.14.0"
 tokio = { version = "1.21", features = ["full"] }
 futures = "0.3.26"
-clipboard = "0.5.0"
-floem = { git = "https://github.com/lapce/floem", rev = "4621c89a5f3d43ec7d8d0f51c0a0b7214eb03a56" }
+floem = { git = "https://github.com/lapce/floem", rev = "e96d11d223bbfe866773d42b99b208f19efaeb58" }
 # floem = { path = "../../workspaces/floem" }
 config = { version = "0.13.2", default-features = false, features = ["toml"] }
 structdesc = { git = "https://github.com/lapce/structdesc" }

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -7,7 +7,6 @@ use std::{
     time::Duration,
 };
 
-use clipboard::{ClipboardContext, ClipboardProvider};
 use floem::{
     action::exec_after,
     cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
@@ -59,9 +58,7 @@ use crate::{
 
 pub mod phantom_text;
 
-pub struct SystemClipboard {
-    ctx: ClipboardContext,
-}
+pub struct SystemClipboard;
 
 impl Default for SystemClipboard {
     fn default() -> Self {
@@ -71,19 +68,17 @@ impl Default for SystemClipboard {
 
 impl SystemClipboard {
     pub fn new() -> Self {
-        SystemClipboard {
-            ctx: ClipboardProvider::new().unwrap(),
-        }
+        Self
     }
 }
 
 impl Clipboard for SystemClipboard {
     fn get_string(&mut self) -> Option<String> {
-        self.ctx.get_contents().ok()
+        floem::Clipboard::get_contents()
     }
 
     fn put_string(&mut self, s: impl AsRef<str>) {
-        let _ = self.ctx.set_contents(s.as_ref().to_string());
+        floem::Clipboard::set_contents(s.as_ref());
     }
 }
 


### PR DESCRIPTION
After #2794 and #2660, I also made a clipboard PR. It supports Wayland and uses the clipboard protocol for GUI applications there, so the clipboard should reliably work in containers like Flatpak in the future without extra permissions. Fixes https://github.com/lapce/lapce/issues/2787, https://github.com/lapce/lapce/issues/2768, https://github.com/lapce/lapce/issues/2676.

It requires the corresponding PR in floem (https://github.com/lapce/floem/pull/203).