### PR TITLE
Remove LapceConfig from do_insert

### DIFF
--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -376,6 +376,43 @@ pub struct DocLineStyling {
     config: Arc<LapceConfig>,
     doc: Document<DocBackend>,
 }
+impl DocLineStyling {
+    /// Iterate over the editor diagnostics on this line
+    fn iter_diagnostics(&self) -> impl Iterator<Item = EditorDiagnostic> + '_ {
+        self.config
+            .editor
+            .enable_completion_lens
+            .then_some(())
+            .map(|_| self.doc.backend.diagnostics.diagnostics.get_untracked())
+            .into_iter()
+            .flatten()
+            .filter(|diag| {
+                diag.diagnostic.range.end.line as usize == self.line
+                    && diag.diagnostic.severity < Some(DiagnosticSeverity::HINT)
+            })
+    }
+
+    /// Get the max severity of the diagnostics.  
+    /// This is used to determine the color given to the background of the line
+    fn max_diag_severity(&self) -> Option<DiagnosticSeverity> {
+        let mut max_severity = None;
+        for diag in self.iter_diagnostics() {
+            match (diag.diagnostic.severity, max_severity) {
+                (Some(severity), Some(max)) => {
+                    if severity < max {
+                        max_severity = Some(severity);
+                    }
+                }
+                (Some(severity), None) => {
+                    max_severity = Some(severity);
+                }
+                _ => {}
+            }
+        }
+
+        max_severity
+    }
+}
 impl LineStyling for DocLineStyling {
     fn line_height(&self) -> f32 {
         self.config.editor.line_height() as f32
@@ -457,8 +494,6 @@ impl LineStyling for DocLineStyling {
         // overall.
         let mut text: SmallVec<[PhantomText; 6]> = hints.collect();
 
-        // The max severity is used to determine the color given to the background of the line
-        let mut max_severity = None;
         // If error lens is enabled, and the diagnostics field is filled, then get the diagnostics
         // that end on this line which have a severity worse than HINT and convert them into
         // PhantomText instances
@@ -474,18 +509,6 @@ impl LineStyling for DocLineStyling {
                     && diag.diagnostic.severity < Some(DiagnosticSeverity::HINT)
             })
             .map(|diag| {
-                match (diag.diagnostic.severity, max_severity) {
-                    (Some(severity), Some(max)) => {
-                        if severity < max {
-                            max_severity = Some(severity);
-                        }
-                    }
-                    (Some(severity), None) => {
-                        max_severity = Some(severity);
-                    }
-                    _ => {}
-                }
-
                 let col = self.doc.buffer.with_untracked(|buffer| {
                     buffer.offset_of_line(self.line + 1)
                         - buffer.offset_of_line(self.line)
@@ -592,7 +615,7 @@ impl LineStyling for DocLineStyling {
             }
         });
 
-        PhantomTextLine { text, max_severity }
+        PhantomTextLine { text }
     }
 
     /// Get the style information for the particular line from semantic/syntax highlighting.
@@ -848,7 +871,8 @@ impl Backend for DocBackend {
         text_layout_line.extra_style.clear();
         let text_layout = &text_layout_line.text;
 
-        let phantom_text = doc.line_phantom_text(line);
+        let styling = doc.line_styling(line);
+        let phantom_text = styling.phantom_text();
 
         let phantom_styles = phantom_text
             .offset_size_iter()
@@ -869,7 +893,7 @@ impl Backend for DocBackend {
         text_layout_line.extra_style.extend(phantom_styles);
 
         // Add the styling for the diagnostic severity, if applicable
-        if let Some(max_severity) = phantom_text.max_severity {
+        if let Some(max_severity) = styling.max_diag_severity() {
             let theme_prop = if max_severity == DiagnosticSeverity::ERROR {
                 LapceColor::ERROR_LENS_ERROR_BACKGROUND
             } else if max_severity == DiagnosticSeverity::WARNING {

--- a/lapce-app/src/doc/phantom_text.rs
+++ b/lapce-app/src/doc/phantom_text.rs
@@ -1,5 +1,4 @@
 use floem::peniko::Color;
-use lsp_types::DiagnosticSeverity;
 use smallvec::SmallVec;
 
 /// `PhantomText` is for text that is not in the actual document, but should be rendered with it.  
@@ -37,9 +36,6 @@ pub enum PhantomTextKind {
 pub struct PhantomTextLine {
     /// This uses a smallvec because most lines rarely have more than a couple phantom texts
     pub text: SmallVec<[PhantomText; 6]>,
-    /// Maximum diagnostic severity, so that we can color the background as an error if there is a
-    /// warning and error on the line. (For error lens)
-    pub max_severity: Option<DiagnosticSeverity>,
 }
 
 impl PhantomTextLine {

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -2617,12 +2617,7 @@ impl KeyPressFocus for EditorData {
             // normal editor receive char
             if self.get_mode() == Mode::Insert {
                 let mut cursor = self.cursor.get_untracked();
-                let config = self.common.config.get_untracked();
-                let deltas =
-                    self.view
-                        .doc
-                        .get_untracked()
-                        .do_insert(&mut cursor, c, &config);
+                let deltas = self.view.doc.get_untracked().do_insert(&mut cursor, c);
                 self.cursor.set(cursor);
 
                 if !c

--- a/lapce-app/src/editor/visual_line.rs
+++ b/lapce-app/src/editor/visual_line.rs
@@ -2398,7 +2398,6 @@ mod tests {
                     0,
                     "hello world abc"
                 )],
-                max_severity: None,
             },
         );
         let (text_prov, lines) = make_lines_ph(&text, 20.0, false, ph);
@@ -2506,7 +2505,6 @@ mod tests {
             0,
             PhantomTextLine {
                 text: smallvec![mph(PhantomTextKind::Completion, 0, "greet world")],
-                max_severity: None,
             },
         );
 
@@ -2545,7 +2543,6 @@ mod tests {
                  text: smallvec![
                      mph(PhantomTextKind::Completion, 0, "greet\nworld"),
                  ],
-                 max_severity: None,
              },
          );
 
@@ -2635,7 +2632,6 @@ mod tests {
                  text: smallvec![
                      mph(PhantomTextKind::Completion, 3, "greet\nworld"),
                  ],
-                 max_severity: None,
              },
          );
 
@@ -2874,7 +2870,6 @@ mod tests {
             0,
             PhantomTextLine {
                 text: smallvec![mph(PhantomTextKind::Completion, 0, "greet world")],
-                max_severity: None,
             },
         );
 
@@ -2997,7 +2992,6 @@ mod tests {
             0,
             PhantomTextLine {
                 text: smallvec![mph(PhantomTextKind::Completion, 0, "greet\nworld")],
-                max_severity: None,
             },
         );
 
@@ -3175,7 +3169,6 @@ mod tests {
             0,
             PhantomTextLine {
                 text: smallvec![mph(PhantomTextKind::Completion, 1, "hi")],
-                max_severity: None,
             },
         );
 
@@ -3226,7 +3219,6 @@ mod tests {
             0,
             PhantomTextLine {
                 text: smallvec![mph(PhantomTextKind::Completion, 2, "hi")],
-                max_severity: None,
             },
         );
 


### PR DESCRIPTION
This PR removes the `LapceConfig` parameter to `do_insert` and asks the backend about what auto closing/surround configuration it has. Forgot to do this in previous PR.
It also removes the `DiagnosticSeverity` from the `PhantomTextLine`, as that is LSP originating and only really useful for Lapce because of us processing diagnostics.