### PR TITLE
Refactor color handling

### DIFF
--- a/lapce-app/src/about.rs
+++ b/lapce-app/src/about.rs
@@ -100,56 +100,56 @@ pub fn about_popup(window_tab_data: Rc<WindowTabData>) -> impl View {
 
     exclusive_popup(window_tab_data, about_data.visible, move || {
         stack((
-            svg(move || (*config.get()).logo_svg()).style(move |s| {
+            svg(move || (config.get()).logo_svg()).style(move |s| {
                 s.size(logo_size, logo_size)
-                    .color(*config.get().get_color(LapceColor::EDITOR_FOREGROUND))
+                    .color(config.get().color(LapceColor::EDITOR_FOREGROUND))
             }),
             label(|| "Lapce".to_string()).style(move |s| {
                 s.font_bold()
                     .margin_top(10.0)
-                    .color(*config.get().get_color(LapceColor::EDITOR_FOREGROUND))
+                    .color(config.get().color(LapceColor::EDITOR_FOREGROUND))
             }),
             label(|| format!("Version: {}", VERSION)).style(move |s| {
                 s.margin_top(10.0)
-                    .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                    .color(config.get().color(LapceColor::EDITOR_DIM))
             }),
             web_link(
                 || "Website".to_string(),
                 || AboutUri::LAPCE.to_string(),
-                move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                move || config.get().color(LapceColor::EDITOR_LINK),
                 internal_command,
             )
             .style(|s| s.margin_top(20.0)),
             web_link(
                 || "GitHub".to_string(),
                 || AboutUri::GITHUB.to_string(),
-                move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                move || config.get().color(LapceColor::EDITOR_LINK),
                 internal_command,
             )
             .style(|s| s.margin_top(10.0)),
             web_link(
                 || "Discord".to_string(),
                 || AboutUri::DISCORD.to_string(),
-                move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                move || config.get().color(LapceColor::EDITOR_LINK),
                 internal_command,
             )
             .style(|s| s.margin_top(10.0)),
             web_link(
                 || "Matrix".to_string(),
                 || AboutUri::MATRIX.to_string(),
-                move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                move || config.get().color(LapceColor::EDITOR_LINK),
                 internal_command,
             )
             .style(|s| s.margin_top(10.0)),
             label(|| "Attributions".to_string()).style(move |s| {
                 s.font_bold()
-                    .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                    .color(config.get().color(LapceColor::EDITOR_DIM))
                     .margin_top(40.0)
             }),
             web_link(
                 || "Codicons (CC-BY-4.0)".to_string(),
                 || AboutUri::CODICONS.to_string(),
-                move || *config.get().get_color(LapceColor::EDITOR_LINK),
+                move || config.get().color(LapceColor::EDITOR_LINK),
                 internal_command,
             )
             .style(|s| s.margin_top(10.0)),
@@ -174,8 +174,8 @@ fn exclusive_popup<V: View + 'static>(
                         .padding_horiz(100.0)
                         .border(1.0)
                         .border_radius(6.0)
-                        .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                        .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                        .border_color(config.color(LapceColor::LAPCE_BORDER))
+                        .background(config.color(LapceColor::PANEL_BACKGROUND))
                 })
                 .on_event_stop(EventListener::PointerDown, move |_| {}),
         )
@@ -204,7 +204,7 @@ fn exclusive_popup<V: View + 'static>(
         .background(
             config
                 .get()
-                .get_color(LapceColor::LAPCE_DROPDOWN_SHADOW)
+                .color(LapceColor::LAPCE_DROPDOWN_SHADOW)
                 .with_alpha_factor(0.5),
         )
     })

--- a/lapce-app/src/alert.rs
+++ b/lapce-app/src/alert.rs
@@ -66,7 +66,7 @@ pub fn alert_box(alert_data: AlertBoxData) -> impl View {
                 svg(move || config.get().ui_svg(LapceIcons::WARNING)).style(
                     move |s| {
                         s.size(50.0, 50.0)
-                            .color(*config.get().get_color(LapceColor::LAPCE_WARN))
+                            .color(config.get().color(LapceColor::LAPCE_WARN))
                     },
                 ),
                 label(move || title.get()).style(move |s| {
@@ -97,17 +97,17 @@ pub fn alert_box(alert_data: AlertBoxData) -> impl View {
                                     .border(1.0)
                                     .border_radius(6.0)
                                     .border_color(
-                                        *config.get_color(LapceColor::LAPCE_BORDER),
+                                        config.color(LapceColor::LAPCE_BORDER),
                                     )
                                     .hover(|s| {
                                         s.cursor(CursorStyle::Pointer).background(
-                                            *config.get_color(
+                                            config.color(
                                                 LapceColor::PANEL_HOVERED_BACKGROUND,
                                             ),
                                         )
                                     })
                                     .active(|s| {
-                                        s.background(*config.get_color(
+                                        s.background(config.color(
                                     LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
                                 ))
                                     })
@@ -128,18 +128,15 @@ pub fn alert_box(alert_data: AlertBoxData) -> impl View {
                             .line_height(1.5)
                             .border(1.0)
                             .border_radius(6.0)
-                            .border_color(
-                                *config.get_color(LapceColor::LAPCE_BORDER),
-                            )
+                            .border_color(config.color(LapceColor::LAPCE_BORDER))
                             .hover(|s| {
                                 s.cursor(CursorStyle::Pointer).background(
-                                    *config.get_color(
-                                        LapceColor::PANEL_HOVERED_BACKGROUND,
-                                    ),
+                                    config
+                                        .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                                 )
                             })
                             .active(|s| {
-                                s.background(*config.get_color(
+                                s.background(config.color(
                                     LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
                                 ))
                             })
@@ -154,9 +151,9 @@ pub fn alert_box(alert_data: AlertBoxData) -> impl View {
                 .width(250.0)
                 .border(1.0)
                 .border_radius(6.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                .color(*config.get_color(LapceColor::EDITOR_FOREGROUND))
-                .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
+                .color(config.color(LapceColor::EDITOR_FOREGROUND))
+                .background(config.color(LapceColor::PANEL_BACKGROUND))
         })
     })
     .on_event_stop(EventListener::PointerDown, move |_| {})
@@ -169,7 +166,7 @@ pub fn alert_box(alert_data: AlertBoxData) -> impl View {
             .background(
                 config
                     .get()
-                    .get_color(LapceColor::LAPCE_DROPDOWN_SHADOW)
+                    .color(LapceColor::LAPCE_DROPDOWN_SHADOW)
                     .with_alpha_factor(0.5),
             )
     })

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -670,7 +670,7 @@ fn editor_tab_header(
                 s.items_center()
                     .border_left(if i.get() == 0 { 1.0 } else { 0.0 })
                     .border_right(1.0)
-                    .border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.get().color(LapceColor::LAPCE_BORDER))
             };
 
             match tab_close_button_style {
@@ -780,10 +780,10 @@ fn editor_tab_header(
                         .border_radius(6.0)
                         .background(
                             config
-                                .get_color(LapceColor::PANEL_BACKGROUND)
+                                .color(LapceColor::PANEL_BACKGROUND)
                                 .with_alpha_factor(0.7),
                         )
-                        .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                        .border_color(config.color(LapceColor::LAPCE_BORDER))
                 })
                 .style(|s| s.align_items(Some(AlignItems::Center)).height_full()),
             container(empty().style(move |s| {
@@ -793,7 +793,7 @@ fn editor_tab_header(
                     } else {
                         0.0
                     })
-                    .border_color(*config.get().get_color(if is_focused() {
+                    .border_color(config.get().color(if is_focused() {
                         LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE
                     } else {
                         LapceColor::LAPCE_TAB_INACTIVE_UNDERLINE
@@ -825,7 +825,7 @@ fn editor_tab_header(
                     .border_color(
                         config
                             .get()
-                            .get_color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE)
+                            .color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE)
                             .with_alpha_factor(0.5),
                     )
             }),
@@ -847,10 +847,10 @@ fn editor_tab_header(
                     s.absolute()
                         .height_full()
                         .width(size.get().width as f32)
-                        .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                        .background(config.color(LapceColor::PANEL_BACKGROUND))
                         .box_shadow_blur(3.0)
                         .box_shadow_color(
-                            *config.get_color(LapceColor::LAPCE_DROPDOWN_SHADOW),
+                            config.color(LapceColor::LAPCE_DROPDOWN_SHADOW),
                         )
                 }))
                 .style(move |s| {
@@ -929,12 +929,10 @@ fn editor_tab_header(
                             .height_full()
                             .margin_left(30.0)
                             .width(size.get().width as f32)
-                            .background(
-                                *config.get_color(LapceColor::PANEL_BACKGROUND),
-                            )
+                            .background(config.color(LapceColor::PANEL_BACKGROUND))
                             .box_shadow_blur(3.0)
                             .box_shadow_color(
-                                *config.get_color(LapceColor::LAPCE_DROPDOWN_SHADOW),
+                                config.color(LapceColor::LAPCE_DROPDOWN_SHADOW),
                             )
                     })
                 })
@@ -992,8 +990,8 @@ fn editor_tab_header(
         let config = config.get();
         s.items_center()
             .border_bottom(1.0)
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .background(config.color(LapceColor::PANEL_BACKGROUND))
     })
 }
 
@@ -1137,9 +1135,7 @@ fn editor_tab_content(
                                     .flex_basis(0.0)
                                     .border_right(1.0)
                                     .border_color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::LAPCE_BORDER),
+                                        config.get().color(LapceColor::LAPCE_BORDER),
                                     )
                             }),
                             container(editor_container_view(
@@ -1282,9 +1278,7 @@ fn editor_tab(
                     .margin_left(margin_left as f32)
                     .apply_if(pos.is_none(), |s| s.hide())
                     .background(
-                        *config
-                            .get()
-                            .get_color(LapceColor::EDITOR_DRAG_DROP_BACKGROUND),
+                        config.get().color(LapceColor::EDITOR_DRAG_DROP_BACKGROUND),
                     )
             }),
             empty()
@@ -1564,18 +1558,14 @@ fn split_resize_border(
                             SplitDirection::Vertical => CursorStyle::ColResize,
                             SplitDirection::Horizontal => CursorStyle::RowResize,
                         })
-                        .background(
-                            *config.get().get_color(LapceColor::EDITOR_CARET),
-                        )
+                        .background(config.get().color(LapceColor::EDITOR_CARET))
                     })
                     .hover(|s| {
                         s.cursor(match direction {
                             SplitDirection::Vertical => CursorStyle::ColResize,
                             SplitDirection::Horizontal => CursorStyle::RowResize,
                         })
-                        .background(
-                            *config.get().get_color(LapceColor::EDITOR_CARET),
-                        )
+                        .background(config.get().color(LapceColor::EDITOR_CARET))
                     })
             })
         },
@@ -1604,7 +1594,7 @@ fn split_border(
                     SplitDirection::Vertical => PxPctAuto::Pct(100.0),
                     SplitDirection::Horizontal => PxPctAuto::Px(1.0),
                 })
-                .background(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                .background(config.get().color(LapceColor::LAPCE_BORDER))
             }))
             .style(move |s| {
                 let rect = match &content {
@@ -1801,8 +1791,8 @@ fn main_split(window_tab_data: Rc<WindowTabData>) -> impl View {
         let config = config.get();
         let is_hidden = panel.panel_bottom_maximized(true)
             && panel.is_container_shown(&PanelContainerPosition::Bottom, true);
-        s.border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+        s.border_color(config.color(LapceColor::LAPCE_BORDER))
+            .background(config.color(LapceColor::EDITOR_BACKGROUND))
             .apply_if(is_hidden, |s| s.display(Display::None))
             .width_full()
             .flex_grow(1.0)
@@ -1824,12 +1814,10 @@ pub fn clickable_icon(
                     let config = config.get();
                     let size = config.ui.icon_size() as f32;
                     s.size(size, size)
-                        .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                        .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                         .disabled(|s| {
-                            s.color(
-                                *config.get_color(LapceColor::LAPCE_ICON_INACTIVE),
-                            )
-                            .cursor(CursorStyle::Default)
+                            s.color(config.color(LapceColor::LAPCE_ICON_INACTIVE))
+                                .cursor(CursorStyle::Default)
                         })
                 })
                 .disabled(disabled_fn),
@@ -1845,17 +1833,16 @@ pub fn clickable_icon(
                 .border(1.0)
                 .border_color(Color::TRANSPARENT)
                 .apply_if(active_fn(), |s| {
-                    s.border_color(*config.get_color(LapceColor::EDITOR_CARET))
+                    s.border_color(config.color(LapceColor::EDITOR_CARET))
                 })
                 .hover(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
                 .active(|s| {
                     s.background(
-                        *config
-                            .get_color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
                     )
                 })
         }),
@@ -1950,7 +1937,7 @@ fn palette_item(
                     svg(move || config.get().file_svg(&path).0).style(move |s| {
                         let config = config.get();
                         let size = config.ui.icon_size() as f32;
-                        let color = config.file_svg(&style_path).1.copied();
+                        let color = config.file_svg(&style_path).1;
                         s.min_width(size)
                             .size(size, size)
                             .margin_right(5.0)
@@ -1959,16 +1946,16 @@ fn palette_item(
                     focus_text(
                         move || file_name.clone(),
                         move || file_name_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(|s| s.margin_right(6.0).max_width_full()),
                     focus_text(
                         move || folder.clone(),
                         move || folder_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(move |s| {
-                        s.color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                        s.color(config.get().color(LapceColor::EDITOR_DIM))
                             .min_width(0.0)
                             .flex_grow(1.0)
                             .flex_basis(0.0)
@@ -2024,21 +2011,21 @@ fn palette_item(
                         s.min_width(size)
                             .size(size, size)
                             .margin_right(5.0)
-                            .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                            .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                     }),
                     focus_text(
                         move || text.clone(),
                         move || text_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(|s| s.margin_right(6.0).max_width_full()),
                     focus_text(
                         move || hint.clone(),
                         move || hint_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(move |s| {
-                        s.color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                        s.color(config.get().color(LapceColor::EDITOR_DIM))
                             .min_width(0.0)
                             .flex_grow(1.0)
                             .flex_basis(0.0)
@@ -2105,21 +2092,21 @@ fn palette_item(
                         s.min_width(size)
                             .size(size, size)
                             .margin_right(5.0)
-                            .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                            .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                     }),
                     focus_text(
                         move || text.clone(),
                         move || text_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(|s| s.margin_right(6.0).max_width_full()),
                     focus_text(
                         move || hint.clone(),
                         move || hint_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(move |s| {
-                        s.color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                        s.color(config.get().color(LapceColor::EDITOR_DIM))
                             .min_width(0.0)
                             .flex_grow(1.0)
                             .flex_basis(0.0)
@@ -2178,21 +2165,21 @@ fn palette_item(
                         s.min_width(size)
                             .size(size, size)
                             .margin_right(5.0)
-                            .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                            .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                     }),
                     focus_text(
                         move || text.clone(),
                         move || text_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(|s| s.margin_right(6.0).max_width_full()),
                     focus_text(
                         move || hint.clone(),
                         move || hint_indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(move |s| {
-                        s.color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                        s.color(config.get().color(LapceColor::EDITOR_DIM))
                             .min_width(0.0)
                             .flex_grow(1.0)
                             .flex_basis(0.0)
@@ -2220,7 +2207,7 @@ fn palette_item(
                     focus_text(
                         move || text.clone(),
                         move || indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(|s| {
                         s.flex_row()
@@ -2238,9 +2225,7 @@ fn palette_item(
                                     .border(1.0)
                                     .border_radius(3.0)
                                     .border_color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::LAPCE_BORDER),
+                                        config.get().color(LapceColor::LAPCE_BORDER),
                                     )
                             })
                         },
@@ -2263,7 +2248,7 @@ fn palette_item(
                 focus_text(
                     move || text.clone(),
                     move || indices.clone(),
-                    move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                    move || config.get().color(LapceColor::EDITOR_FOCUS),
                 )
                 .style(|s| s.align_items(Some(AlignItems::Center)).max_width_full()),
             )
@@ -2275,9 +2260,7 @@ fn palette_item(
             .padding_horiz(10.0)
             .apply_if(index.get() == i, |style| {
                 style.background(
-                    *config
-                        .get()
-                        .get_color(LapceColor::PALETTE_CURRENT_BACKGROUND),
+                    config.get().color(LapceColor::PALETTE_CURRENT_BACKGROUND),
                 )
             })
     })
@@ -2296,8 +2279,8 @@ fn palette_input(window_tab_data: Rc<WindowTabData>) -> impl View {
                     .height(25.0)
                     .items_center()
                     .border_bottom(1.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                    .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
+                    .background(config.color(LapceColor::EDITOR_BACKGROUND))
             },
         ),
     )
@@ -2384,9 +2367,9 @@ fn palette_content(
                     .style(move |s| {
                         s.width_full().cursor(CursorStyle::Pointer).hover(|s| {
                             s.background(
-                                *config
+                                config
                                     .get()
-                                    .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                                    .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                             )
                         })
                     })
@@ -2442,9 +2425,9 @@ fn palette_preview(window_tab_data: Rc<WindowTabData>) -> impl View {
             let config = config.get();
             s.position(Position::Absolute)
                 .border_top(1.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
                 .size_full()
-                .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                .background(config.color(LapceColor::EDITOR_BACKGROUND))
         }),
     )
     .style(move |s| {
@@ -2487,9 +2470,9 @@ fn palette(window_tab_data: Rc<WindowTabData>) -> impl View {
                 .margin_top(5.0)
                 .border(1.0)
                 .border_radius(6.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
                 .flex_col()
-                .background(*config.get_color(LapceColor::PALETTE_BACKGROUND))
+                .background(config.color(LapceColor::PALETTE_BACKGROUND))
         }),
     )
     .style(move |s| {
@@ -2523,15 +2506,15 @@ fn window_message_view(
                     let config = config.get();
                     let size = config.ui.icon_size() as f32;
                     let color = if let MessageType::ERROR = message.typ {
-                        config.get_color(LapceColor::LAPCE_ERROR)
+                        config.color(LapceColor::LAPCE_ERROR)
                     } else {
-                        config.get_color(LapceColor::LAPCE_WARN)
+                        config.color(LapceColor::LAPCE_WARN)
                     };
                     s.min_width(size)
                         .size(size, size)
                         .margin_right(10.0)
                         .margin_top(4.0)
-                        .color(*color)
+                        .color(color)
                 }),
                 stack((
                     text(title.clone()).style(|s| {
@@ -2564,8 +2547,8 @@ fn window_message_view(
                     .padding(10.0)
                     .border(1.0)
                     .border_radius(6.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                    .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
+                    .background(config.color(LapceColor::PANEL_BACKGROUND))
                     .apply_if(i > 0, |s| s.margin_top(10.0))
             })
         };
@@ -2660,9 +2643,10 @@ fn hover(window_tab_data: Rc<WindowTabData>) -> impl View {
                 MarkdownContent::Image { .. } => container_box(empty()),
                 MarkdownContent::Separator => {
                     container_box(empty().style(move |s| {
-                        s.width_full().margin_vert(5.0).height(1.0).background(
-                            *config.get().get_color(LapceColor::LAPCE_BORDER),
-                        )
+                        s.width_full()
+                            .margin_vert(5.0)
+                            .height(1.0)
+                            .background(config.get().color(LapceColor::LAPCE_BORDER))
                     }))
                 }
             },
@@ -2686,8 +2670,8 @@ fn hover(window_tab_data: Rc<WindowTabData>) -> impl View {
                     .max_height(300.0)
                     .border(1.0)
                     .border_radius(6.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                    .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
+                    .background(config.color(LapceColor::PANEL_BACKGROUND))
             } else {
                 s.hide()
             }
@@ -2738,7 +2722,7 @@ fn completion(window_tab_data: Rc<WindowTabData>) -> impl View {
                     focus_text(
                         move || item.item.label.clone(),
                         move || item.indices.clone(),
-                        move || *config.get().get_color(LapceColor::EDITOR_FOCUS),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
                     )
                     .style(move |s| {
                         let config = config.get();
@@ -2748,8 +2732,7 @@ fn completion(window_tab_data: Rc<WindowTabData>) -> impl View {
                             .size_full()
                             .apply_if(active.get() == i, |s| {
                                 s.background(
-                                    *config
-                                        .get_color(LapceColor::COMPLETION_CURRENT),
+                                    config.color(LapceColor::COMPLETION_CURRENT),
                                 )
                             })
                     }),
@@ -2791,7 +2774,7 @@ fn completion(window_tab_data: Rc<WindowTabData>) -> impl View {
             .max_height(400.0)
             .margin_left(origin.x as f32)
             .margin_top(origin.y as f32)
-            .background(*config.get_color(LapceColor::COMPLETION_BACKGROUND))
+            .background(config.color(LapceColor::COMPLETION_BACKGROUND))
             .font_family(config.editor.font_family.clone())
             .font_size(config.editor.font_size() as f32)
             .border_radius(6.0)
@@ -2828,8 +2811,7 @@ fn code_action(window_tab_data: Rc<WindowTabData>) -> impl View {
                             .line_height(1.6)
                             .apply_if(active.get() == i, |s| {
                                 s.border_radius(6.0).background(
-                                    *config
-                                        .get_color(LapceColor::COMPLETION_CURRENT),
+                                    config.color(LapceColor::COMPLETION_CURRENT),
                                 )
                             })
                     })
@@ -2866,7 +2848,7 @@ fn code_action(window_tab_data: Rc<WindowTabData>) -> impl View {
         .max_height(400.0)
         .margin_left(origin.x as f32)
         .margin_top(origin.y as f32)
-        .background(*config.get().get_color(LapceColor::COMPLETION_BACKGROUND))
+        .background(config.get().color(LapceColor::COMPLETION_BACKGROUND))
         .border_radius(6.0)
     })
 }
@@ -2887,8 +2869,8 @@ fn rename(window_tab_data: Rc<WindowTabData>) -> impl View {
                 .font_size(config.editor.font_size() as f32)
                 .border(1.0)
                 .border_radius(6.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
+                .background(config.color(LapceColor::EDITOR_BACKGROUND))
         }),
     )
     .on_resize(move |rect| {
@@ -2902,7 +2884,7 @@ fn rename(window_tab_data: Rc<WindowTabData>) -> impl View {
             .apply_if(!active.get(), |s| s.hide())
             .margin_left(origin.x as f32)
             .margin_top(origin.y as f32)
-            .background(*config.get().get_color(LapceColor::PANEL_BACKGROUND))
+            .background(config.get().color(LapceColor::PANEL_BACKGROUND))
             .border_radius(6.0)
             .padding(6.0)
     })
@@ -2956,14 +2938,14 @@ fn window_tab(window_tab_data: Rc<WindowTabData>) -> impl View {
     .style(move |s| {
         let config = config.get();
         s.size_full()
-            .color(*config.get_color(LapceColor::EDITOR_FOREGROUND))
-            .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+            .color(config.color(LapceColor::EDITOR_FOREGROUND))
+            .background(config.color(LapceColor::EDITOR_BACKGROUND))
             .font_size(config.ui.font_size() as f32)
             .apply_if(!config.ui.font_family.is_empty(), |s| {
                 s.font_family(config.ui.font_family.clone())
             })
             .class(floem::views::scroll::Handle, |s| {
-                s.background(*config.get_color(LapceColor::LAPCE_SCROLL_BAR))
+                s.background(config.color(LapceColor::LAPCE_SCROLL_BAR))
             })
     });
 
@@ -3097,9 +3079,7 @@ fn workspace_tab_header(window_data: WindowData) -> impl View {
                             .min_width(0.0)
                             .items_center()
                             .border_right(1.0)
-                            .border_color(
-                                *config.get_color(LapceColor::LAPCE_BORDER),
-                            )
+                            .border_color(config.color(LapceColor::LAPCE_BORDER))
                             .apply_if(
                                 cfg!(target_os = "macos") && index.get() == 0,
                                 |s| s.border_left(1.0),
@@ -3111,9 +3091,9 @@ fn workspace_tab_header(window_data: WindowData) -> impl View {
                                 s.border_bottom(2.0)
                             })
                             .border_color(
-                                *config.get().get_color(
-                                    LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE,
-                                ),
+                                config
+                                    .get()
+                                    .color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE),
                             )
                     }))
                     .style(|s| {
@@ -3135,15 +3115,15 @@ fn workspace_tab_header(window_data: WindowData) -> impl View {
                 let config = config.get();
                 s.border(1.0)
                     .border_radius(6.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
                     .color(
                         config
-                            .get_color(LapceColor::EDITOR_FOREGROUND)
+                            .color(LapceColor::EDITOR_FOREGROUND)
                             .with_alpha_factor(0.7),
                     )
                     .background(
                         config
-                            .get_color(LapceColor::PANEL_BACKGROUND)
+                            .color(LapceColor::PANEL_BACKGROUND)
                             .with_alpha_factor(0.7),
                     )
             })
@@ -3160,9 +3140,7 @@ fn workspace_tab_header(window_data: WindowData) -> impl View {
                     )
                     .height_full()
                     .border_color(
-                        *config
-                            .get()
-                            .get_color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE),
+                        config.get().color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE),
                     )
                     .apply_if(drag_over_left.get().is_some(), move |s| {
                         let drag_over_left = drag_over_left.get_untracked().unwrap();
@@ -3256,9 +3234,9 @@ fn workspace_tab_header(window_data: WindowData) -> impl View {
                 s.font_family(config.ui.font_family.clone())
             })
             .apply_if(tabs.with(|tabs| tabs.len() < 2), |s| s.hide())
-            .color(*config.get_color(LapceColor::EDITOR_FOREGROUND))
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+            .color(config.color(LapceColor::EDITOR_FOREGROUND))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .background(config.color(LapceColor::PANEL_BACKGROUND))
             .items_center()
     })
 }

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -382,7 +382,7 @@ impl LineStyling for DocLineStyling {
     }
 
     fn color(&self) -> Color {
-        *self.config.get_color(LapceColor::EDITOR_FOREGROUND)
+        self.config.color(LapceColor::EDITOR_FOREGROUND)
     }
 
     fn tab_width(&self) -> usize {
@@ -390,7 +390,7 @@ impl LineStyling for DocLineStyling {
     }
 
     fn style_color(&self, style: &str) -> Option<Color> {
-        self.config.get_style_color(style).copied()
+        self.config.style_color(style)
     }
 
     fn phantom_text(&self) -> PhantomTextLine {
@@ -433,10 +433,10 @@ impl LineStyling for DocLineStyling {
                     kind: PhantomTextKind::InlayHint,
                     col,
                     text,
-                    fg: Some(*config.get_color(LapceColor::INLAY_HINT_FOREGROUND)),
+                    fg: Some(config.color(LapceColor::INLAY_HINT_FOREGROUND)),
                     // font_family: Some(config.editor.inlay_hint_font_family()),
                     font_size: Some(config.editor.inlay_hint_font_size()),
-                    bg: Some(*config.get_color(LapceColor::INLAY_HINT_BACKGROUND)),
+                    bg: Some(config.color(LapceColor::INLAY_HINT_BACKGROUND)),
                     under_line: None,
                 }
             });
@@ -492,7 +492,7 @@ impl LineStyling for DocLineStyling {
                         LapceColor::ERROR_LENS_OTHER_FOREGROUND
                     };
 
-                    *config.get_color(theme_prop)
+                    config.color(theme_prop)
                 };
 
                 let text = if config.editor.error_lens_multiline {
@@ -528,7 +528,7 @@ impl LineStyling for DocLineStyling {
                 kind: PhantomTextKind::Completion,
                 col: completion_col,
                 text: completion.clone(),
-                fg: Some(*config.get_color(LapceColor::COMPLETION_LENS_FOREGROUND)),
+                fg: Some(config.color(LapceColor::COMPLETION_LENS_FOREGROUND)),
                 font_size: Some(config.editor.completion_lens_font_size()),
                 // font_family: Some(config.editor.completion_lens_font_family()),
                 bg: None,
@@ -554,7 +554,7 @@ impl LineStyling for DocLineStyling {
                 kind: PhantomTextKind::Completion,
                 col: inline_completion_col,
                 text: completion.clone(),
-                fg: Some(*config.get_color(LapceColor::COMPLETION_LENS_FOREGROUND)),
+                fg: Some(config.color(LapceColor::COMPLETION_LENS_FOREGROUND)),
                 font_size: Some(config.editor.completion_lens_font_size()),
                 // font_family: Some(config.editor.completion_lens_font_family()),
                 bg: None,
@@ -566,7 +566,7 @@ impl LineStyling for DocLineStyling {
         }
 
         if let Some(preedit) = self.doc.preedit_phantom_text(
-            Some(*config.get_color(LapceColor::EDITOR_FOREGROUND)),
+            Some(config.color(LapceColor::EDITOR_FOREGROUND)),
             self.line,
         ) {
             text.push(preedit)
@@ -882,7 +882,7 @@ impl Backend for DocBackend {
                 y: 0.0,
                 width: x1,
                 height: text_layout.size().height,
-                bg_color: Some(*config.get_color(theme_prop)),
+                bg_color: Some(config.color(theme_prop)),
                 under_line: None,
                 wave_line: None,
             });
@@ -924,7 +924,7 @@ impl Backend for DocBackend {
                             }
                             _ => LapceColor::LAPCE_WARN,
                         };
-                        let color = *config.get_color(color_name);
+                        let color = config.color(color_name);
 
                         let styles = extra_styles_for_range(
                             text_layout,

--- a/lapce-app/src/editor/diff.rs
+++ b/lapce-app/src/editor/diff.rs
@@ -384,7 +384,7 @@ pub fn diff_show_more_section_view(
             wave_box().style(move |s| {
                 s.absolute()
                     .size_pct(100.0, 100.0)
-                    .color(*config.get().get_color(LapceColor::PANEL_BACKGROUND))
+                    .color(config.get().color(LapceColor::PANEL_BACKGROUND))
             }),
             label(move || format!("{} Hidden Lines", section.lines)),
             label(|| "|".to_string()).style(|s| s.margin_left(10.0)),
@@ -393,7 +393,7 @@ pub fn diff_show_more_section_view(
                     let config = config.get();
                     let size = config.ui.icon_size() as f32;
                     s.size(size, size)
-                        .color(*config.get_color(LapceColor::EDITOR_FOREGROUND))
+                        .color(config.color(LapceColor::EDITOR_FOREGROUND))
                 }),
                 label(|| "Expand All".to_string()).style(|s| s.margin_left(6.0)),
             ))
@@ -433,7 +433,7 @@ pub fn diff_show_more_section_view(
                         let config = config.get();
                         let size = config.ui.icon_size() as f32;
                         s.size(size, size)
-                            .color(*config.get_color(LapceColor::EDITOR_FOREGROUND))
+                            .color(config.color(LapceColor::EDITOR_FOREGROUND))
                     },
                 ),
                 label(|| "Expand Up".to_string()).style(|s| s.margin_left(6.0)),
@@ -474,7 +474,7 @@ pub fn diff_show_more_section_view(
                         let config = config.get();
                         let size = config.ui.icon_size() as f32;
                         s.size(size, size)
-                            .color(*config.get_color(LapceColor::EDITOR_FOREGROUND))
+                            .color(config.color(LapceColor::EDITOR_FOREGROUND))
                     },
                 ),
                 label(|| "Expand Down".to_string()).style(|s| s.margin_left(6.0)),

--- a/lapce-app/src/editor/gutter.rs
+++ b/lapce-app/src/editor/gutter.rs
@@ -100,12 +100,12 @@ impl EditorGutterView {
                 .inflate(25.0, 0.0);
         cx.fill(
             &sticky_area_rect,
-            config.get_color(LapceColor::LAPCE_DROPDOWN_SHADOW),
+            config.color(LapceColor::LAPCE_DROPDOWN_SHADOW),
             3.0,
         );
         cx.fill(
             &sticky_area_rect,
-            config.get_color(LapceColor::EDITOR_STICKY_HEADER_BACKGROUND),
+            config.color(LapceColor::EDITOR_STICKY_HEADER_BACKGROUND),
             0.0,
         );
     }
@@ -161,12 +161,11 @@ impl View for EditorGutterView {
             FamilyOwned::parse_list(&config.editor.font_family).collect();
         let attrs = Attrs::new()
             .family(&family)
-            .color(*config.get_color(LapceColor::EDITOR_DIM))
+            .color(config.color(LapceColor::EDITOR_DIM))
             .font_size(config.editor.font_size() as f32);
         let attrs_list = AttrsList::new(attrs);
-        let current_line_attrs_list = AttrsList::new(
-            attrs.color(*config.get_color(LapceColor::EDITOR_FOREGROUND)),
-        );
+        let current_line_attrs_list =
+            AttrsList::new(attrs.color(config.color(LapceColor::EDITOR_FOREGROUND)));
         let show_relative = config.core.modal
             && config.editor.modal_mode_relative_line_numbers
             && mode != Mode::Insert

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -534,7 +534,7 @@ impl EditorView {
                                 (section.y_idx * config.editor.line_height()) as f64,
                             )),
                         config
-                            .get_color(LapceColor::SOURCE_CONTROL_ADDED)
+                            .color(LapceColor::SOURCE_CONTROL_ADDED)
                             .with_alpha_factor(0.2),
                         0.0,
                     );
@@ -552,7 +552,7 @@ impl EditorView {
                                 (section.y_idx * config.editor.line_height()) as f64,
                             )),
                         config
-                            .get_color(LapceColor::SOURCE_CONTROL_REMOVED)
+                            .color(LapceColor::SOURCE_CONTROL_REMOVED)
                             .with_alpha_factor(0.2),
                         0.0,
                     );
@@ -603,7 +603,7 @@ impl EditorView {
                 let p1 = Point::new(x as f64 - height, y + height);
                 cx.stroke(
                     &Line::new(p0, p1),
-                    *config.get_color(LapceColor::EDITOR_DIM),
+                    config.color(LapceColor::EDITOR_DIM),
                     1.0,
                 );
             }
@@ -813,9 +813,9 @@ impl EditorView {
         let is_active =
             self.is_active.get_untracked() && !find_focus.get_untracked();
 
-        let current_line_color = *config.get_color(LapceColor::EDITOR_CURRENT_LINE);
-        let selection_color = *config.get_color(LapceColor::EDITOR_SELECTION);
-        let caret_color = *config.get_color(LapceColor::EDITOR_CARET);
+        let current_line_color = config.color(LapceColor::EDITOR_CURRENT_LINE);
+        let selection_color = config.color(LapceColor::EDITOR_SELECTION);
+        let caret_color = config.color(LapceColor::EDITOR_CARET);
 
         let breakline = self.debug_breakline.get_untracked().and_then(
             |(breakline, breakline_path)| {
@@ -842,7 +842,7 @@ impl EditorView {
 
                 cx.fill(
                     &rect,
-                    config.get_color(LapceColor::EDITOR_DEBUG_BREAK_LINE),
+                    config.color(LapceColor::EDITOR_DEBUG_BREAK_LINE),
                     0.0,
                 );
             }
@@ -1077,7 +1077,7 @@ impl EditorView {
                 let family: Vec<FamilyOwned> =
                     FamilyOwned::parse_list(&config.editor.font_family).collect();
                 let attrs = Attrs::new()
-                    .color(*config.get_color(LapceColor::EDITOR_VISIBLE_WHITESPACE))
+                    .color(config.color(LapceColor::EDITOR_VISIBLE_WHITESPACE))
                     .family(&family)
                     .font_size(config.editor.font_size() as f32);
                 let attrs_list = AttrsList::new(attrs);
@@ -1104,7 +1104,7 @@ impl EditorView {
                 while x + 1.0 < text_layout.indent {
                     cx.stroke(
                         &Line::new(Point::new(x, y), Point::new(x, y + line_height)),
-                        config.get_color(LapceColor::EDITOR_INDENT_GUIDE),
+                        config.color(LapceColor::EDITOR_INDENT_GUIDE),
                         1.0,
                     );
                     x += indent_text_width;
@@ -1204,7 +1204,7 @@ impl EditorView {
             }
         }
 
-        let color = config.get_color(LapceColor::EDITOR_FOREGROUND);
+        let color = config.color(LapceColor::EDITOR_FOREGROUND);
         for rect in rects {
             cx.stroke(&rect, color, 1.0);
         }
@@ -1276,12 +1276,12 @@ impl EditorView {
 
         cx.fill(
             &sticky_area_rect,
-            config.get_color(LapceColor::LAPCE_DROPDOWN_SHADOW),
+            config.color(LapceColor::LAPCE_DROPDOWN_SHADOW),
             3.0,
         );
         cx.fill(
             &sticky_area_rect,
-            config.get_color(LapceColor::EDITOR_STICKY_HEADER_BACKGROUND),
+            config.color(LapceColor::EDITOR_STICKY_HEADER_BACKGROUND),
             0.0,
         );
 
@@ -1341,7 +1341,7 @@ impl EditorView {
                     viewport.y0,
                 ))
                 .inflate(0.0, 10.0),
-            config.get_color(LapceColor::LAPCE_SCROLL_BAR),
+            config.color(LapceColor::LAPCE_SCROLL_BAR),
             0.0,
         );
 
@@ -1425,11 +1425,7 @@ impl EditorView {
 
                 let rect = Rect::new(x0, y0, x1, y1);
 
-                cx.stroke(
-                    &rect,
-                    config.get_color(LapceColor::EDITOR_FOREGROUND),
-                    1.0,
-                );
+                cx.stroke(&rect, config.color(LapceColor::EDITOR_FOREGROUND), 1.0);
             }
         }
     }
@@ -1448,7 +1444,7 @@ impl EditorView {
         let doc = view.doc.get_untracked();
         let config = self.editor.common.config.get_untracked();
         let line_height = config.editor.line_height() as f64;
-        let brush = config.get_color(LapceColor::EDITOR_FOREGROUND);
+        let brush = config.color(LapceColor::EDITOR_FOREGROUND);
 
         if start == end {
             if let Some(line_info) = screen_lines.info(start) {
@@ -1957,7 +1953,7 @@ pub fn editor_container_view(
                         // .box_shadow_blur(5.0)
                         // .border_bottom(1.0)
                         // .border_color(
-                        //     *config.get_color(LapceColor::LAPCE_BORDER),
+                        //     config.get_color(LapceColor::LAPCE_BORDER),
                         // )
                         .apply_if(
                             !config.editor.sticky_header
@@ -2071,7 +2067,7 @@ fn editor_gutter(
                     let config = config.get();
                     let size = config.ui.icon_size() as f32 + 2.0;
                     s.size(size, size)
-                        .color(*config.get_color(LapceColor::DEBUG_BREAKPOINT_HOVER))
+                        .color(config.color(LapceColor::DEBUG_BREAKPOINT_HOVER))
                         .apply_if(!hovered.get(), |s| s.hide())
                 },
             ),
@@ -2220,7 +2216,7 @@ fn editor_gutter(
                                 } else {
                                     LapceColor::EDITOR_DIM
                                 };
-                                let color = *config.get_color(color);
+                                let color = config.color(color);
                                 s.size(size, size).color(color)
                             }),
                         )
@@ -2242,7 +2238,7 @@ fn editor_gutter(
         .style(move |s| {
             s.absolute()
                 .size_pct(100.0, 100.0)
-                .background(*config.get().get_color(LapceColor::EDITOR_BACKGROUND))
+                .background(config.get().color(LapceColor::EDITOR_BACKGROUND))
         }),
         clip(
             stack((
@@ -2262,7 +2258,7 @@ fn editor_gutter(
                             let config = config.get();
                             let size = config.ui.icon_size() as f32;
                             s.size(size, size)
-                                .color(*config.get_color(LapceColor::LAPCE_WARN))
+                                .color(config.color(LapceColor::LAPCE_WARN))
                         },
                     ),
                 )
@@ -2293,14 +2289,15 @@ fn editor_gutter(
                         .apply_if(code_action_vline.is_none(), |s| s.hide())
                         .hover(|s| {
                             s.cursor(CursorStyle::Pointer).background(
-                                *config
-                                    .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                                config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                             )
                         })
                         .active(|s| {
-                            s.background(*config.get_color(
-                                LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
-                            ))
+                            s.background(
+                                config.color(
+                                    LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
+                                ),
+                            )
                         })
                 }),
             ))
@@ -2374,9 +2371,11 @@ fn editor_breadcrumbs(
                                     let size = config.ui.icon_size() as f32;
                                     s.apply_if(i == 0, |s| s.hide())
                                         .size(size, size)
-                                        .color(*config.get_color(
-                                            LapceColor::LAPCE_ICON_ACTIVE,
-                                        ))
+                                        .color(
+                                            config.color(
+                                                LapceColor::LAPCE_ICON_ACTIVE,
+                                            ),
+                                        )
                                 }),
                                 label(move || section.clone()),
                             ))
@@ -2413,7 +2412,7 @@ fn editor_breadcrumbs(
             s.absolute()
                 .size_pct(100.0, 100.0)
                 .border_bottom(1.0)
-                .border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                .border_color(config.get().color(LapceColor::LAPCE_BORDER))
                 .items_center()
         }),
     )
@@ -2614,8 +2613,8 @@ fn search_editor_view(
             .items_center()
             .border(1.0)
             .border_radius(6.0)
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .background(config.color(LapceColor::EDITOR_BACKGROUND))
     })
 }
 
@@ -2654,8 +2653,8 @@ fn replace_editor_view(
             .items_center()
             .border(1.0)
             .border_radius(6.0)
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .background(config.color(LapceColor::EDITOR_BACKGROUND))
     })
 }
 
@@ -2813,10 +2812,10 @@ fn find_view(
         .style(move |s| {
             let config = config.get();
             s.margin_right(50.0)
-                .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                .background(config.color(LapceColor::PANEL_BACKGROUND))
                 .border_radius(6.0)
                 .border(1.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
                 .padding_vert(4.0)
                 .cursor(CursorStyle::Default)
                 .flex_col()
@@ -2856,21 +2855,20 @@ fn changes_color_iter<'a>(
         let mut modified = false;
         let color = match change {
             DiffLines::Left(_range) => {
-                Some(config.get_color(LapceColor::SOURCE_CONTROL_REMOVED))
+                Some(config.color(LapceColor::SOURCE_CONTROL_REMOVED))
             }
             DiffLines::Right(_range) => {
                 if let Some(DiffLines::Left(_)) = last_change.as_ref() {
                     modified = true;
                 }
                 if modified {
-                    Some(config.get_color(LapceColor::SOURCE_CONTROL_MODIFIED))
+                    Some(config.color(LapceColor::SOURCE_CONTROL_MODIFIED))
                 } else {
-                    Some(config.get_color(LapceColor::SOURCE_CONTROL_ADDED))
+                    Some(config.color(LapceColor::SOURCE_CONTROL_ADDED))
                 }
             }
             _ => None,
-        }
-        .cloned();
+        };
 
         last_change = Some(change.clone());
 

--- a/lapce-app/src/editor_tab.rs
+++ b/lapce-app/src/editor_tab.rs
@@ -238,7 +238,7 @@ impl EditorTabChild {
                         let (svg, color) = config.file_svg(&path);
                         (
                             svg,
-                            color.cloned(),
+                            color,
                             path.file_name()
                                 .unwrap_or_default()
                                 .to_string_lossy()
@@ -249,7 +249,7 @@ impl EditorTabChild {
                     }
                     None => (
                         config.ui_svg(LapceIcons::FILE),
-                        Some(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE)),
+                        Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
                         "local".to_string(),
                         create_rw_signal(true),
                         true,
@@ -289,7 +289,7 @@ impl EditorTabChild {
                         let (svg, color) = config.file_svg(&path);
                         (
                             svg,
-                            color.cloned(),
+                            color,
                             format!(
                                 "{} (Diff)",
                                 path.file_name()
@@ -301,7 +301,7 @@ impl EditorTabChild {
                     }
                     None => (
                         config.ui_svg(LapceIcons::FILE),
-                        Some(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE)),
+                        Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
                         "local".to_string(),
                         true,
                     ),
@@ -318,7 +318,7 @@ impl EditorTabChild {
                 let config = config.get();
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::SETTINGS),
-                    color: Some(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE)),
+                    color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
                     path: "Settings".to_string(),
                     confirmed: None,
                     is_pristine: true,
@@ -328,7 +328,7 @@ impl EditorTabChild {
                 let config = config.get();
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::SYMBOL_COLOR),
-                    color: Some(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE)),
+                    color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
                     path: "Theme Colors".to_string(),
                     confirmed: None,
                     is_pristine: true,
@@ -338,7 +338,7 @@ impl EditorTabChild {
                 let config = config.get();
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::KEYBOARD),
-                    color: Some(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE)),
+                    color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
                     path: "Keyboard Shortcuts".to_string(),
                     confirmed: None,
                     is_pristine: true,
@@ -361,7 +361,7 @@ impl EditorTabChild {
                     .unwrap_or_else(|| id.name.clone());
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::EXTENSIONS),
-                    color: Some(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE)),
+                    color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
                     path: display_name,
                     confirmed: None,
                     is_pristine: true,

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -88,7 +88,7 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                     let size = config.ui.icon_size() as f32;
 
                     let color = if is_dir {
-                        *config.get_color(LapceColor::LAPCE_ICON_ACTIVE)
+                        config.color(LapceColor::LAPCE_ICON_ACTIVE)
                     } else {
                         Color::TRANSPARENT
                     };
@@ -116,13 +116,11 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                         s.size(size, size)
                             .margin_horiz(6.0)
                             .apply_if(is_dir, |s| {
-                                s.color(
-                                    *config.get_color(LapceColor::LAPCE_ICON_ACTIVE),
-                                )
+                                s.color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                             })
                             .apply_if(!is_dir, |s| {
                                 s.apply_opt(
-                                    config.file_svg(&path_for_style).1.cloned(),
+                                    config.file_svg(&path_for_style).1,
                                     Style::color,
                                 )
                             })
@@ -142,9 +140,7 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                     .min_width_pct(100.0)
                     .hover(|s| {
                         s.background(
-                            *config
-                                .get()
-                                .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                            config.get().color(LapceColor::PANEL_HOVERED_BACKGROUND),
                         )
                         .cursor(CursorStyle::Pointer)
                     })
@@ -247,14 +243,12 @@ fn open_editors_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                             == child_index.get(),
                     |s| {
                         s.background(
-                            *config.get_color(LapceColor::PANEL_CURRENT_BACKGROUND),
+                            config.color(LapceColor::PANEL_CURRENT_BACKGROUND),
                         )
                     },
                 )
                 .hover(|s| {
-                    s.background(
-                        *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
-                    )
+                    s.background(config.color(LapceColor::PANEL_HOVERED_BACKGROUND))
                 })
         })
         .on_event_cont(EventListener::PointerDown, move |_| {

--- a/lapce-app/src/keymap.rs
+++ b/lapce-app/src/keymap.rs
@@ -115,9 +115,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                         .flex_basis(0.0)
                         .flex_grow(1.0)
                         .border_right(1.0)
-                        .border_color(
-                            *config.get().get_color(LapceColor::LAPCE_BORDER),
-                        )
+                        .border_color(config.get().color(LapceColor::LAPCE_BORDER))
                 }),
                 {
                     let keymap = keymap.clone();
@@ -144,9 +142,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                                     .border(1.0)
                                     .border_radius(3.0)
                                     .border_color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::LAPCE_BORDER),
+                                        config.get().color(LapceColor::LAPCE_BORDER),
                                     )
                             })
                         },
@@ -158,7 +154,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                             .height_pct(100.0)
                             .border_right(1.0)
                             .border_color(
-                                *config.get().get_color(LapceColor::LAPCE_BORDER),
+                                config.get().color(LapceColor::LAPCE_BORDER),
                             )
                     })
                 },
@@ -195,9 +191,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                                     .border(1.0)
                                     .border_radius(3.0)
                                     .border_color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::LAPCE_BORDER),
+                                        config.get().color(LapceColor::LAPCE_BORDER),
                                     )
                             })
                         },
@@ -209,7 +203,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                             .height_pct(100.0)
                             .border_right(1.0)
                             .border_color(
-                                *config.get().get_color(LapceColor::LAPCE_BORDER),
+                                config.get().color(LapceColor::LAPCE_BORDER),
                             )
                             .apply_if(!modal.get(), |s| s.hide())
                     })
@@ -260,12 +254,10 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                     .height(ui_line_height() as f32)
                     .width_pct(100.0)
                     .apply_if(i % 2 > 0, |s| {
-                        s.background(
-                            *config.get_color(LapceColor::EDITOR_CURRENT_LINE),
-                        )
+                        s.background(config.color(LapceColor::EDITOR_CURRENT_LINE))
                     })
                     .border_bottom(1.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
             })
         };
 
@@ -278,9 +270,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                     s.width_pct(100.0)
                         .border_radius(6.0)
                         .border(1.0)
-                        .border_color(
-                            *config.get().get_color(LapceColor::LAPCE_BORDER),
-                        )
+                        .border_color(config.get().color(LapceColor::LAPCE_BORDER))
                 }),
         )
         .style(|s| s.padding_bottom(10.0).width_pct(100.0)),
@@ -295,7 +285,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                     .flex_basis(0.0)
                     .flex_grow(1.0)
                     .border_right(1.0)
-                    .border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.get().color(LapceColor::LAPCE_BORDER))
             }),
             text("Key Binding").style(move |s| {
                 s.width(200.0)
@@ -303,7 +293,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                     .padding_horiz(10.0)
                     .height_pct(100.0)
                     .border_right(1.0)
-                    .border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.get().color(LapceColor::LAPCE_BORDER))
             }),
             text("Modes").style(move |s| {
                 s.width(200.0)
@@ -311,7 +301,7 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                     .padding_horiz(10.0)
                     .height_pct(100.0)
                     .border_right(1.0)
-                    .border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.get().color(LapceColor::LAPCE_BORDER))
                     .apply_if(!modal.get(), |s| s.hide())
             }),
             container(text("When").style(move |s| {
@@ -332,8 +322,8 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
                 .width_pct(100.0)
                 .border_top(1.0)
                 .border_bottom(1.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                .background(*config.get_color(LapceColor::EDITOR_CURRENT_LINE))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
+                .background(config.color(LapceColor::EDITOR_CURRENT_LINE))
         }),
         container(
             scroll(
@@ -404,7 +394,7 @@ fn keyboard_picker_view(
                             .border(1.0)
                             .border_radius(6.0)
                             .border_color(
-                                *config.get().get_color(LapceColor::LAPCE_BORDER),
+                                config.get().color(LapceColor::LAPCE_BORDER),
                             )
                     })
                 },
@@ -418,8 +408,8 @@ fn keyboard_picker_view(
                     .height(ui_line_height.get() as f32 + 16.0)
                     .border(1.0)
                     .border_radius(6.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                    .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
+                    .background(config.color(LapceColor::EDITOR_BACKGROUND))
             }),
             stack((
                 text("Save")
@@ -430,18 +420,15 @@ fn keyboard_picker_view(
                             .padding_vert(8.0)
                             .border(1.0)
                             .border_radius(6.0)
-                            .border_color(
-                                *config.get_color(LapceColor::LAPCE_BORDER),
-                            )
+                            .border_color(config.color(LapceColor::LAPCE_BORDER))
                             .hover(|s| {
                                 s.cursor(CursorStyle::Pointer).background(
-                                    *config.get_color(
-                                        LapceColor::PANEL_HOVERED_BACKGROUND,
-                                    ),
+                                    config
+                                        .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                                 )
                             })
                             .active(|s| {
-                                s.background(*config.get_color(
+                                s.background(config.color(
                                     LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
                                 ))
                             })
@@ -469,18 +456,15 @@ fn keyboard_picker_view(
                             .padding_vert(8.0)
                             .border(1.0)
                             .border_radius(6.0)
-                            .border_color(
-                                *config.get_color(LapceColor::LAPCE_BORDER),
-                            )
+                            .border_color(config.color(LapceColor::LAPCE_BORDER))
                             .hover(|s| {
                                 s.cursor(CursorStyle::Pointer).background(
-                                    *config.get_color(
-                                        LapceColor::PANEL_HOVERED_BACKGROUND,
-                                    ),
+                                    config
+                                        .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                                 )
                             })
                             .active(|s| {
-                                s.background(*config.get_color(
+                                s.background(config.color(
                                     LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
                                 ))
                             })
@@ -495,7 +479,7 @@ fn keyboard_picker_view(
                     .justify_center()
                     .width_pct(100.0)
                     .margin_top(20.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
             }),
         ))
         .style(move |s| {
@@ -506,8 +490,8 @@ fn keyboard_picker_view(
                 .width(400.0)
                 .border(1.0)
                 .border_radius(6.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
+                .background(config.color(LapceColor::PANEL_BACKGROUND))
         }),
     )
     .keyboard_navigatable()

--- a/lapce-app/src/markdown.rs
+++ b/lapce-app/src/markdown.rs
@@ -28,7 +28,7 @@ pub fn parse_markdown(
         FamilyOwned::parse_list(&config.editor.font_family).collect();
 
     let default_attrs = Attrs::new()
-        .color(*config.get_color(LapceColor::EDITOR_FOREGROUND))
+        .color(config.color(LapceColor::EDITOR_FOREGROUND))
         .font_size(config.ui.font_size() as f32)
         .line_height(LineHeightValue::Normal(line_height as f32));
     let mut attr_list = AttrsList::new(default_attrs);
@@ -159,7 +159,7 @@ pub fn parse_markdown(
                     pos..pos + text.len(),
                     default_attrs
                         .family(&code_font_family)
-                        .color(*config.get_color(LapceColor::MARKDOWN_BLOCKQUOTE)),
+                        .color(config.color(LapceColor::MARKDOWN_BLOCKQUOTE)),
                 );
                 current_text.push_str(&text);
                 pos += text.len();
@@ -219,7 +219,7 @@ fn attribute_for_tag<'a>(
         Tag::BlockQuote => Some(
             default_attrs
                 .style(Style::Italic)
-                .color(*config.get_color(LapceColor::MARKDOWN_BLOCKQUOTE)),
+                .color(config.color(LapceColor::MARKDOWN_BLOCKQUOTE)),
         ),
         Tag::CodeBlock(_) => Some(default_attrs.family(code_font_family)),
         Tag::Emphasis => Some(default_attrs.style(Style::Italic)),
@@ -227,7 +227,7 @@ fn attribute_for_tag<'a>(
         // TODO: Strikethrough support
         Tag::Link(_link_type, _target, _title) => {
             // TODO: Link support
-            Some(default_attrs.color(*config.get_color(LapceColor::EDITOR_LINK)))
+            Some(default_attrs.color(config.color(LapceColor::EDITOR_LINK)))
         }
         // All other tags are currently ignored
         _ => None,
@@ -276,11 +276,11 @@ pub fn highlight_as_code(
             if let Some(color) = style
                 .fg_color
                 .as_ref()
-                .and_then(|fg| config.get_style_color(fg))
+                .and_then(|fg| config.style_color(fg))
             {
                 attr_list.add_span(
                     start_offset + range.start..start_offset + range.end,
-                    default_attrs.color(*color),
+                    default_attrs.color(color),
                 );
             }
         }

--- a/lapce-app/src/panel/debug_view.rs
+++ b/lapce-app/src/panel/debug_view.rs
@@ -267,9 +267,7 @@ fn debug_processes(
                             s.size(size, size)
                                 .margin_vert(5.0)
                                 .margin_horiz(10.0)
-                                .color(
-                                    *config.get_color(LapceColor::LAPCE_ICON_ACTIVE),
-                                )
+                                .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                         })
                     },
                     label(move || p.config.name.clone()).style(|s| {
@@ -307,16 +305,13 @@ fn debug_processes(
                         .items_center()
                         .apply_if(is_active(), |s| {
                             s.background(
-                                *config
-                                    .get_color(LapceColor::PANEL_CURRENT_BACKGROUND),
+                                config.color(LapceColor::PANEL_CURRENT_BACKGROUND),
                             )
                         })
                         .hover(|s| {
                             s.cursor(CursorStyle::Pointer).background(
-                                (*config.get_color(
-                                    LapceColor::PANEL_HOVERED_BACKGROUND,
-                                ))
-                                .with_alpha_factor(0.3),
+                                (config.color(LapceColor::PANEL_HOVERED_BACKGROUND))
+                                    .with_alpha_factor(0.3),
                             )
                         })
                 })
@@ -385,7 +380,7 @@ fn variables_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                             let size = config.ui.icon_size() as f32;
 
                             let color = if reference > 0 {
-                                *config.get_color(LapceColor::LAPCE_ICON_ACTIVE)
+                                config.color(LapceColor::LAPCE_ICON_ACTIVE)
                             } else {
                                 Color::TRANSPARENT
                             };
@@ -396,7 +391,7 @@ fn variables_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                             s.apply_if(!type_exists || reference == 0, |s| s.hide())
                         }),
                         text(node.item.ty().unwrap_or("")).style(move |s| {
-                            s.color(*config.get().get_style_color("type").unwrap())
+                            s.color(config.get().style_color("type").unwrap())
                                 .apply_if(!type_exists || reference == 0, |s| {
                                     s.hide()
                                 })
@@ -431,9 +426,11 @@ fn variables_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                             .min_width_pct(100.0)
                             .hover(|s| {
                                 s.apply_if(reference > 0, |s| {
-                                    s.background(*config.get().get_color(
-                                        LapceColor::PANEL_HOVERED_BACKGROUND,
-                                    ))
+                                    s.background(
+                                        config.get().color(
+                                            LapceColor::PANEL_HOVERED_BACKGROUND,
+                                        ),
+                                    )
                                 })
                             })
                     })
@@ -465,9 +462,7 @@ fn debug_stack_frames(
             .style(move |s| {
                 s.padding_horiz(10.0).min_width_pct(100.0).hover(move |s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config
-                            .get()
-                            .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.get().color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
             }),
@@ -501,15 +496,15 @@ fn debug_stack_frames(
                     label(move || frame.name.clone()).style(move |s| {
                         s.hover(|s| {
                             s.background(
-                                *config
+                                config
                                     .get()
-                                    .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                                    .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                             )
                         })
                     }),
                     label(move || source_path.clone()).style(move |s| {
                         s.margin_left(10.0)
-                            .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                            .color(config.get().color(LapceColor::EDITOR_DIM))
                             .font_style(FontStyle::Italic)
                             .apply_if(!has_source, |s| s.hide())
                     }),
@@ -542,12 +537,11 @@ fn debug_stack_frames(
                         .padding_right(10.0)
                         .min_width_pct(100.0)
                         .apply_if(!has_source, |s| {
-                            s.color(*config.get_color(LapceColor::EDITOR_DIM))
+                            s.color(config.color(LapceColor::EDITOR_DIM))
                         })
                         .hover(|s| {
                             s.background(
-                                *config
-                                    .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                                config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                             )
                             .apply_if(has_source, |s| s.cursor(CursorStyle::Pointer))
                         })
@@ -711,9 +705,7 @@ fn breakpoints_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                             s.text_ellipsis()
                                 .flex_grow(1.0)
                                 .flex_basis(0.0)
-                                .color(
-                                    *config.get().get_color(LapceColor::EDITOR_DIM),
-                                )
+                                .color(config.get().color(LapceColor::EDITOR_DIM))
                                 .min_width(0.0)
                                 .margin_left(6.0)
                                 .apply_if(folder_empty, |s| s.hide())
@@ -723,9 +715,9 @@ fn breakpoints_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                         s.items_center().padding_horiz(10.0).width_pct(100.0).hover(
                             |s| {
                                 s.background(
-                                    *config.get().get_color(
-                                        LapceColor::PANEL_HOVERED_BACKGROUND,
-                                    ),
+                                    config
+                                        .get()
+                                        .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                                 )
                             },
                         )

--- a/lapce-app/src/panel/global_search_view.rs
+++ b/lapce-app/src/panel/global_search_view.rs
@@ -94,7 +94,7 @@ pub fn global_search_panel(
                     .items_center()
                     .border(1.0)
                     .border_radius(6.0)
-                    .border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.get().color(LapceColor::LAPCE_BORDER))
             }),
         )
         .style(|s| s.width_pct(100.0).padding(10.0)),
@@ -164,17 +164,14 @@ fn search_result(
                                     .size(size, size)
                                     .min_size(size, size)
                                     .color(
-                                        *config.get_color(
-                                            LapceColor::LAPCE_ICON_ACTIVE,
-                                        ),
+                                        config.color(LapceColor::LAPCE_ICON_ACTIVE),
                                     )
                             }),
                             svg(move || config.get().file_svg(&path).0).style(
                                 move |s| {
                                     let config = config.get();
                                     let size = config.ui.icon_size() as f32;
-                                    let color =
-                                        config.file_svg(&style_path).1.copied();
+                                    let color = config.file_svg(&style_path).1;
                                     s.margin_right(6.0)
                                         .size(size, size)
                                         .min_size(size, size)
@@ -189,9 +186,7 @@ fn search_result(
                                 }),
                                 label(move || folder.clone()).style(move |s| {
                                     s.color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::EDITOR_DIM),
+                                        config.get().color(LapceColor::EDITOR_DIM),
                                     )
                                     .min_width(0.0)
                                     .text_ellipsis()
@@ -208,7 +203,7 @@ fn search_result(
                                 .items_center()
                                 .hover(|s| {
                                     s.cursor(CursorStyle::Pointer).background(
-                                        *config.get().get_color(
+                                        config.get().color(
                                             LapceColor::PANEL_HOVERED_BACKGROUND,
                                         ),
                                     )
@@ -266,9 +261,7 @@ fn search_result(
                                             .collect()
                                     },
                                     move || {
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::EDITOR_FOCUS)
+                                        config.get().color(LapceColor::EDITOR_FOCUS)
                                     },
                                 )
                                 .style(move |s| {
@@ -277,7 +270,7 @@ fn search_result(
                                     s.margin_left(10.0 + icon_size + 6.0).hover(
                                         |s| {
                                             s.cursor(CursorStyle::Pointer)
-                                                .background(*config.get_color(
+                                                .background(config.color(
                                                 LapceColor::PANEL_HOVERED_BACKGROUND,
                                             ))
                                         },

--- a/lapce-app/src/panel/plugin_view.rs
+++ b/lapce-app/src/panel/plugin_view.rs
@@ -178,9 +178,7 @@ fn installed_view(plugin: PluginData) -> impl View {
                 .padding_vert(5.0)
                 .hover(|s| {
                     s.background(
-                        *config
-                            .get()
-                            .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.get().color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
         })
@@ -217,54 +215,51 @@ fn available_view(plugin: PluginData) -> impl View {
     let internal_command = plugin.common.internal_command;
 
     let local_plugin = plugin.clone();
-    let install_button = move |id: VoltID,
-                               info: RwSignal<VoltInfo>,
-                               installing: RwSignal<bool>| {
-        let plugin = local_plugin.clone();
-        let installed = create_memo(move |_| {
-            installed.with(|installed| installed.contains_key(&id))
-        });
-        label(move || {
-            if installed.get() {
-                "Installed".to_string()
-            } else if installing.get() {
-                "Installing".to_string()
-            } else {
-                "Install".to_string()
-            }
-        })
-        .disabled(move || installed.get() || installing.get())
-        .on_click_stop(move |_| {
-            plugin.install_volt(info.get_untracked());
-        })
-        .style(move |s| {
-            let config = config.get();
-            s.color(*config.get_color(LapceColor::LAPCE_BUTTON_PRIMARY_FOREGROUND))
-                .background(
-                    *config.get_color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND),
-                )
-                .margin_left(6.0)
-                .padding_horiz(6.0)
-                .border_radius(6.0)
-                .hover(|s| {
-                    s.cursor(CursorStyle::Pointer).background(
-                        config
-                            .get_color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND)
-                            .with_alpha_factor(0.8),
+    let install_button =
+        move |id: VoltID, info: RwSignal<VoltInfo>, installing: RwSignal<bool>| {
+            let plugin = local_plugin.clone();
+            let installed = create_memo(move |_| {
+                installed.with(|installed| installed.contains_key(&id))
+            });
+            label(move || {
+                if installed.get() {
+                    "Installed".to_string()
+                } else if installing.get() {
+                    "Installing".to_string()
+                } else {
+                    "Install".to_string()
+                }
+            })
+            .disabled(move || installed.get() || installing.get())
+            .on_click_stop(move |_| {
+                plugin.install_volt(info.get_untracked());
+            })
+            .style(move |s| {
+                let config = config.get();
+                s.color(config.color(LapceColor::LAPCE_BUTTON_PRIMARY_FOREGROUND))
+                    .background(
+                        config.color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND),
                     )
-                })
-                .active(|s| {
-                    s.background(
-                        config
-                            .get_color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND)
-                            .with_alpha_factor(0.6),
-                    )
-                })
-                .disabled(|s| {
-                    s.background(*config.get_color(LapceColor::EDITOR_DIM))
-                })
-        })
-    };
+                    .margin_left(6.0)
+                    .padding_horiz(6.0)
+                    .border_radius(6.0)
+                    .hover(|s| {
+                        s.cursor(CursorStyle::Pointer).background(
+                            config
+                                .color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND)
+                                .with_alpha_factor(0.8),
+                        )
+                    })
+                    .active(|s| {
+                        s.background(
+                            config
+                                .color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND)
+                                .with_alpha_factor(0.6),
+                        )
+                    })
+                    .disabled(|s| s.background(config.color(LapceColor::EDITOR_DIM)))
+            })
+        };
 
     let view_fn = move |(_, id, volt): (usize, VoltID, AvailableVoltData)| {
         let info = volt.info.get_untracked();
@@ -322,9 +317,7 @@ fn available_view(plugin: PluginData) -> impl View {
                 .padding_vert(5.0)
                 .hover(|s| {
                     s.background(
-                        *config
-                            .get()
-                            .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.get().color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
         })
@@ -362,10 +355,10 @@ fn available_view(plugin: PluginData) -> impl View {
                 s.width_pct(100.0)
                     .cursor(CursorStyle::Text)
                     .items_center()
-                    .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                    .background(config.color(LapceColor::EDITOR_BACKGROUND))
                     .border(1.0)
                     .border_radius(6.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
             })
         })
         .style(|s| s.padding(10.0).width_pct(100.0)),

--- a/lapce-app/src/panel/problem_view.rs
+++ b/lapce-app/src/panel/problem_view.rs
@@ -37,7 +37,7 @@ pub fn problem_panel(
             s.flex_col()
                 .flex_basis(0.0)
                 .flex_grow(1.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
                 .apply_if(is_bottom, |s| s.border_right(1.0))
                 .apply_if(!is_bottom, |s| s.border_bottom(1.0))
         }),
@@ -125,8 +125,8 @@ fn file_view(
     let icon_color = move || {
         let config = config.get();
         match severity {
-            DiagnosticSeverity::ERROR => *config.get_color(LapceColor::LAPCE_ERROR),
-            _ => *config.get_color(LapceColor::LAPCE_WARN),
+            DiagnosticSeverity::ERROR => config.color(LapceColor::LAPCE_ERROR),
+            _ => config.color(LapceColor::LAPCE_WARN),
         }
     };
 
@@ -150,7 +150,7 @@ fn file_view(
                         s.margin_right(6.0).max_width_pct(100.0).text_ellipsis()
                     }),
                     label(move || folder.clone()).style(move |s| {
-                        s.color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                        s.color(config.get().color(LapceColor::EDITOR_DIM))
                             .min_width(0.0)
                             .text_ellipsis()
                     }),
@@ -168,7 +168,7 @@ fn file_view(
                     .padding_right(10.0)
                     .hover(|s| {
                         s.cursor(CursorStyle::Pointer).background(
-                            *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                            config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                         )
                     })
             }),
@@ -185,12 +185,12 @@ fn file_view(
                     let size = config.ui.icon_size() as f32;
                     s.margin_right(6.0)
                         .size(size, size)
-                        .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                        .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                 }),
                 svg(move || config.get().file_svg(&path).0).style(move |s| {
                     let config = config.get();
                     let size = config.ui.icon_size() as f32;
-                    let color = config.file_svg(&style_path).1.copied();
+                    let color = config.file_svg(&style_path).1;
                     s.min_width(size)
                         .size(size, size)
                         .apply_opt(color, Style::color)
@@ -274,9 +274,7 @@ fn item_view(
             .style(move |s| {
                 s.width_pct(100.0).min_width(0.0).hover(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config
-                            .get()
-                            .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.get().color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
             })
@@ -342,8 +340,7 @@ fn related_view(
                         .min_width(0.0)
                         .hover(|s| {
                             s.cursor(CursorStyle::Pointer).background(
-                                *config
-                                    .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                                config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                             )
                         })
                 })
@@ -355,7 +352,7 @@ fn related_view(
                 let config = config.get();
                 let size = config.ui.icon_size() as f32;
                 s.size(size, size)
-                    .color(*config.get_color(LapceColor::EDITOR_DIM))
+                    .color(config.color(LapceColor::EDITOR_DIM))
             }),
             label(|| " ".to_string()),
         ))
@@ -369,7 +366,7 @@ fn related_view(
         s.width_pct(100.0)
             .min_width(0.0)
             .items_start()
-            .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+            .color(config.get().color(LapceColor::EDITOR_DIM))
             .apply_if(is_empty, |s| s.hide())
     })
 }

--- a/lapce-app/src/panel/source_control_view.rs
+++ b/lapce-app/src/panel/source_control_view.rs
@@ -66,7 +66,7 @@ pub fn source_control_panel(
                             s.absolute()
                                 .items_center()
                                 .height(config.editor.line_height() as f32)
-                                .color(*config.get_color(LapceColor::EDITOR_DIM))
+                                .color(config.color(LapceColor::EDITOR_DIM))
                                 .apply_if(!is_empty.get(), |s| s.hide())
                         }),
                     ))
@@ -139,8 +139,8 @@ pub fn source_control_panel(
                     .border(1.0)
                     .padding(-1.0)
                     .border_radius(6.0)
-                    .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-                    .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                    .border_color(config.color(LapceColor::LAPCE_BORDER))
+                    .background(config.color(LapceColor::EDITOR_BACKGROUND))
             }),
             {
                 let source_control = source_control.clone();
@@ -156,18 +156,15 @@ pub fn source_control_panel(
                             .justify_center()
                             .border(1.0)
                             .border_radius(6.0)
-                            .border_color(
-                                *config.get_color(LapceColor::LAPCE_BORDER),
-                            )
+                            .border_color(config.color(LapceColor::LAPCE_BORDER))
                             .hover(|s| {
                                 s.cursor(CursorStyle::Pointer).background(
-                                    *config.get_color(
-                                        LapceColor::PANEL_HOVERED_BACKGROUND,
-                                    ),
+                                    config
+                                        .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                                 )
                             })
                             .active(|s| {
-                                s.background(*config.get_color(
+                                s.background(config.color(
                                     LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
                                 ))
                             })
@@ -235,7 +232,7 @@ fn file_diffs_view(source_control: SourceControlData) -> impl View {
             svg(move || config.get().file_svg(&path).0).style(move |s| {
                 let config = config.get();
                 let size = config.ui.icon_size() as f32;
-                let color = config.file_svg(&style_path).1.copied();
+                let color = config.file_svg(&style_path).1;
                 s.min_width(size)
                     .size(size, size)
                     .margin(6.0)
@@ -259,7 +256,7 @@ fn file_diffs_view(source_control: SourceControlData) -> impl View {
                 s.text_ellipsis()
                     .flex_grow(1.0)
                     .flex_basis(0.0)
-                    .color(*config.get().get_color(LapceColor::EDITOR_DIM))
+                    .color(config.get().color(LapceColor::EDITOR_DIM))
                     .min_width(0.0)
             }),
             container({
@@ -283,8 +280,8 @@ fn file_diffs_view(source_control: SourceControlData) -> impl View {
                             LapceColor::SOURCE_CONTROL_MODIFIED
                         }
                     };
-                    let color = config.get_color(color);
-                    s.min_width(size).size(size, size).color(*color)
+                    let color = config.color(color);
+                    s.min_width(size).size(size, size).color(color)
                 })
             })
             .style(|s| {
@@ -328,9 +325,7 @@ fn file_diffs_view(source_control: SourceControlData) -> impl View {
                 .width_pct(100.0)
                 .items_center()
                 .hover(|s| {
-                    s.background(
-                        *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
-                    )
+                    s.background(config.color(LapceColor::PANEL_HOVERED_BACKGROUND))
                 })
         })
     };

--- a/lapce-app/src/panel/terminal_view.rs
+++ b/lapce-app/src/panel/terminal_view.rs
@@ -115,9 +115,11 @@ fn terminal_tab_header(window_tab_data: Rc<WindowTabData>) -> impl View {
                                     .style(move |s| {
                                         let config = config.get();
                                         let size = config.ui.icon_size() as f32;
-                                        s.size(size, size).color(*config.get_color(
-                                            LapceColor::LAPCE_ICON_ACTIVE,
-                                        ))
+                                        s.size(size, size).color(
+                                            config.color(
+                                                LapceColor::LAPCE_ICON_ACTIVE,
+                                            ),
+                                        )
                                     }),
                             )
                             .style(|s| s.padding_horiz(10.0).padding_vert(12.0)),
@@ -143,15 +145,13 @@ fn terminal_tab_header(window_tab_data: Rc<WindowTabData>) -> impl View {
                                     .height(header_height.get() - 15.0)
                                     .border_right(1.0)
                                     .border_color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::LAPCE_BORDER),
+                                        config.get().color(LapceColor::LAPCE_BORDER),
                                     )
                             }),
                         ))
                         .style(move |s| {
                             s.items_center().width(200.0).border_color(
-                                *config.get().get_color(LapceColor::LAPCE_BORDER),
+                                config.get().color(LapceColor::LAPCE_BORDER),
                             )
                         })
                     })
@@ -164,7 +164,7 @@ fn terminal_tab_header(window_tab_data: Rc<WindowTabData>) -> impl View {
                                 } else {
                                     0.0
                                 })
-                                .border_color(*config.get().get_color(
+                                .border_color(config.get().color(
                                     if focus.get()
                                         == Focus::Panel(PanelKind::Terminal)
                                     {
@@ -242,7 +242,7 @@ fn terminal_tab_header(window_tab_data: Rc<WindowTabData>) -> impl View {
         s.width_pct(100.0)
             .items_center()
             .border_bottom(1.0)
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
     })
 }
 
@@ -297,7 +297,7 @@ fn terminal_tab_split(
                     index.get() > 0,
                     |s| {
                         s.border_left(1.0).border_color(
-                            *config.get().get_color(LapceColor::LAPCE_BORDER),
+                            config.get().color(LapceColor::LAPCE_BORDER),
                         )
                     },
                 )

--- a/lapce-app/src/panel/view.rs
+++ b/lapce-app/src/panel/view.rs
@@ -76,9 +76,9 @@ pub fn panel_container_view(
                 .style(move |s| {
                     s.size_pct(100.0, 100.0).apply_if(dragging_over.get(), |s| {
                         s.background(
-                            *config
+                            config
                                 .get()
-                                .get_color(LapceColor::EDITOR_DRAG_DROP_BACKGROUND),
+                                .color(LapceColor::EDITOR_DRAG_DROP_BACKGROUND),
                         )
                     })
                 })
@@ -185,7 +185,7 @@ pub fn panel_container_view(
                         s.width(4.0).margin_left(-2.0).height_pct(100.0)
                     })
                     .apply_if(is_dragging, |s| {
-                        s.background(*config.get_color(LapceColor::EDITOR_CARET))
+                        s.background(config.color(LapceColor::EDITOR_CARET))
                             .apply_if(
                                 position == PanelContainerPosition::Bottom,
                                 |s| s.cursor(CursorStyle::RowResize),
@@ -197,7 +197,7 @@ pub fn panel_container_view(
                             .z_index(2)
                     })
                     .hover(|s| {
-                        s.background(*config.get_color(LapceColor::EDITOR_CARET))
+                        s.background(config.color(LapceColor::EDITOR_CARET))
                             .apply_if(
                                 position == PanelContainerPosition::Bottom,
                                 |s| s.cursor(CursorStyle::RowResize),
@@ -253,17 +253,17 @@ pub fn panel_container_view(
                 s.border_right(1.0)
                     .width(size as f32)
                     .height_pct(100.0)
-                    .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                    .background(config.color(LapceColor::PANEL_BACKGROUND))
             })
             .apply_if(position == PanelContainerPosition::Right, |s| {
                 s.border_left(1.0)
                     .width(size as f32)
                     .height_pct(100.0)
-                    .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                    .background(config.color(LapceColor::PANEL_BACKGROUND))
             })
             .apply_if(!is_bottom, |s| s.flex_col())
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .color(*config.get_color(LapceColor::PANEL_FOREGROUND))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .color(config.color(LapceColor::PANEL_FOREGROUND))
     })
 }
 
@@ -333,7 +333,7 @@ pub fn panel_header(
         s.padding_horiz(10.0)
             .padding_vert(6.0)
             .width_pct(100.0)
-            .background(*config.get().get_color(LapceColor::EDITOR_BACKGROUND))
+            .background(config.get().color(LapceColor::EDITOR_BACKGROUND))
     })
 }
 
@@ -399,11 +399,11 @@ fn panel_picker(
                     let config = config.get();
                     s.border(1.0)
                         .border_radius(6.0)
-                        .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                        .border_color(config.color(LapceColor::LAPCE_BORDER))
                         .padding(6.0)
                         .background(
                             config
-                                .get_color(LapceColor::PANEL_BACKGROUND)
+                                .color(LapceColor::PANEL_BACKGROUND)
                                 .with_alpha_factor(0.7),
                         )
                 })
@@ -426,9 +426,9 @@ fn panel_picker(
                             })
                         })
                         .border_color(
-                            *config
+                            config
                                 .get()
-                                .get_color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE),
+                                .color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE),
                         )
                 }),
             )))
@@ -436,7 +436,7 @@ fn panel_picker(
         },
     )
     .style(move |s| {
-        s.border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+        s.border_color(config.get().color(LapceColor::LAPCE_BORDER))
             .apply_if(
                 panels.with(|p| {
                     p.get(&position).map(|p| p.is_empty()).unwrap_or(true)

--- a/lapce-app/src/plugin.rs
+++ b/lapce-app/src/plugin.rs
@@ -692,98 +692,98 @@ pub fn plugin_info_view(plugin: PluginData, volt: VoltID) -> impl View {
             })
     });
 
-    let version_view =
-        move |plugin: PluginData, plugin_info: PluginInfo| {
-            let version_info =
-                plugin_info.as_ref().map(|(_, volt, _, latest, _)| {
-                    (
-                        volt.version.clone(),
-                        latest.as_ref().map(|i| i.version.clone()),
-                    )
-                });
-            let installing = plugin_info
+    let version_view = move |plugin: PluginData, plugin_info: PluginInfo| {
+        let version_info = plugin_info.as_ref().map(|(_, volt, _, latest, _)| {
+            (
+                volt.version.clone(),
+                latest.as_ref().map(|i| i.version.clone()),
+            )
+        });
+        let installing = plugin_info
+            .as_ref()
+            .and_then(|(_, _, _, _, installing)| *installing);
+        let local_version_info = version_info.clone();
+        let control = {
+            move |version_info: Option<(String, Option<String>)>| match version_info
                 .as_ref()
-                .and_then(|(_, _, _, _, installing)| *installing);
-            let local_version_info = version_info.clone();
-            let control = {
-                move |version_info: Option<(String, Option<String>)>| {
-                    match version_info.as_ref().map(|(v, l)| match l {
-                        Some(l) => (true, l == v),
-                        None => (false, false),
-                    }) {
-                        Some((true, true)) => "Installed ▼",
-                        Some((true, false)) => "Upgrade ▼",
-                        _ => {
-                            if installing.map(|i| i.get()).unwrap_or(false) {
-                                "Installing"
-                            } else {
-                                "Install"
-                            }
-                        }
+                .map(|(v, l)| match l {
+                    Some(l) => (true, l == v),
+                    None => (false, false),
+                }) {
+                Some((true, true)) => "Installed ▼",
+                Some((true, false)) => "Upgrade ▼",
+                _ => {
+                    if installing.map(|i| i.get()).unwrap_or(false) {
+                        "Installing"
+                    } else {
+                        "Install"
                     }
                 }
-            };
-            let local_plugin_info = plugin_info.clone();
-            let local_plugin = plugin.clone();
-            stack((
-                text(
-                    version_info
-                        .as_ref()
-                        .map(|(v, _)| format!("v{v}"))
-                        .unwrap_or_default(),
-                ),
-                label(move || control(local_version_info.clone()))
-                    .style(move |s| {
-                        let config = config.get();
-                        s.margin_left(10)
-                            .padding_horiz(10)
-                            .border_radius(6.0)
-                            .color(*config.get_color(
-                                LapceColor::LAPCE_BUTTON_PRIMARY_FOREGROUND,
-                            ))
-                            .background(*config.get_color(
-                                LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND,
-                            ))
-                            .hover(|s| {
-                                s.cursor(CursorStyle::Pointer).background(
-                        config
-                            .get_color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND)
-                            .with_alpha_factor(0.8),
-                    )
-                            })
-                            .active(|s| {
-                                s.background(
-                        config
-                            .get_color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND)
-                            .with_alpha_factor(0.6),
-                    )
-                            })
-                            .disabled(|s| {
-                                s.background(
-                                    *config.get_color(LapceColor::EDITOR_DIM),
-                                )
-                            })
-                    })
-                    .disabled(move || installing.map(|i| i.get()).unwrap_or(false))
-                    .on_click_stop(move |_| {
-                        if let Some((meta, info, _, latest, _)) =
-                            local_plugin_info.as_ref()
-                        {
-                            if let Some(meta) = meta {
-                                let menu = local_plugin.plugin_controls(
-                                    meta.to_owned(),
-                                    latest
-                                        .clone()
-                                        .unwrap_or_else(|| info.to_owned()),
-                                );
-                                show_context_menu(menu, None);
-                            } else {
-                                local_plugin.install_volt(info.to_owned());
-                            }
-                        }
-                    }),
-            ))
+            }
         };
+        let local_plugin_info = plugin_info.clone();
+        let local_plugin = plugin.clone();
+        stack((
+            text(
+                version_info
+                    .as_ref()
+                    .map(|(v, _)| format!("v{v}"))
+                    .unwrap_or_default(),
+            ),
+            label(move || control(local_version_info.clone()))
+                .style(move |s| {
+                    let config = config.get();
+                    s.margin_left(10)
+                        .padding_horiz(10)
+                        .border_radius(6.0)
+                        .color(
+                            config
+                                .color(LapceColor::LAPCE_BUTTON_PRIMARY_FOREGROUND),
+                        )
+                        .background(
+                            config
+                                .color(LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND),
+                        )
+                        .hover(|s| {
+                            s.cursor(CursorStyle::Pointer).background(
+                                config
+                                    .color(
+                                        LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND,
+                                    )
+                                    .with_alpha_factor(0.8),
+                            )
+                        })
+                        .active(|s| {
+                            s.background(
+                                config
+                                    .color(
+                                        LapceColor::LAPCE_BUTTON_PRIMARY_BACKGROUND,
+                                    )
+                                    .with_alpha_factor(0.6),
+                            )
+                        })
+                        .disabled(|s| {
+                            s.background(config.color(LapceColor::EDITOR_DIM))
+                        })
+                })
+                .disabled(move || installing.map(|i| i.get()).unwrap_or(false))
+                .on_click_stop(move |_| {
+                    if let Some((meta, info, _, latest, _)) =
+                        local_plugin_info.as_ref()
+                    {
+                        if let Some(meta) = meta {
+                            let menu = local_plugin.plugin_controls(
+                                meta.to_owned(),
+                                latest.clone().unwrap_or_else(|| info.to_owned()),
+                            );
+                            show_context_menu(menu, None);
+                        } else {
+                            local_plugin.install_volt(info.to_owned());
+                        }
+                    }
+                }),
+        ))
+    };
 
     scroll(
         dyn_container(
@@ -862,9 +862,9 @@ pub fn plugin_info_view(plugin: PluginData, volt: VoltID) -> impl View {
                                             move || repo.clone(),
                                             move || local_repo.clone(),
                                             move || {
-                                                *config.get().get_color(
-                                                    LapceColor::EDITOR_LINK,
-                                                )
+                                                config
+                                                    .get()
+                                                    .color(LapceColor::EDITOR_LINK)
                                             },
                                             internal_command,
                                         ),
@@ -880,9 +880,7 @@ pub fn plugin_info_view(plugin: PluginData, volt: VoltID) -> impl View {
                                 )
                                 .style(move |s| {
                                     s.color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::EDITOR_DIM),
+                                        config.get().color(LapceColor::EDITOR_DIM),
                                     )
                                 }),
                                 version_view(
@@ -904,7 +902,7 @@ pub fn plugin_info_view(plugin: PluginData, volt: VoltID) -> impl View {
                         }),
                         empty().style(move |s| {
                             s.margin_vert(6).height(1).width_full().background(
-                                *config.get().get_color(LapceColor::LAPCE_BORDER),
+                                config.get().color(LapceColor::LAPCE_BORDER),
                             )
                         }),
                         {
@@ -967,11 +965,9 @@ pub fn plugin_info_view(plugin: PluginData, volt: VoltID) -> impl View {
                                                 s.width_full()
                                                     .margin_vert(5.0)
                                                     .height(1.0)
-                                                    .background(
-                                                        *config.get().get_color(
-                                                            LapceColor::LAPCE_BORDER,
-                                                        ),
-                                                    )
+                                                    .background(config.get().color(
+                                                        LapceColor::LAPCE_BORDER,
+                                                    ))
                                             }))
                                         }
                                     },

--- a/lapce-app/src/settings.rs
+++ b/lapce-app/src/settings.rs
@@ -399,19 +399,16 @@ pub fn settings_view(
             s.padding_horiz(20.0)
                 .width_pct(100.0)
                 .apply_if(kind == current_kind.get(), |s| {
-                    s.background(
-                        *config.get_color(LapceColor::PANEL_CURRENT_BACKGROUND),
-                    )
+                    s.background(config.color(LapceColor::PANEL_CURRENT_BACKGROUND))
                 })
                 .hover(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
                 .active(|s| {
                     s.background(
-                        *config
-                            .get_color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
                     )
                 })
         })
@@ -469,7 +466,7 @@ pub fn settings_view(
             s.height_pct(100.0)
                 .width(200.0)
                 .border_right(1.0)
-                .border_color(*config.get().get_color(LapceColor::LAPCE_BORDER))
+                .border_color(config.get().color(LapceColor::LAPCE_BORDER))
         }),
         stack((
             container({
@@ -481,7 +478,7 @@ pub fn settings_view(
                             .border_radius(6.0)
                             .border(1.0)
                             .border_color(
-                                *config.get().get_color(LapceColor::LAPCE_BORDER),
+                                config.get().color(LapceColor::LAPCE_BORDER),
                             )
                     })
             })
@@ -620,9 +617,7 @@ fn settings_item_view(settings_data: SettingsData, item: SettingsItem) -> impl V
                                 .border(1.0)
                                 .border_radius(6.0)
                                 .border_color(
-                                    *config
-                                        .get()
-                                        .get_color(LapceColor::LAPCE_BORDER),
+                                    config.get().color(LapceColor::LAPCE_BORDER),
                                 )
                         },
                     ),
@@ -657,9 +652,9 @@ fn settings_item_view(settings_data: SettingsData, item: SettingsItem) -> impl V
                         .style(move |s| {
                             s.text_ellipsis().padding_horiz(10.0).hover(|s| {
                                 s.cursor(CursorStyle::Pointer).background(
-                                    *config.get().get_color(
-                                        LapceColor::PANEL_HOVERED_BACKGROUND,
-                                    ),
+                                    config
+                                        .get()
+                                        .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                                 )
                             })
                         })
@@ -680,9 +675,7 @@ fn settings_item_view(settings_data: SettingsData, item: SettingsItem) -> impl V
                                     let config = config.get();
                                     let size = config.ui.icon_size() as f32;
                                     s.size(size, size).color(
-                                        *config.get_color(
-                                            LapceColor::LAPCE_ICON_ACTIVE,
-                                        ),
+                                        config.color(LapceColor::LAPCE_ICON_ACTIVE),
                                     )
                                 }),
                             )
@@ -702,9 +695,7 @@ fn settings_item_view(settings_data: SettingsData, item: SettingsItem) -> impl V
                                 .border_radius(6.0)
                                 .apply_if(!expanded.get(), |s| {
                                     s.border_color(
-                                        *config
-                                            .get()
-                                            .get_color(LapceColor::LAPCE_BORDER),
+                                        config.get().color(LapceColor::LAPCE_BORDER),
                                     )
                                 })
                         }),
@@ -725,16 +716,14 @@ fn settings_item_view(settings_data: SettingsData, item: SettingsItem) -> impl V
                             .style(move |s| {
                                 let config = config.get();
                                 s.background(
-                                    *config.get_color(LapceColor::EDITOR_BACKGROUND),
+                                    config.color(LapceColor::EDITOR_BACKGROUND),
                                 )
                                 .width_pct(100.0)
                                 .max_height(300.0)
                                 .z_index(1)
                                 .border_top(1.0)
                                 .border_radius(6.0)
-                                .border_color(
-                                    *config.get_color(LapceColor::LAPCE_BORDER),
-                                )
+                                .border_color(config.color(LapceColor::LAPCE_BORDER))
                                 .apply_if(!expanded.get(), |s| s.hide())
                             }),
                         ))
@@ -751,9 +740,7 @@ fn settings_item_view(settings_data: SettingsData, item: SettingsItem) -> impl V
                                 .border(1.0)
                                 .border_radius(6.0)
                                 .border_color(
-                                    *config
-                                        .get()
-                                        .get_color(LapceColor::LAPCE_BORDER),
+                                    config.get().color(LapceColor::LAPCE_BORDER),
                                 )
                                 .apply_if(!expanded.get(), |s| {
                                     s.border_color(Color::TRANSPARENT)
@@ -770,7 +757,7 @@ fn settings_item_view(settings_data: SettingsData, item: SettingsItem) -> impl V
                         .width_pct(100.0)
                         .padding_horiz(10.0)
                         .font_size(config.ui.font_size() as f32 + 2.0)
-                        .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+                        .background(config.color(LapceColor::PANEL_BACKGROUND))
                 }))
             } else {
                 container_box(empty())
@@ -867,7 +854,7 @@ pub fn checkbox(
     svg(svg_str).base_style(move |s| {
         let config = config.get();
         let size = config.ui.font_size() as f32;
-        let color = *config.get_color(LapceColor::EDITOR_FOREGROUND);
+        let color = config.color(LapceColor::EDITOR_FOREGROUND);
 
         s.min_width(size)
             .size(size, size)
@@ -1041,9 +1028,7 @@ fn color_section_list(
                                 .border(1)
                                 .border_radius(6)
                                 .border_color(
-                                    *config
-                                        .get()
-                                        .get_color(LapceColor::LAPCE_BORDER),
+                                    config.get().color(LapceColor::LAPCE_BORDER),
                                 )
                         },
                     ),
@@ -1060,11 +1045,9 @@ fn color_section_list(
                             .border_radius(6)
                             .size(size, size)
                             .margin_left(10)
-                            .border_color(
-                                *config.get_color(LapceColor::LAPCE_BORDER),
-                            )
-                            .background(*color.unwrap_or_else(|| {
-                                config.get_color(LapceColor::EDITOR_FOREGROUND)
+                            .border_color(config.color(LapceColor::LAPCE_BORDER))
+                            .background(color.copied().unwrap_or_else(|| {
+                                config.color(LapceColor::EDITOR_FOREGROUND)
                             }))
                     }),
                     {
@@ -1106,14 +1089,13 @@ fn color_section_list(
                                     .border(1)
                                     .border_radius(6)
                                     .border_color(
-                                        *config.get_color(LapceColor::LAPCE_BORDER),
+                                        config.color(LapceColor::LAPCE_BORDER),
                                     )
                                     .apply_if(same, |s| s.hide())
                                     .active(|s| {
                                         s.background(
-                                            *config.get_color(
-                                                LapceColor::PANEL_BACKGROUND,
-                                            ),
+                                            config
+                                                .color(LapceColor::PANEL_BACKGROUND),
                                         )
                                     })
                             })

--- a/lapce-app/src/status.rs
+++ b/lapce-app/src/status.rs
@@ -109,8 +109,8 @@ pub fn status(
                     ),
                 };
 
-                let bg = *config.get_color(bg);
-                let fg = *config.get_color(fg);
+                let bg = config.color(bg);
+                let fg = config.color(fg);
 
                 s.display(display)
                     .padding_horiz(10.0)
@@ -124,12 +124,11 @@ pub fn status(
                     let config = config.get();
                     let icon_size = config.ui.icon_size() as f32;
                     s.size(icon_size, icon_size)
-                        .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                        .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                 }),
                 label(branch).style(move |s| {
-                    s.margin_left(10.0).color(
-                        *config.get().get_color(LapceColor::STATUS_FOREGROUND),
-                    )
+                    s.margin_left(10.0)
+                        .color(config.get().color(LapceColor::STATUS_FOREGROUND))
                 }),
             ))
             .style(move |s| {
@@ -143,9 +142,7 @@ pub fn status(
                 .align_items(Some(AlignItems::Center))
                 .hover(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config
-                            .get()
-                            .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.get().color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
             })
@@ -159,17 +156,14 @@ pub fn status(
                         move |s| {
                             let config = config.get();
                             let size = config.ui.icon_size() as f32;
-                            s.size(size, size).color(
-                                *config.get_color(LapceColor::LAPCE_ICON_ACTIVE),
-                            )
+                            s.size(size, size)
+                                .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                         },
                     ),
                     label(move || diagnostic_count.get().0.to_string()).style(
                         move |s| {
                             s.margin_left(5.0).color(
-                                *config
-                                    .get()
-                                    .get_color(LapceColor::STATUS_FOREGROUND),
+                                config.get().color(LapceColor::STATUS_FOREGROUND),
                             )
                         },
                     ),
@@ -177,17 +171,15 @@ pub fn status(
                         move |s| {
                             let config = config.get();
                             let size = config.ui.icon_size() as f32;
-                            s.size(size, size).margin_left(5.0).color(
-                                *config.get_color(LapceColor::LAPCE_ICON_ACTIVE),
-                            )
+                            s.size(size, size)
+                                .margin_left(5.0)
+                                .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                         },
                     ),
                     label(move || diagnostic_count.get().1.to_string()).style(
                         move |s| {
                             s.margin_left(5.0).color(
-                                *config
-                                    .get()
-                                    .get_color(LapceColor::STATUS_FOREGROUND),
+                                config.get().color(LapceColor::STATUS_FOREGROUND),
                             )
                         },
                     ),
@@ -201,9 +193,9 @@ pub fn status(
                         .items_center()
                         .hover(|s| {
                             s.cursor(CursorStyle::Pointer).background(
-                                *config
+                                config
                                     .get()
-                                    .get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                                    .color(LapceColor::PANEL_HOVERED_BACKGROUND),
                             )
                         })
                 })
@@ -295,7 +287,7 @@ pub fn status(
         .style(move |s| {
             s.height_pct(100.0)
                 .items_center()
-                .color(*config.get().get_color(LapceColor::STATUS_FOREGROUND))
+                .color(config.get().color(LapceColor::STATUS_FOREGROUND))
         }),
         stack({
             let palette_clone = palette.clone();
@@ -352,10 +344,10 @@ pub fn status(
                 .height_pct(100.0)
                 .padding_horiz(10.0)
                 .items_center()
-                .color(*config.get_color(LapceColor::STATUS_FOREGROUND))
+                .color(config.color(LapceColor::STATUS_FOREGROUND))
                 .hover(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
             });
@@ -389,10 +381,10 @@ pub fn status(
                 .height_pct(100.0)
                 .padding_horiz(10.0)
                 .items_center()
-                .color(*config.get_color(LapceColor::STATUS_FOREGROUND))
+                .color(config.color(LapceColor::STATUS_FOREGROUND))
                 .hover(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
             });
@@ -414,8 +406,8 @@ pub fn status(
     .style(move |s| {
         let config = config.get();
         s.border_top(1.0)
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .background(*config.get_color(LapceColor::STATUS_BACKGROUND))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .background(config.color(LapceColor::STATUS_BACKGROUND))
             .height(config.ui.status_height() as f32)
             .align_items(Some(AlignItems::Center))
     })
@@ -441,7 +433,7 @@ fn progress_view(
             }))
             .style(move |s| {
                 s.margin_left(10.0)
-                    .color(*config.get().get_color(LapceColor::STATUS_FOREGROUND))
+                    .color(config.get().color(LapceColor::STATUS_FOREGROUND))
             })
         },
     )

--- a/lapce-app/src/terminal/view.rs
+++ b/lapce-app/src/terminal/view.rs
@@ -215,7 +215,7 @@ impl View for TerminalView {
             text_layout.set_text(
                 &format!("Terminal failed to launch. Error: {error}"),
                 AttrsList::new(
-                    attrs.color(*config.get_color(LapceColor::EDITOR_FOREGROUND)),
+                    attrs.color(config.color(LapceColor::EDITOR_FOREGROUND)),
                 ),
             );
             cx.draw_text(
@@ -259,7 +259,7 @@ impl View for TerminalView {
                 let y1 = y0 + line_height;
                 cx.fill(
                     &Rect::new(x0, y0, x1, y1),
-                    config.get_color(LapceColor::EDITOR_SELECTION),
+                    config.color(LapceColor::EDITOR_SELECTION),
                     0.0,
                 );
             }
@@ -269,14 +269,14 @@ impl View for TerminalView {
                 * line_height;
             cx.fill(
                 &Rect::new(0.0, y, self.size.width, y + line_height),
-                config.get_color(LapceColor::EDITOR_CURRENT_LINE),
+                config.color(LapceColor::EDITOR_CURRENT_LINE),
                 0.0,
             );
         }
 
         let cursor_point = &content.cursor.point;
 
-        let term_bg = *config.get_color(LapceColor::TERMINAL_BACKGROUND);
+        let term_bg = config.color(LapceColor::TERMINAL_BACKGROUND);
         let mut text_layout = TextLayout::new();
         for item in content.display_iter {
             let point = item.point;
@@ -321,12 +321,12 @@ impl View for TerminalView {
                     if self.run_config.with_untracked(|run_config| {
                         run_config.as_ref().map(|r| r.stopped).unwrap_or(false)
                     }) {
-                        config.get_color(LapceColor::LAPCE_ERROR)
+                        config.color(LapceColor::LAPCE_ERROR)
                     } else {
-                        config.get_color(LapceColor::TERMINAL_CURSOR)
+                        config.color(LapceColor::TERMINAL_CURSOR)
                     }
                 } else {
-                    config.get_color(LapceColor::EDITOR_CARET)
+                    config.color(LapceColor::EDITOR_CARET)
                 };
                 if self.is_focused {
                     cx.fill(&rect, cursor_color, 0.0);

--- a/lapce-app/src/text_area.rs
+++ b/lapce-app/src/text_area.rs
@@ -24,9 +24,9 @@ pub fn text_area(
         let config = config.get();
         let font_size = config.ui.font_size();
         let font_family = config.ui.font_family();
-        let color = config.get_color(LapceColor::EDITOR_FOREGROUND);
+        let color = config.color(LapceColor::EDITOR_FOREGROUND);
         let attrs = Attrs::new()
-            .color(*color)
+            .color(color)
             .family(&font_family)
             .font_size(font_size as f32)
             .line_height(LineHeightValue::Normal(line_height));
@@ -47,9 +47,9 @@ pub fn text_area(
         let config = config.get_untracked();
         let font_size = config.ui.font_size();
         let font_family = config.ui.font_family();
-        let color = config.get_color(LapceColor::EDITOR_FOREGROUND);
+        let color = config.color(LapceColor::EDITOR_FOREGROUND);
         let attrs = Attrs::new()
-            .color(*color)
+            .color(color)
             .family(&font_family)
             .font_size(font_size as f32)
             .line_height(LineHeightValue::Normal(1.2));
@@ -101,9 +101,7 @@ pub fn text_area(
                         .margin_left(cursor_pos.x as f32 - 1.0)
                         .margin_top(cursor_pos.y as f32)
                         .border_left(2.0)
-                        .border_color(
-                            *config.get().get_color(LapceColor::EDITOR_CARET),
-                        )
+                        .border_color(config.get().color(LapceColor::EDITOR_CARET))
                         .apply_if(!is_active(), |s| s.hide())
                 }),
             ))
@@ -115,7 +113,7 @@ pub fn text_area(
         let config = config.get();
         s.border(1.0)
             .border_radius(6.0)
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
-            .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .background(config.color(LapceColor::EDITOR_BACKGROUND))
     })
 }

--- a/lapce-app/src/text_input.rs
+++ b/lapce-app/src/text_input.rs
@@ -632,7 +632,7 @@ impl View for TextInput {
                             &Rect::ZERO
                                 .with_size(Size::new(max - min, height))
                                 .with_origin(Point::new(min + point.x, point.y)),
-                            *config.get_color(LapceColor::EDITOR_SELECTION),
+                            config.color(LapceColor::EDITOR_SELECTION),
                             0.0,
                         );
                     }
@@ -665,11 +665,7 @@ impl View for TextInput {
                         end_point.y + end_position.glyph_descent,
                     ),
                 );
-                cx.stroke(
-                    &line,
-                    *config.get_color(LapceColor::EDITOR_FOREGROUND),
-                    1.0,
-                );
+                cx.stroke(&line, config.color(LapceColor::EDITOR_FOREGROUND), 1.0);
             }
 
             if !self.hide_cursor.get_untracked()
@@ -695,10 +691,7 @@ impl View for TextInput {
 
                 cx.stroke(
                     &line,
-                    *self
-                        .config
-                        .get_untracked()
-                        .get_color(LapceColor::EDITOR_CARET),
+                    self.config.get_untracked().color(LapceColor::EDITOR_CARET),
                     2.0,
                 );
             }

--- a/lapce-app/src/title.rs
+++ b/lapce-app/src/title.rs
@@ -46,7 +46,7 @@ fn left(
             move |s| {
                 let config = config.get();
                 s.size(16.0, 16.0)
-                    .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                    .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
             },
         ))
         .style(move |s| s.margin_horiz(10.0).apply_if(is_macos, |s| s.hide())),
@@ -62,11 +62,11 @@ fn left(
                 let config = config.get();
                 let size = (config.ui.icon_size() as f32 + 2.0).min(30.0);
                 s.size(size, size).color(if is_local {
-                    *config.get_color(LapceColor::LAPCE_ICON_ACTIVE)
+                    config.color(LapceColor::LAPCE_ICON_ACTIVE)
                 } else {
                     match proxy_status.get() {
                         Some(_) => Color::WHITE,
-                        None => *config.get_color(LapceColor::LAPCE_ICON_ACTIVE),
+                        None => config.color(LapceColor::LAPCE_ICON_ACTIVE),
                     }
                 })
             },
@@ -94,13 +94,13 @@ fn left(
             } else {
                 match proxy_status.get() {
                     Some(ProxyStatus::Connected) => {
-                        *config.get_color(LapceColor::LAPCE_REMOTE_CONNECTED)
+                        config.color(LapceColor::LAPCE_REMOTE_CONNECTED)
                     }
                     Some(ProxyStatus::Connecting) => {
-                        *config.get_color(LapceColor::LAPCE_REMOTE_CONNECTING)
+                        config.color(LapceColor::LAPCE_REMOTE_CONNECTING)
                     }
                     Some(ProxyStatus::Disconnected) => {
-                        *config.get_color(LapceColor::LAPCE_REMOTE_DISCONNECTED)
+                        config.color(LapceColor::LAPCE_REMOTE_DISCONNECTED)
                     }
                     None => Color::TRANSPARENT,
                 }
@@ -111,13 +111,12 @@ fn left(
                 .background(color)
                 .hover(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config.get_color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
                     )
                 })
                 .active(|s| {
                     s.cursor(CursorStyle::Pointer).background(
-                        *config
-                            .get_color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
+                        config.color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
                     )
                 })
         }),
@@ -209,7 +208,7 @@ fn middle(
                         let config = config.get();
                         let icon_size = config.ui.icon_size() as f32;
                         s.size(icon_size, icon_size)
-                            .color(*config.get_color(LapceColor::LAPCE_ICON_ACTIVE))
+                            .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
                     },
                 ),
                 label(move || {
@@ -242,9 +241,9 @@ fn middle(
                 .justify_content(Some(JustifyContent::Center))
                 .align_items(Some(AlignItems::Center))
                 .border(1.0)
-                .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+                .border_color(config.color(LapceColor::LAPCE_BORDER))
                 .border_radius(6.0)
-                .background(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                .background(config.color(LapceColor::EDITOR_BACKGROUND))
         }),
         stack((
             clickable_icon(
@@ -354,11 +353,11 @@ fn right(
             container(label(|| "1".to_string()).style(move |s| {
                 let config = config.get();
                 s.font_size(10.0)
-                    .color(*config.get_color(LapceColor::EDITOR_BACKGROUND))
+                    .color(config.color(LapceColor::EDITOR_BACKGROUND))
                     .border_radius(100.0)
                     .margin_left(5.0)
                     .margin_top(10.0)
-                    .background(*config.get_color(LapceColor::EDITOR_CARET))
+                    .background(config.color(LapceColor::EDITOR_CARET))
             }))
             .style(move |s| {
                 let has_update = has_update();
@@ -433,9 +432,9 @@ pub fn title(window_tab_data: Rc<WindowTabData>) -> impl View {
         s.width_pct(100.0)
             .height(37.0)
             .items_center()
-            .background(*config.get_color(LapceColor::PANEL_BACKGROUND))
+            .background(config.color(LapceColor::PANEL_BACKGROUND))
             .border_bottom(1.0)
-            .border_color(*config.get_color(LapceColor::LAPCE_BORDER))
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
     })
 }
 


### PR DESCRIPTION
This PR changes `get_color`/`get_style_color` -> `color`/`style_color`, and changes the return from `&Color` -> `Color`.  

The aim for this was mostly to make performing these very common operations simpler. This fits other getter-style functions, like we use `terminal_font_family`/`font_size`/`symbol_svg` instead of prefixing `get` on them.