### PR TITLE
Doc backend continued

### DIFF
--- a/lapce-app/src/config/editor.rs
+++ b/lapce-app/src/config/editor.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use structdesc::FieldNames;
 
+use crate::doc::RenderWhitespace;
+
 pub const SCALE_OR_SIZE_LIMIT: f64 = 5.0;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -191,7 +193,7 @@ pub struct EditorConfig {
     #[field_names(
         desc = "How the editor should render whitespace characters.\nOptions: none, all, boundary, trailing."
     )]
-    pub render_whitespace: String,
+    pub render_whitespace: RenderWhitespace,
     #[field_names(desc = "Whether the editor show indent guide.")]
     pub show_indent_guide: bool,
     #[field_names(

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -374,7 +374,7 @@ pub fn editor_view(
     let hide_cursor = editor.common.window_common.hide_cursor;
     create_effect(move |_| {
         hide_cursor.track();
-        let occurrences = doc.with(|doc| doc.find_result.occurrences);
+        let occurrences = doc.with(|doc| doc.backend.find_result.occurrences);
         occurrences.track();
         id.request_paint();
     });
@@ -2681,7 +2681,7 @@ fn find_view(
         let editor = editor.get_untracked();
         let cursor = editor.cursor;
         let offset = cursor.with(|cursor| cursor.offset());
-        let occurrences = editor.view.doc.get().find_result.occurrences;
+        let occurrences = editor.view.doc.get().backend.find_result.occurrences;
         occurrences.with(|occurrences| {
             for (i, region) in occurrences.regions().iter().enumerate() {
                 if offset <= region.max() {

--- a/lapce-app/src/editor/view_data.rs
+++ b/lapce-app/src/editor/view_data.rs
@@ -294,7 +294,7 @@ impl EditorViewData {
     }
 
     pub fn find_result(&self) -> FindResult {
-        self.doc.get_untracked().find_result.clone()
+        self.doc.get_untracked().backend.find_result.clone()
     }
 
     pub fn update_find(&self) {


### PR DESCRIPTION
~~- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users~~

Continuation of #2836 

- Completely removes dependency on `common: Rc<CommonData>` for `Document`
- Changes `render_whitespace` to use an enum rather than a string so it is a more reasonable API
- Moved find onto proxy
  - I think it would be good to have a decent default find impl in floem-editor, but it would need some adaption work that doesn't need to be done immediately
- Introduce `LineStyling` onto `Document`
  - I want to use something like this for `VisualLines` as well most likely
- Moves autosave duration onto backend
- Add a function for creating preedit phantom text, currently encouraging implementors of `Backend` to add it seems the best way