### PR TITLE
fix: save without formatting now calls save.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 - [#2754](https://github.com/lapce/lapce/pull/2754): Don't mark nonexistent files as read only (fix saving new files)
+- [#2819](https://github.com/lapce/lapce/issues/2819): `Save Witohut Formatting` doesn't save the file
 
 ## 0.3.0
 

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -756,6 +756,9 @@ impl EditorData {
             FocusCommand::Save => {
                 self.save(true, || {});
             }
+            FocusCommand::SaveWithoutFormatting => {
+                self.save(false, || {});
+            }
             FocusCommand::InlineFindLeft => {
                 self.inline_find.set(Some(InlineFindDirection::Left));
             }


### PR DESCRIPTION
Along with a few other `FocusCommand`s (`ToggleCaseSensitive`, `GlobalSearchRefresh`, `SearchInView`, and 23 more), `SaveWithoutFormatting` was not being handled. This pr adds handling for `SaveWithoutFormatting` and sets the catch-all match arm to be `_ => unimplemented!()`

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users