### PR TITLE
Add inline completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
  "tar",
  "thiserror",
  "tokio",
- "toml 0.5.9",
+ "toml 0.8.2",
  "toml_edit 0.19.14",
  "tracing 0.2.0",
  "tracing-appender",
@@ -3022,7 +3022,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tar",
- "toml 0.5.9",
+ "toml 0.8.2",
  "toml_edit 0.19.14",
  "tracing 0.2.0",
  "trash",
@@ -3218,9 +3218,8 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bcfee315dde785ba887edb540b08765fd7df75a7d948844be6bf5712246734"
+version = "0.94.1"
+source = "git+https://github.com/lapce/lsp-types?rev=3031a76c4452f46ed265eb0154d6bb1d10ddb9f6#3031a76c4452f46ed265eb0154d6bb1d10ddb9f6"
 dependencies = [
  "bitflags 1.3.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ toml = { version = "*" }
 toml_edit = { version = "0.19.14", features = ["serde"] }
 url = { version = "2.3.1" }
 
-lsp-types = { version = "0.93", features = ["proposed"] }
+lsp-types = { version = "0.94", features = ["proposed"] }
 psp-types = { git = "https://github.com/lapce/psp-types", rev = "f7fea28f59e7b2d6faa1034a21679ad49b3524ad" }
 
 lapce-xi-rope = { version = "0.3.2", features = ["serde"] }
@@ -71,6 +71,10 @@ lapce-xi-rope = { version = "0.3.2", features = ["serde"] }
 lapce-core = { path = "./lapce-core" }
 lapce-rpc = { path = "./lapce-rpc" }
 lapce-proxy = { path = "./lapce-proxy" }
+
+[patch.crates-io]
+# Temporarily patch lsp-types with a version that supports inline-completion
+lsp-types = { git = "https://github.com/lapce/lsp-types", rev = "3031a76c4452f46ed265eb0154d6bb1d10ddb9f6" }
 
 [workspace.dependencies.tracing]
 git = "https://github.com/tokio-rs/tracing"

--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -205,7 +205,37 @@ mode = "n"
 [[keymaps]]
 key = "esc"
 command = "modal.close"
-when = "modal_focus"
+when = "modal_focus || completion_focus"
+
+[[keymaps]]
+key = "tab"
+command = "inline_completion.select"
+when = "inline_completion_visible && !search_focus && !modal_focus && !list_focus && !search_active"
+mode = "i"
+
+[[keymaps]]
+key = "esc"
+command = "inline_completion.cancel"
+when = "inline_completion_visible && !search_focus && !modal_focus && !list_focus && !search_active"
+mode = "i"
+
+[[keymaps]]
+key = "alt+["
+command = "inline_completion.previous"
+when = "inline_completion_visible && !search_focus && !modal_focus && !list_focus && !search_active"
+mode = "i"
+
+[[keymaps]]
+key = "alt+]"
+command = "inline_completion.next"
+when = "inline_completion_visible && !search_focus && !modal_focus && !list_focus && !search_active"
+mode = "i"
+
+[[keymaps]]
+key = "alt+\\"
+command = "inline_completion.invoke"
+when = "!inline_completion_visible && !search_focus && !modal_focus && !list_focus && !search_active"
+mode = "i"
 
 [[keymaps]]
 key = "ctrl+b"
@@ -299,7 +329,7 @@ mode = "i"
 [[keymaps]]
 key = "tab"
 command = "insert_tab"
-when = "!in_snippet && !completion_focus && !search_focus && !replace_focus"
+when = "!in_snippet && !completion_focus && !inline_completion_visible && !search_focus && !replace_focus"
 mode = "i"
 
 [[keymaps]]
@@ -324,7 +354,7 @@ mode = "i"
 key = "esc"
 command = "normal_mode"
 mode = "niv"
-when = "!search_focus && !modal_focus && !search_active"
+when = "!search_focus && !modal_focus && !search_active && !inline_completion_visible"
 
 [[keymaps]]
 key = "ctrl+c"

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -43,6 +43,7 @@ error-lens-font-family = ""
 error-lens-font-size = 0
 error-lens-multiline = false
 enable-completion-lens = false
+enable-inline-completion = true
 completion-lens-font-family = ""
 completion-lens-font-size = 0
 blink-interval = 500                    # ms
@@ -53,8 +54,8 @@ show-indent-guide = true
 atomic-soft-tabs = false
 double-click = "single"
 move-focus-while-search = true
-diff-context-lines=3
-scroll-speed-modifier=1
+diff-context-lines = 3
+scroll-speed-modifier = 1
 
 [terminal]
 font-family = ""

--- a/lapce-app/src/completion.rs
+++ b/lapce-app/src/completion.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf, rc::Rc, str::FromStr, sync::Arc};
+use std::{borrow::Cow, path::PathBuf, str::FromStr, sync::Arc};
 
 use floem::{
     peniko::kurbo::Rect,
@@ -13,11 +13,8 @@ use lsp_types::{
 use nucleo::Utf32Str;
 
 use crate::{
-    config::LapceConfig,
-    doc::{Document, DocumentExt},
-    editor::view_data::EditorViewData,
-    id::EditorId,
-    snippet::Snippet,
+    config::LapceConfig, doc::DocumentExt, editor::view_data::EditorViewData,
+    id::EditorId, snippet::Snippet,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -313,7 +310,7 @@ impl CompletionData {
         let config = self.config.get_untracked();
 
         if !config.editor.enable_completion_lens {
-            clear_completion_lens(doc);
+            doc.clear_completion_lens();
             return;
         }
 
@@ -335,20 +332,9 @@ impl CompletionData {
             // Unchanged
             Some(None) => {}
             None => {
-                clear_completion_lens(doc);
+                doc.clear_completion_lens();
             }
         }
-    }
-}
-
-/// Clear the current completion lens. Only `update`s if there is a completion lens.
-pub fn clear_completion_lens(doc: Rc<Document>) {
-    let has_completion = doc
-        .backend
-        .completion_lens
-        .with_untracked(|lens| lens.is_some());
-    if has_completion {
-        doc.clear_completion_lens();
     }
 }
 

--- a/lapce-app/src/config/editor.rs
+++ b/lapce-app/src/config/editor.rs
@@ -166,6 +166,8 @@ pub struct EditorConfig {
         desc = "If the editor should display the completion item as phantom text"
     )]
     pub enable_completion_lens: bool,
+    #[field_names(desc = "If the editor should display inline completions")]
+    pub enable_inline_completion: bool,
     #[field_names(
         desc = "Set completion lens font family. If empty, it uses the inlay hint font family."
     )]

--- a/lapce-app/src/doc/phantom_text.rs
+++ b/lapce-app/src/doc/phantom_text.rs
@@ -22,7 +22,7 @@ pub struct PhantomText {
 pub enum PhantomTextKind {
     /// Input methods
     Ime,
-    /// Completion lens
+    /// Completion lens / Inline completion
     Completion,
     /// Inlay hints supplied by an LSP/PSP (like type annotations)
     InlayHint,
@@ -78,11 +78,11 @@ impl PhantomTextLine {
         &self,
         pre_col: usize,
         before_cursor: bool,
-        ignored: Option<PhantomTextKind>,
+        skip: impl Fn(&PhantomText) -> bool,
     ) -> usize {
         let mut last = pre_col;
         for (col_shift, size, col, phantom) in self.offset_size_iter() {
-            if ignored == Some(phantom.kind) {
+            if skip(phantom) {
                 continue;
             }
 

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -1859,12 +1859,14 @@ pub fn cursor_caret(
     let phantom_text = view.line_phantom_text(info.rvline.line);
 
     let (_, col) = view.offset_to_line_col(offset);
+    let ime_kind = preedit_start.map(|_| PhantomTextKind::Ime);
     // The cursor should be after phantom text if the affinity is forward, or it is a block cursor.
-    // As well, if we have a relevant preedit we skip over IMEs
+    // - if we have a relevant preedit we skip over IMEs
+    // - we skip over completion lens, as the text should be after the cursor
     let col = phantom_text.col_after_ignore(
         col,
         affinity == CursorAffinity::Forward || (block && !after_last_char),
-        preedit_start.map(|_| PhantomTextKind::Ime),
+        |p| p.kind == PhantomTextKind::Completion || Some(p.kind) == ime_kind,
     );
     // We shift forward by the IME's start. This is due to the cursor potentially being in the
     // middle of IME phantom text while editing it.

--- a/lapce-app/src/inline_completion.rs
+++ b/lapce-app/src/inline_completion.rs
@@ -1,0 +1,293 @@
+use std::{borrow::Cow, ops::Range, path::PathBuf, str::FromStr};
+
+use floem::reactive::{batch, RwSignal, Scope};
+use lapce_core::{
+    buffer::{
+        rope_text::{RopeText, RopeTextRef},
+        Buffer,
+    },
+    selection::Selection,
+};
+
+use lsp_types::InsertTextFormat;
+
+use crate::{
+    config::LapceConfig,
+    doc::{Document, DocumentExt},
+    editor::EditorData,
+    snippet::Snippet,
+};
+
+// TODO: we could integrate completion lens with this, so it is considered at the same time
+
+/// Redefinition of lsp types inline completion item with offset range
+#[derive(Debug, Clone)]
+pub struct InlineCompletionItem {
+    /// The text to replace the range with.
+    pub insert_text: String,
+    /// Text used to decide if this inline completion should be shown.
+    pub filter_text: Option<String>,
+    /// The range (of offsets) to replace  
+    pub range: Option<Range<usize>>,
+    pub command: Option<lsp_types::Command>,
+    pub insert_text_format: Option<InsertTextFormat>,
+}
+impl InlineCompletionItem {
+    pub fn from_lsp(buffer: &Buffer, item: lsp_types::InlineCompletionItem) -> Self {
+        let range = item.range.map(|r| {
+            let start = buffer.offset_of_position(&r.start);
+            let end = buffer.offset_of_position(&r.end);
+            start..end
+        });
+        Self {
+            insert_text: item.insert_text,
+            filter_text: item.filter_text,
+            range,
+            command: item.command,
+            insert_text_format: item.insert_text_format,
+        }
+    }
+
+    pub fn apply(
+        &self,
+        editor: &EditorData,
+        start_offset: usize,
+    ) -> anyhow::Result<()> {
+        let text_format = self
+            .insert_text_format
+            .unwrap_or(InsertTextFormat::PLAIN_TEXT);
+
+        let selection = if let Some(range) = &self.range {
+            Selection::region(range.start, range.end)
+        } else {
+            Selection::caret(start_offset)
+        };
+
+        match text_format {
+            InsertTextFormat::PLAIN_TEXT => editor.do_edit(
+                &selection,
+                &[(selection.clone(), self.insert_text.as_str())],
+            ),
+            InsertTextFormat::SNIPPET => {
+                editor.completion_apply_snippet(
+                    &self.insert_text,
+                    &selection,
+                    Vec::new(),
+                    start_offset,
+                )?;
+            }
+            _ => {
+                // We don't know how to support this text format
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineCompletionStatus {
+    /// The inline completion is not active.
+    Inactive,
+    /// The inline completion is active and is waiting for the server to respond.
+    Started,
+    /// The inline completion is active and has received a response from the server.
+    Active,
+}
+
+#[derive(Clone)]
+pub struct InlineCompletionData {
+    pub status: InlineCompletionStatus,
+    /// The active inline completion index in the list of completions.
+    pub active: RwSignal<usize>,
+    pub items: im::Vector<InlineCompletionItem>,
+    pub start_offset: usize,
+    pub path: PathBuf,
+}
+impl InlineCompletionData {
+    pub fn new(cx: Scope) -> Self {
+        Self {
+            status: InlineCompletionStatus::Inactive,
+            active: cx.create_rw_signal(0),
+            items: im::vector![],
+            start_offset: 0,
+            path: PathBuf::new(),
+        }
+    }
+
+    pub fn current_item(&self) -> Option<&InlineCompletionItem> {
+        let active = self.active.get_untracked();
+        self.items.get(active)
+    }
+
+    pub fn next(&mut self) {
+        if !self.items.is_empty() {
+            let next_index = (self.active.get_untracked() + 1) % self.items.len();
+            self.active.set(next_index);
+        }
+    }
+
+    pub fn previous(&mut self) {
+        if !self.items.is_empty() {
+            let prev_index = if self.active.get_untracked() == 0 {
+                self.items.len() - 1
+            } else {
+                self.active.get_untracked() - 1
+            };
+            self.active.set(prev_index);
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        if self.status == InlineCompletionStatus::Inactive {
+            return;
+        }
+
+        self.items.clear();
+        self.status = InlineCompletionStatus::Inactive;
+    }
+
+    /// Set the items for the inline completion.  
+    /// Sets `active` to `0` and `status` to `InlineCompletionStatus::Active`.
+    pub fn set_items(
+        &mut self,
+        items: im::Vector<InlineCompletionItem>,
+        start_offset: usize,
+        path: PathBuf,
+    ) {
+        batch(|| {
+            self.items = items;
+            self.active.set(0);
+            self.status = InlineCompletionStatus::Active;
+            self.start_offset = start_offset;
+            self.path = path;
+        });
+    }
+
+    pub fn update_doc(&self, doc: &Document, offset: usize) {
+        if self.status != InlineCompletionStatus::Active {
+            doc.clear_inline_completion();
+            return;
+        }
+
+        if self.items.is_empty() {
+            doc.clear_inline_completion();
+            return;
+        }
+
+        let active = self.active.get_untracked();
+        let active = if active >= self.items.len() {
+            self.active.set(0);
+            0
+        } else {
+            active
+        };
+
+        let item = &self.items[active];
+        let text = item.insert_text.clone();
+
+        // TODO: is range really meant to be used for this?
+        let offset = item.range.as_ref().map(|r| r.start).unwrap_or(offset);
+        let (line, col) = doc
+            .buffer
+            .with_untracked(|buffer| buffer.offset_to_line_col(offset));
+        doc.set_inline_completion(text, line, col);
+    }
+
+    pub fn update_inline_completion(
+        &self,
+        config: &LapceConfig,
+        doc: &Document,
+        cursor_offset: usize,
+    ) {
+        if !config.editor.enable_inline_completion {
+            doc.clear_inline_completion();
+            return;
+        }
+
+        let text = doc.buffer.with_untracked(|buffer| buffer.text().clone());
+        let text = RopeTextRef::new(&text);
+        let Some(item) = self.current_item() else {
+            // TODO(minor): should we cancel completion
+            return;
+        };
+
+        let completion = doc.backend.inline_completion.with_untracked(|cur| {
+            let cur = cur.as_deref();
+            inline_completion_text(text, self.start_offset, cursor_offset, item, cur)
+        });
+
+        match completion {
+            ICompletionRes::Hide => {
+                doc.clear_inline_completion();
+            }
+            ICompletionRes::Unchanged => {}
+            ICompletionRes::Set(new, shift) => {
+                let offset = self.start_offset + shift;
+                let (line, col) = text.offset_to_line_col(offset);
+                doc.set_inline_completion(new, line, col);
+            }
+        }
+    }
+}
+
+enum ICompletionRes {
+    Hide,
+    Unchanged,
+    Set(String, usize),
+}
+
+/// Get the text of the inline completion item  
+fn inline_completion_text(
+    rope_text: impl RopeText,
+    start_offset: usize,
+    cursor_offset: usize,
+    item: &InlineCompletionItem,
+    current_completion: Option<&str>,
+) -> ICompletionRes {
+    let text_format = item
+        .insert_text_format
+        .unwrap_or(InsertTextFormat::PLAIN_TEXT);
+
+    // TODO: is this check correct? I mostly copied it from completion lens
+    let cursor_prev_offset = rope_text.prev_code_boundary(cursor_offset);
+    if let Some(range) = &item.range {
+        let edit_start = range.start;
+
+        // If the start of the edit isn't where the cursor currently is, and is not at the start of
+        // the inline completion, then we ignore it.
+        if cursor_prev_offset != edit_start && start_offset != edit_start {
+            return ICompletionRes::Hide;
+        }
+    }
+
+    let text = match text_format {
+        InsertTextFormat::PLAIN_TEXT => Cow::Borrowed(&item.insert_text),
+        InsertTextFormat::SNIPPET => {
+            let Ok(snippet) = Snippet::from_str(&item.insert_text) else {
+                return ICompletionRes::Hide;
+            };
+            let text = snippet.text();
+
+            Cow::Owned(text)
+        }
+        _ => {
+            // We don't know how to support this text format
+            return ICompletionRes::Hide;
+        }
+    };
+
+    let range = start_offset..rope_text.offset_line_end(start_offset, true);
+    let prefix = rope_text.slice_to_cow(range);
+    // We strip the prefix of the current input from the label.
+    // So that, for example `p` with a completion of `println` will show `rintln`.
+    let Some(text) = text.strip_prefix(prefix.as_ref()) else {
+        return ICompletionRes::Hide;
+    };
+
+    if Some(text) == current_completion {
+        ICompletionRes::Unchanged
+    } else {
+        ICompletionRes::Set(text.to_string(), prefix.len())
+    }
+}

--- a/lapce-app/src/keypress/condition.rs
+++ b/lapce-app/src/keypress/condition.rs
@@ -49,6 +49,8 @@ pub enum Condition {
     PaletteFocus,
     #[strum(serialize = "completion_focus")]
     CompletionFocus,
+    #[strum(serialize = "inline_completion_visible")]
+    InlineCompletionVisible,
     #[strum(serialize = "modal_focus")]
     ModalFocus,
     #[strum(serialize = "in_snippet")]

--- a/lapce-app/src/lib.rs
+++ b/lapce-app/src/lib.rs
@@ -17,6 +17,7 @@ pub mod global_search;
 pub mod history;
 pub mod hover;
 pub mod id;
+pub mod inline_completion;
 pub mod keymap;
 pub mod keypress;
 pub mod listener;

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -56,6 +56,7 @@ use crate::{
     global_search::GlobalSearchData,
     hover::HoverData,
     id::WindowTabId,
+    inline_completion::InlineCompletionData,
     keypress::{condition::Condition, EventRef, KeyPressData, KeyPressFocus},
     listener::Listener,
     main_split::{MainSplitData, SplitData, SplitDirection, SplitMoveDirection},
@@ -114,6 +115,7 @@ pub struct CommonData {
     pub focus: RwSignal<Focus>,
     pub keypress: RwSignal<KeyPressData>,
     pub completion: RwSignal<CompletionData>,
+    pub inline_completion: RwSignal<InlineCompletionData>,
     pub hover: HoverData,
     pub register: RwSignal<Register>,
     pub find: Find,
@@ -295,6 +297,7 @@ impl WindowTabData {
 
         let focus = cx.create_rw_signal(Focus::Workbench);
         let completion = cx.create_rw_signal(CompletionData::new(cx, config));
+        let inline_completion = cx.create_rw_signal(InlineCompletionData::new(cx));
         let hover = HoverData::new(cx);
 
         let register = cx.create_rw_signal(Register::default());
@@ -322,6 +325,7 @@ impl WindowTabData {
             keypress,
             focus,
             completion,
+            inline_completion,
             hover,
             register,
             find,

--- a/lapce-core/src/command.rs
+++ b/lapce-core/src/command.rs
@@ -361,6 +361,21 @@ pub enum FocusCommand {
     SelectPreviousSyntaxItem,
     #[strum(serialize = "open_source_file")]
     OpenSourceFile,
+    #[strum(serialize = "inline_completion.select")]
+    #[strum(message = "Inline Completion Select")]
+    InlineCompletionSelect,
+    #[strum(serialize = "inline_completion.next")]
+    #[strum(message = "Inline Completion Next")]
+    InlineCompletionNext,
+    #[strum(serialize = "inline_completion.previous")]
+    #[strum(message = "Inline Completion Previous")]
+    InlineCompletionPrevious,
+    #[strum(serialize = "inline_completion.cancel")]
+    #[strum(message = "Inline Completion Cancel")]
+    InlineCompletionCancel,
+    #[strum(serialize = "inline_completion.invoke")]
+    #[strum(message = "Inline Completion Invoke")]
+    InlineCompletionInvoke,
 }
 
 #[derive(

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -521,6 +521,24 @@ impl ProxyHandler for Dispatcher {
                         proxy_rpc.handle_response(id, result);
                     });
             }
+            GetInlineCompletions {
+                path,
+                position,
+                trigger_kind,
+            } => {
+                let proxy_rpc = self.proxy_rpc.clone();
+                self.catalog_rpc.get_inline_completions(
+                    &path,
+                    position,
+                    trigger_kind,
+                    move |_, result| {
+                        let result = result.map(|completions| {
+                            ProxyResponse::GetInlineCompletions { completions }
+                        });
+                        proxy_rpc.handle_response(id, result);
+                    },
+                );
+            }
             GetSemanticTokens { path } => {
                 let buffer = self.buffers.get(&path).unwrap();
                 let text = buffer.rope.clone();

--- a/lapce-proxy/src/plugin/lsp.rs
+++ b/lapce-proxy/src/plugin/lsp.rs
@@ -342,6 +342,7 @@ impl LspClient {
             }),
             locale: None,
             root_path: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
         };
         if let Ok(value) = self.server_rpc.server_request(
             Initialize::METHOD,

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -33,10 +33,10 @@ use lsp_types::{
     request::{
         CodeActionRequest, CodeActionResolveRequest, Completion,
         DocumentSymbolRequest, Formatting, GotoDefinition, GotoTypeDefinition,
-        HoverRequest, Initialize, InlayHintRequest, PrepareRenameRequest,
-        References, RegisterCapability, Rename, ResolveCompletionItem,
-        SelectionRangeRequest, SemanticTokensFullRequest, SignatureHelpRequest,
-        WorkDoneProgressCreate, WorkspaceSymbol,
+        HoverRequest, Initialize, InlayHintRequest, InlineCompletionRequest,
+        PrepareRenameRequest, References, RegisterCapability, Rename,
+        ResolveCompletionItem, SelectionRangeRequest, SemanticTokensFullRequest,
+        SignatureHelpRequest, WorkDoneProgressCreate, WorkspaceSymbolRequest,
     },
     CodeActionProviderCapability, DidChangeTextDocumentParams,
     DidSaveTextDocumentParams, DocumentSelector, HoverProviderCapability,
@@ -760,10 +760,14 @@ impl PluginHostHandler {
             InlayHintRequest::METHOD => {
                 self.server_capabilities.inlay_hint_provider.is_some()
             }
+            InlineCompletionRequest::METHOD => self
+                .server_capabilities
+                .inline_completion_provider
+                .is_some(),
             DocumentSymbolRequest::METHOD => {
                 self.server_capabilities.document_symbol_provider.is_some()
             }
-            WorkspaceSymbol::METHOD => {
+            WorkspaceSymbolRequest::METHOD => {
                 self.server_capabilities.workspace_symbol_provider.is_some()
             }
             PrepareRenameRequest::METHOD => {

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -24,6 +24,7 @@ use lsp_types::{
     notification::Initialized, request::Initialize, DocumentFilter,
     InitializeParams, InitializedParams, TextDocumentContentChangeEvent,
     TextDocumentIdentifier, Url, VersionedTextDocumentIdentifier,
+    WorkDoneProgressParams,
 };
 use parking_lot::Mutex;
 use psp_types::{Notification, Request};
@@ -203,6 +204,7 @@ impl Plugin {
                 locale: None,
                 initialization_options: configurations,
                 workspace_folders: None,
+                work_done_progress_params: WorkDoneProgressParams::default(),
             },
             None,
             None,

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -13,8 +13,9 @@ use lapce_xi_rope::RopeDelta;
 use lsp_types::{
     request::GotoTypeDefinitionResponse, CodeAction, CodeActionResponse,
     CompletionItem, Diagnostic, DocumentSymbolResponse, GotoDefinitionResponse,
-    Hover, InlayHint, Location, Position, PrepareRenameResponse, SelectionRange,
-    SymbolInformation, TextDocumentItem, TextEdit, WorkspaceEdit,
+    Hover, InlayHint, InlineCompletionResponse, InlineCompletionTriggerKind,
+    Location, Position, PrepareRenameResponse, SelectionRange, SymbolInformation,
+    TextDocumentItem, TextEdit, WorkspaceEdit,
 };
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -110,6 +111,11 @@ pub enum ProxyRequest {
     },
     GetInlayHints {
         path: PathBuf,
+    },
+    GetInlineCompletions {
+        path: PathBuf,
+        position: Position,
+        trigger_kind: InlineCompletionTriggerKind,
     },
     GetSemanticTokens {
         path: PathBuf,
@@ -372,6 +378,9 @@ pub enum ProxyResponse {
     },
     GetInlayHints {
         hints: Vec<InlayHint>,
+    },
+    GetInlineCompletions {
+        completions: InlineCompletionResponse,
     },
     GetSemanticTokens {
         styles: SemanticStyles,
@@ -915,6 +924,23 @@ impl ProxyRpcHandler {
 
     pub fn get_inlay_hints(&self, path: PathBuf, f: impl ProxyCallback + 'static) {
         self.request_async(ProxyRequest::GetInlayHints { path }, f);
+    }
+
+    pub fn get_inline_completions(
+        &self,
+        path: PathBuf,
+        position: Position,
+        trigger_kind: InlineCompletionTriggerKind,
+        f: impl ProxyCallback + 'static,
+    ) {
+        self.request_async(
+            ProxyRequest::GetInlineCompletions {
+                path,
+                position,
+                trigger_kind,
+            },
+            f,
+        );
     }
 
     pub fn update(&self, path: PathBuf, delta: RopeDelta, rev: u64) {


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR implements Inline Completion support.
Inline completions are a 3.18 (upcoming) LSP feature which allows language serves to provide completion text within the editor. 
The primary usecase for this is Github Copilot-like extensions which I have implemented at https://github.com/MinusGix/lapce-copilot/ , thus fixing #1081.

This PR has to use a fork of lsp-types as they don't yet support inline-completion. I've created a PR to that repo with support. I've put the fork of lsp-types on the Lapce organization.  
I added a `[patch.crates-io]` for lsp-types so that we won't get two versions of lsp-types from psp-types (which I'm not updating currently).  

(Though, Github Copilot doesn't support Inline Completion by itself - it has a custom request for that. The lapce-copilot plugin just wraps it by using the feature I added in #2610 so we don't have to implement some nonstandard request.)

There's various messing around with keymaps to ensure you don't activate it when you shouldn't. This makes so completion is closed when `modal.close` is activated, rather than (I think) the normal mode esc?  

There's improvements that could be made for this.  
- Flickering off
  - This is due to clearing and then re-requesting, usually
  - Ex: backspacing, pressing enter
  - Can be alleviated by smarter partial updates
- VSCode only shows inline completions when completion is open *if* the active completion item
- Typing `function add` where it wants to complete to `function foo(a, b) {` won't complete right..