### PR TITLE
Doc backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 [[package]]
 name = "floem"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=0694f9672a10a49290af223cac3dc2ab53b1b1dd#0694f9672a10a49290af223cac3dc2ab53b1b1dd"
+source = "git+https://github.com/lapce/floem?rev=9dba15607de6d850e47a94f27cd2909967d9e732#9dba15607de6d850e47a94f27cd2909967d9e732"
 dependencies = [
  "bitflags 2.4.0",
  "copypasta",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "floem_reactive"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=0694f9672a10a49290af223cac3dc2ab53b1b1dd#0694f9672a10a49290af223cac3dc2ab53b1b1dd"
+source = "git+https://github.com/lapce/floem?rev=9dba15607de6d850e47a94f27cd2909967d9e732#9dba15607de6d850e47a94f27cd2909967d9e732"
 dependencies = [
  "smallvec",
 ]
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "floem_renderer"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=0694f9672a10a49290af223cac3dc2ab53b1b1dd#0694f9672a10a49290af223cac3dc2ab53b1b1dd"
+source = "git+https://github.com/lapce/floem?rev=9dba15607de6d850e47a94f27cd2909967d9e732#9dba15607de6d850e47a94f27cd2909967d9e732"
 dependencies = [
  "cosmic-text",
  "image",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "floem_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=0694f9672a10a49290af223cac3dc2ab53b1b1dd#0694f9672a10a49290af223cac3dc2ab53b1b1dd"
+source = "git+https://github.com/lapce/floem?rev=9dba15607de6d850e47a94f27cd2909967d9e732#9dba15607de6d850e47a94f27cd2909967d9e732"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1739,7 +1739,7 @@ dependencies = [
 [[package]]
 name = "floem_vger"
 version = "0.1.0"
-source = "git+https://github.com/lapce/floem?rev=0694f9672a10a49290af223cac3dc2ab53b1b1dd#0694f9672a10a49290af223cac3dc2ab53b1b1dd"
+source = "git+https://github.com/lapce/floem?rev=9dba15607de6d850e47a94f27cd2909967d9e732#9dba15607de6d850e47a94f27cd2909967d9e732"
 dependencies = [
  "anyhow",
  "floem_renderer",

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -51,7 +51,7 @@ sled = "0.34.7"
 bytemuck = "1.14.0"
 tokio = { version = "1.21", features = ["full"] }
 futures = "0.3.26"
-floem = { git = "https://github.com/lapce/floem", rev = "0694f9672a10a49290af223cac3dc2ab53b1b1dd" }
+floem = { git = "https://github.com/lapce/floem", rev = "9dba15607de6d850e47a94f27cd2909967d9e732" }
 # floem = { path = "../../workspaces/floem" }
 config = { version = "0.13.2", default-features = false, features = ["toml"] }
 structdesc = { git = "https://github.com/lapce/structdesc" }

--- a/lapce-app/src/completion.rs
+++ b/lapce-app/src/completion.rs
@@ -13,8 +13,11 @@ use lsp_types::{
 use nucleo::Utf32Str;
 
 use crate::{
-    config::LapceConfig, doc::Document, editor::view_data::EditorViewData,
-    id::EditorId, snippet::Snippet,
+    config::LapceConfig,
+    doc::{Document, DocumentExt},
+    editor::view_data::EditorViewData,
+    id::EditorId,
+    snippet::Snippet,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -340,7 +343,10 @@ impl CompletionData {
 
 /// Clear the current completion lens. Only `update`s if there is a completion lens.
 pub fn clear_completion_lens(doc: Rc<Document>) {
-    let has_completion = doc.completion_lens.with_untracked(|lens| lens.is_some());
+    let has_completion = doc
+        .backend
+        .completion_lens
+        .with_untracked(|lens| lens.is_some());
     if has_completion {
         doc.clear_completion_lens();
     }

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -284,7 +284,7 @@ pub type CodeActions = im::HashMap<usize, Arc<(PluginId, CodeActionResponse)>>;
 // TODO(minor): we could try stripping this down to the fields it exactly needs, like proxy
 /// Lapce backend for files accessible through proxy (local or remote).
 #[derive(Clone)]
-pub struct ProxyBackend {
+pub struct DocBackend {
     pub syntax: RwSignal<Syntax>,
     /// LSP Semantic highlighting information
     semantic_styles: RwSignal<Option<Spans<Style>>>,
@@ -311,7 +311,7 @@ pub struct ProxyBackend {
 
     common: Rc<CommonData>,
 }
-impl ProxyBackend {
+impl DocBackend {
     pub fn new(
         cx: Scope,
         syntax: Syntax,
@@ -380,7 +380,7 @@ impl ProxyBackend {
         });
     }
 }
-impl Backend for ProxyBackend {
+impl Backend for DocBackend {
     type Error = ();
 
     fn pre_update_init_content(doc: &Document<Self>) {
@@ -877,7 +877,7 @@ pub trait DocumentExt {
 
     fn update_breakpoints(&self, delta: &RopeDelta, path: &Path, old_text: &Rope);
 }
-impl DocumentExt for Document<ProxyBackend> {
+impl DocumentExt for Document<DocBackend> {
     fn syntax(&self) -> RwSignal<Syntax> {
         self.backend.syntax
     }
@@ -1265,7 +1265,7 @@ impl DocumentExt for Document<ProxyBackend> {
 /// A single document that can be viewed by multiple [`EditorData`]'s
 /// [`EditorViewData`]s and [`EditorView]s.
 #[derive(Clone)]
-pub struct Document<B: Backend = ProxyBackend> {
+pub struct Document<B: Backend = DocBackend> {
     pub scope: Scope,
     pub buffer_id: BufferId,
     pub content: RwSignal<DocContent>,
@@ -1284,7 +1284,7 @@ pub struct Document<B: Backend = ProxyBackend> {
     // TODO(floem-editor): remove this, it is specific to Lapce
     common: Rc<CommonData>,
 }
-impl Document<ProxyBackend> {
+impl Document<DocBackend> {
     // TODO(floem-editor): These are wrapper shims to avoid needing to call `DocumentBackend::from
     // (common)` at every current caller site in Lapce.
     // In floem-editor, the `new_backend` should simply be the `new` functions since it wouldn't be
@@ -1303,7 +1303,7 @@ impl Document<ProxyBackend> {
         Self::new_backend(
             cx,
             path,
-            ProxyBackend::new(cx, syntax, Some(diagnostics), common.clone()),
+            DocBackend::new(cx, syntax, Some(diagnostics), common.clone()),
             common,
         )
     }
@@ -1312,7 +1312,7 @@ impl Document<ProxyBackend> {
         let syntax = Syntax::plaintext();
         Self::new_local_backend(
             cx,
-            ProxyBackend::new(cx, syntax, None, common.clone()),
+            DocBackend::new(cx, syntax, None, common.clone()),
             common,
         )
     }
@@ -1326,7 +1326,7 @@ impl Document<ProxyBackend> {
         Self::new_content_backend(
             cx,
             content,
-            ProxyBackend::new(cx, syntax, None, common.clone()),
+            DocBackend::new(cx, syntax, None, common.clone()),
             common,
         )
     }
@@ -1344,7 +1344,7 @@ impl Document<ProxyBackend> {
         Self::new_hisotry_backend(
             cx,
             content,
-            ProxyBackend::new(cx, syntax, None, common.clone()),
+            DocBackend::new(cx, syntax, None, common.clone()),
             common,
         )
     }

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -39,7 +39,7 @@ use crate::{
     completion::{clear_completion_lens, CompletionStatus},
     config::LapceConfig,
     db::LapceDb,
-    doc::{DocContent, Document},
+    doc::{DocContent, Document, DocumentExt},
     editor::{
         location::{EditorLocation, EditorPosition},
         visual_line::Lines,
@@ -1613,7 +1613,7 @@ impl EditorData {
             // Get the diagnostics for the current line, which the LSP might use to inform
             // what code actions are available (such as fixes for the diagnostics).
             let diagnostics = doc
-                .diagnostics
+                .diagnostics()
                 .diagnostics
                 .get_untracked()
                 .iter()

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -1595,14 +1595,16 @@ impl EditorData {
         };
 
         let offset = self.cursor.with_untracked(|c| c.offset());
-        let exists = doc.code_actions.with_untracked(|c| c.contains_key(&offset));
+        let exists = doc
+            .code_actions()
+            .with_untracked(|c| c.contains_key(&offset));
 
         if exists {
             return;
         }
 
         // insert some empty data, so that we won't make the request again
-        doc.code_actions.update(|c| {
+        doc.code_actions().update(|c| {
             c.insert(offset, Arc::new((PluginId(0), Vec::new())));
         });
 
@@ -1630,7 +1632,7 @@ impl EditorData {
 
         let send = create_ext_action(self.scope, move |resp| {
             if doc.rev() == rev {
-                doc.code_actions.update(|c| {
+                doc.code_actions().update(|c| {
                     c.insert(offset, Arc::new(resp));
                 });
             }
@@ -1655,8 +1657,9 @@ impl EditorData {
     pub fn show_code_actions(&self, mouse_click: bool) {
         let offset = self.cursor.with_untracked(|c| c.offset());
         let doc = self.view.doc.get_untracked();
-        let code_actions =
-            doc.code_actions.with_untracked(|c| c.get(&offset).cloned());
+        let code_actions = doc
+            .code_actions()
+            .with_untracked(|c| c.get(&offset).cloned());
         if let Some(code_actions) = code_actions {
             if !code_actions.1.is_empty() {
                 self.common.internal_command.send(

--- a/lapce-app/src/editor/gutter.rs
+++ b/lapce-app/src/editor/gutter.rs
@@ -10,7 +10,10 @@ use floem::{
 };
 use lapce_core::{buffer::rope_text::RopeText, mode::Mode};
 
-use crate::config::{color::LapceColor, LapceConfig};
+use crate::{
+    config::{color::LapceColor, LapceConfig},
+    doc::DocumentExt,
+};
 
 use super::{view::changes_colors_screen, view_data::EditorViewData, EditorData};
 
@@ -47,7 +50,7 @@ impl EditorGutterView {
 
         let changes = view
             .doc
-            .with_untracked(|doc| doc.head_changes.get_untracked());
+            .with_untracked(|doc| doc.head_changes().get_untracked());
         let line_height = config.editor.line_height() as f64;
 
         let changes = changes_colors_screen(view, changes);

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -2045,7 +2045,7 @@ fn editor_gutter(
             let (offset, affinity) =
                 cursor.with(|cursor| (cursor.offset(), cursor.affinity));
             let has_code_actions = doc
-                .code_actions
+                .code_actions()
                 .with(|c| c.get(&offset).map(|c| !c.1.is_empty()).unwrap_or(false));
             if has_code_actions {
                 let vline = view.vline_of_offset(offset, affinity);

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -43,7 +43,7 @@ use crate::{
     command::InternalCommand,
     config::{color::LapceColor, icon::LapceIcons, LapceConfig},
     debug::LapceBreakpoint,
-    doc::{phantom_text::PhantomTextKind, DocContent, Document},
+    doc::{phantom_text::PhantomTextKind, DocContent, Document, DocumentExt},
     keypress::KeyPressFocus,
     text_input::text_input,
     window_tab::{Focus, WindowTabData},
@@ -1351,7 +1351,7 @@ impl EditorView {
 
         let doc = self.editor.view.doc.get_untracked();
         let total_len = doc.buffer.with_untracked(|buffer| buffer.last_line());
-        let changes = doc.head_changes.get_untracked();
+        let changes = doc.head_changes().get_untracked();
         let total_height = viewport.height();
         let total_width = viewport.width();
         let line_height = config.editor.line_height();

--- a/lapce-app/src/editor/view_data.rs
+++ b/lapce-app/src/editor/view_data.rs
@@ -912,7 +912,7 @@ impl TextLayoutProvider for ViewDataTextLayoutProv {
         }
 
         self.doc.with_untracked(|doc| {
-            doc.create_styles(line, text_layout_r);
+            doc.apply_styles(line, text_layout_r);
         });
 
         text_layout

--- a/lapce-app/src/editor/view_data.rs
+++ b/lapce-app/src/editor/view_data.rs
@@ -26,7 +26,7 @@ use lapce_xi_rope::Rope;
 
 use crate::{
     config::{editor::WrapStyle, LapceConfig},
-    doc::{phantom_text::PhantomTextLine, Document},
+    doc::{phantom_text::PhantomTextLine, Document, DocumentExt},
     find::{Find, FindResult},
 };
 
@@ -837,7 +837,7 @@ impl EditorViewData {
         // This needs the doc's syntax, but it isn't cheap to clone
         // so this has to be a method on view for now.
         self.doc.with_untracked(|doc| {
-            doc.syntax.with_untracked(|syntax| {
+            doc.syntax().with_untracked(|syntax| {
                 if syntax.layers.is_some() {
                     syntax
                         .find_tag(offset, previous, &CharBuffer::from(ch))
@@ -863,7 +863,7 @@ impl EditorViewData {
         // This needs the doc's syntax, but it isn't cheap to clone
         // so this has to be a method on view for now.
         self.doc.with_untracked(|doc| {
-            doc.syntax.with_untracked(|syntax| {
+            doc.syntax().with_untracked(|syntax| {
                 if syntax.layers.is_some() {
                     syntax.find_matching_pair(offset).unwrap_or(offset)
                 } else {

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -33,7 +33,10 @@ use tracing::warn;
 use crate::{
     alert::AlertButton,
     command::InternalCommand,
-    doc::{DiagnosticData, DocContent, DocHistory, Document, EditorDiagnostic},
+    doc::{
+        DiagnosticData, DocContent, DocHistory, Document, DocumentExt,
+        EditorDiagnostic,
+    },
     editor::{
         diff::DiffEditorData,
         location::{EditorLocation, EditorPosition},

--- a/lapce-app/src/palette.rs
+++ b/lapce-app/src/palette.rs
@@ -39,6 +39,7 @@ use crate::{
     },
     db::LapceDb,
     debug::{RunDebugConfigs, RunDebugMode},
+    doc::DocumentExt,
     editor::{
         location::{EditorLocation, EditorPosition},
         EditorData,
@@ -882,7 +883,7 @@ impl PaletteData {
         if let Some(editor) = self.main_split.active_editor.get_untracked() {
             let doc = editor.view.doc.get_untracked();
             let language =
-                doc.syntax.with_untracked(|syntax| syntax.language.name());
+                doc.syntax().with_untracked(|syntax| syntax.language.name());
             self.preselect_matching(&items, language);
         }
         self.items.set(items);

--- a/lapce-app/src/status.rs
+++ b/lapce-app/src/status.rs
@@ -17,6 +17,7 @@ use crate::{
     app::clickable_icon,
     command::LapceWorkbenchCommand,
     config::{color::LapceColor, icon::LapceIcons, LapceConfig},
+    doc::DocumentExt,
     listener::Listener,
     palette::kind::PaletteKind,
     panel::{kind::PanelKind, position::PanelContainerPosition},
@@ -362,7 +363,7 @@ pub fn status(
             let language_info = label(move || {
                 if let Some(editor) = editor.get() {
                     let doc = editor.view.doc.get();
-                    doc.syntax.with(|s| s.language.name())
+                    doc.syntax().with(|s| s.language.name())
                 } else {
                     "unknown"
                 }

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -48,7 +48,7 @@ use crate::{
     config::LapceConfig,
     db::LapceDb,
     debug::{DapData, LapceBreakpoint, RunDebugMode, RunDebugProcess},
-    doc::{DocContent, EditorDiagnostic},
+    doc::{DocContent, DocumentExt, EditorDiagnostic},
     editor::location::{EditorLocation, EditorPosition},
     editor_tab::EditorTabChild,
     file_explorer::data::FileExplorerData,

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -1595,7 +1595,7 @@ impl LapceLanguage {
         }
     }
 
-    pub fn comment_token(&self) -> &str {
+    pub fn comment_token(&self) -> &'static str {
         self.properties()
             .comment
             .single_line_start


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR is part of extracting the editor code into a crate for users of Floem.
Goals:
- Make `Document`/`Editor`/etc. less dependent on Lapce-specific behaviors
  - Allowing using whatever 'backend' of saving/loading files, such as purely locally
  - Syntax highlighting
  - Phantom text
 - Allow more testing & bench marking
   - Currently many pieces of the code are annoying to test
   - Ex: Movement would be a great place to test, but currently hard due to how closely it is linked to various other parts of the code (like `CommonData` + `EditorViewData`)
   - Ex: Editing the file is a great place to benchmark, with definite areas where it is slower than needed
- Ideally, make the code simpler!

The extraction will be done over multiple PRs, to avoid ending up with one massive PR and allowing discussion of changes since there are open design decisions.  
  
This PR specifically gives the `Document` a backend. Types that implement the `Backend` trait need to handle various actions like 'what should happen when we save the file', 'what is the phantom text for this line; while also handling "event"-like functions such as whatever actions need to be done when the content is initialized, updated, or a delta is applied..  
  
Specifically, I broke out various pieces of `Document` logic out from `Document` and onto `DocBackend`. `DocBackend` serves as the Lapce-specific behavior, which will stay within Lapce.  
Pieces moved to the backend:  
- LSP specific features (diagnostics, inlay hints, code actions, completion lens)
- Git history
- Syntax highlighting
  - Treesitter + LSP semantic highlighting are done from Lapce
  - This would allow library users to apply whatever form of highlighting they want, whether they have a TextMate parser or a quite absurd regex

This PR does not fully make `Document` independent, but does make it quite a bit closer to that.

Notes:
- I don't like `pre_update_init_content` but syntax highlighting needs to happen before the call to `on_update` I believe
- I don't like having to pass a custom `prev_unmatched` function to `Editor` instead of `Syntax`.
- I don't entirely like changing `LapceLanguage::comment_token` to return a `&'static str`. However, we're currently returning `&'static str`s elsewhere. If I did not do that, I'd either need to clone or use a callback to properly pass the `Syntax`'s comment token around
- I need to fix `Backend::on_update` taking treesitter edits since I don't want to force treesitter on users of `floem-editor`