### PR TITLE
Modern D tree-sitter grammar and queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features/Changes
 
+- [#2826](https://github.com/lapce/lapce/issues/2826): Update grammar and queries for D language
+
 ### Bug Fixes
 - [#2754](https://github.com/lapce/lapce/pull/2754): Don't mark nonexistent files as read only (fix saving new files)
 - [#2819](https://github.com/lapce/lapce/issues/2819): `Save Witohut Formatting` doesn't save the file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,6 +2891,7 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-cpp",
+ "tree-sitter-d",
  "tree-sitter-javascript",
  "tree-sitter-json",
  "tree-sitter-md",
@@ -5612,6 +5613,16 @@ name = "tree-sitter-cpp"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a869e3c5cef4e5db4e9ab16a8dc84d73010e60ada14cdc60d2f6d8aed17779d"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-d"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f4e85d476b4305b1ef00b33433577633cf1d42ada92af7829c8adcf8ebf7f2"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/lapce-core/Cargo.toml
+++ b/lapce-core/Cargo.toml
@@ -33,6 +33,7 @@ tree-sitter = "0.20.10"
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "4488aa41406547e478636a4fcfd24f5bbc3f2f74", optional = true }
 tree-sitter-c = { version = "0.20.6", optional = true }
 tree-sitter-cpp = { version = "0.20.0", optional = true }
+tree-sitter-d = { version = "0.3.8", optional = true }
 tree-sitter-javascript = { version = "0.20.1", optional = true }
 # new version cannot be published on crates.io - https://github.com/tree-sitter/tree-sitter-json/issues/21
 # tree-sitter-json = { version = "0.19.0", optional = true }
@@ -52,6 +53,7 @@ portable = []
 lang-bash = ["dep:tree-sitter-bash"]
 lang-c = ["dep:tree-sitter-c"]
 lang-cpp = ["dep:tree-sitter-cpp"]
+lang-d = ["dep:tree-sitter-d"]
 lang-javascript = ["dep:tree-sitter-javascript"]
 lang-json = ["dep:tree-sitter-json"]
 lang-markdown = ["dep:tree-sitter-md"]

--- a/lapce-core/queries/d/highlights.scm
+++ b/lapce-core/queries/d/highlights.scm
@@ -1,0 +1,234 @@
+; highlights.scm
+;
+; Highlighting queries for D code for use by Tree-Sitter.
+;
+; Copyright 2023 Garrett D'Amore
+;
+; Distributed under the MIT License.
+; (See accompanying file LICENSE.txt or https://opensource.org/licenses/MIT)
+; SPDX-License-Identifier: MIT
+
+; these are listed first, because they override keyword queries
+(identity_expression (in) @operator)
+(identity_expression (is) @operator)
+
+(storage_class) @keyword.storage
+
+(function_declaration (identifier) @function)
+
+(call_expression (identifier) @function)
+(call_expression (type (identifier) @function))
+
+(module_fqn) @namespace
+
+[
+    (abstract)
+    (alias)
+    (align)
+    (asm)
+    (assert)
+    (auto)
+    (cast)
+    (const)
+    (debug)
+    (delete)
+    (deprecated)
+    (export)
+    (extern)
+    (final)
+    (immutable)
+    (in)
+    (inout)
+    (invariant)
+    (is)
+    (lazy)
+    ; "macro" - obsolete
+    (mixin)
+    (module)
+    (new)
+    (nothrow)
+    (out)
+    (override)
+    (package)
+    (pragma)
+    (private)
+    (protected)
+    (public)
+    (pure)
+    (ref)
+    (scope)
+    (shared)
+    (static)
+    (super)
+    (synchronized)
+    (template)
+    (this)
+    (throw)
+    (typeid)
+    (typeof)
+    (unittest)
+    (version)
+    (with)
+    (gshared)
+    (traits)
+    (vector)
+    (parameters_)
+] @keyword
+
+[
+    (class)
+    (struct)
+    (interface)
+    (union)
+    (enum)
+    (function)
+    (delegate)
+] @keyword.storage.type
+
+[
+    (break)
+    (case)
+    (catch)
+    (continue)
+    (do)
+    (default)
+    (finally)
+    (else)
+    (goto)
+    (if)
+    (switch)
+    (try)
+] @keyword.control
+
+(return) @keyword.control.return
+
+(import) @keyword.control.import
+
+[
+    (for)
+    (foreach)
+    (foreach_reverse)
+    (while)
+] @keyword.control.repeat
+
+[
+    (not_in)
+    (not_is)
+    "/="
+    "/"
+    ".."
+    "..."
+    "&"
+    "&="
+    "&&"
+    "|"
+    "|="
+    "||"
+    "-"
+    "-="
+    "--"
+    "+"
+    "+="
+    "++"
+    "<"
+    "<="
+    "<<"
+    "<<="
+    ">"
+    ">="
+    ">>="
+    ">>>="
+    ">>"
+    ">>>"
+    "!"
+    "!="
+    "?"
+    "$"
+    "="
+    "=="
+    "*"
+    "*="
+    "%"
+    "%="
+    "^"
+    "^="
+    "^^"
+    "^^="
+    "~"
+    "~="
+    "@"
+    "=>"
+] @operator
+
+[
+    "("
+    ")"
+    "["
+    "]"
+    "{"
+    "}"
+] @punctuation.bracket
+
+[
+    ";"
+    "."
+    ":"
+    ","
+] @punctuation.delimiter
+
+[
+    (true)
+    (false)
+] @constant.builtin.boolean
+
+(null) @constant.builtin
+
+(special_keyword) @constant.builtin
+
+(directive) @keyword.directive
+(shebang) @keyword.directive
+
+(comment) @comment
+
+[
+    (void)
+    (bool)
+    (byte)
+    (ubyte)
+    (char)
+    (short)
+    (ushort)
+    (wchar)
+    (dchar)
+    (int)
+    (uint)
+    (long)
+    (ulong)
+    (real)
+    (double)
+    (float)
+] @type.builtin
+
+[
+    (cent)
+    (ucent)
+    (ireal)
+    (idouble)
+    (ifloat)
+    (creal)
+    (double)
+    (cfloat)
+] @warning ; these types are deprecated
+
+(label (identifier) @label)
+(goto_statement (goto) @keyword (identifier) @label)
+
+(string_literal) @string
+(int_literal) @constant.numeric.integer
+(float_literal) @constant.numeric.float
+(char_literal) @constant.character
+(identifier) @variable
+(at_attribute) @attribute
+
+; everything after __EOF_ is plain text
+(end_file) @ui.text

--- a/lapce-core/queries/d/indents.scm
+++ b/lapce-core/queries/d/indents.scm
@@ -1,0 +1,17 @@
+[
+  (parameters)
+  (template_parameters)
+  (expression_statement)
+  (aggregate_body)
+  (function_body)
+  (scope_statement)
+  (block_statement)
+  (case_statement)
+] @indent
+
+[
+  (case)
+  (default)
+  "}"
+  "]"
+] @outdent

--- a/lapce-core/queries/d/injections.scm
+++ b/lapce-core/queries/d/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/lapce-core/queries/d/textobjects.scm
+++ b/lapce-core/queries/d/textobjects.scm
@@ -1,0 +1,9 @@
+(function_declaration (function_body) @function.inside) @function.around
+(comment) @comment.inside
+(comment)+ @comment.around
+(class_declaration (aggregate_body) @class.inside) @class.around
+(interface_declaration (aggregate_body) @class.inside) @class.around
+(struct_declaration (aggregate_body) @class.inside) @class.around
+(unittest_declaration (block_statement) @test.insid) @test.around
+(parameter) @parameter.inside
+(template_parameter) @parameter.inside


### PR DESCRIPTION
- [ x ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

I'm the author of the tree-sitter-d crate (and the grammar itself), and have provided this grammar for other editors.  I did test this and it seems to work, whereas the stock build I downloaded does not seem to have syntax highlighting for D at all, which was very disappointing (as I use D in my day job).