### PR TITLE
Implement path renaming from the file explorer

### DIFF
--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -524,10 +524,13 @@ pub enum InternalCommand {
     OpenFileChanges {
         path: PathBuf,
     },
-    StartRenameFile {
+    StartRenamePath {
         path: PathBuf,
     },
-    FinishRenameFile {
+    TestRenamePath {
+        new_path: PathBuf,
+    },
+    FinishRenamePath {
         current_path: PathBuf,
         new_path: PathBuf,
     },

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -524,6 +524,13 @@ pub enum InternalCommand {
     OpenFileChanges {
         path: PathBuf,
     },
+    StartRenameFile {
+        path: PathBuf,
+    },
+    FinishRenameFile {
+        current_path: PathBuf,
+        new_path: PathBuf,
+    },
     GoToLocation {
         location: EditorLocation,
     },

--- a/lapce-app/src/file_explorer/node.rs
+++ b/lapce-app/src/file_explorer/node.rs
@@ -1,19 +1,19 @@
-use std::path::PathBuf;
-
 use floem::views::VirtualListVector;
 
 use lapce_rpc::file::{FileNodeItem, FileNodeViewData};
 
+use lapce_rpc::file::RenameState;
+
 pub struct FileNodeVirtualList {
     file_node_item: FileNodeItem,
-    rename_path: Option<PathBuf>,
+    rename_state: RenameState,
 }
 
 impl FileNodeVirtualList {
-    pub fn new(file_node_item: FileNodeItem, rename_path: Option<PathBuf>) -> Self {
+    pub fn new(file_node_item: FileNodeItem, rename_state: RenameState) -> Self {
         Self {
             file_node_item,
-            rename_path,
+            rename_state,
         }
     }
 }
@@ -33,7 +33,7 @@ impl VirtualListVector<FileNodeViewData> for FileNodeVirtualList {
         for item in self.file_node_item.sorted_children() {
             i = item.append_view_slice(
                 &mut view_items,
-                self.rename_path.as_deref(),
+                &self.rename_state,
                 min,
                 max,
                 i + 1,

--- a/lapce-app/src/file_explorer/node.rs
+++ b/lapce-app/src/file_explorer/node.rs
@@ -1,14 +1,28 @@
+use std::path::PathBuf;
+
 use floem::views::VirtualListVector;
 
 use lapce_rpc::file::{FileNodeItem, FileNodeViewData};
 
-pub struct FileNodeVirtualList(pub FileNodeItem);
+pub struct FileNodeVirtualList {
+    file_node_item: FileNodeItem,
+    rename_path: Option<PathBuf>,
+}
+
+impl FileNodeVirtualList {
+    pub fn new(file_node_item: FileNodeItem, rename_path: Option<PathBuf>) -> Self {
+        Self {
+            file_node_item,
+            rename_path,
+        }
+    }
+}
 
 impl VirtualListVector<FileNodeViewData> for FileNodeVirtualList {
     type ItemIterator = Box<dyn Iterator<Item = FileNodeViewData>>;
 
     fn total_len(&self) -> usize {
-        self.0.children_open_count
+        self.file_node_item.children_open_count
     }
 
     fn slice(&mut self, range: std::ops::Range<usize>) -> Self::ItemIterator {
@@ -16,8 +30,15 @@ impl VirtualListVector<FileNodeViewData> for FileNodeVirtualList {
         let max = range.end;
         let mut i = 0;
         let mut view_items = Vec::new();
-        for item in self.0.sorted_children() {
-            i = item.append_view_slice(&mut view_items, min, max, i + 1, 0);
+        for item in self.file_node_item.sorted_children() {
+            i = item.append_view_slice(
+                &mut view_items,
+                self.rename_path.as_deref(),
+                min,
+                max,
+                i + 1,
+                0,
+            );
             if i > max {
                 return Box::new(view_items.into_iter());
             }

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -5,7 +5,7 @@ use floem::{
     event::{Event, EventListener},
     peniko::Color,
     reactive::{create_rw_signal, RwSignal},
-    style::{AlignItems, CursorStyle, Style},
+    style::{AlignItems, CursorStyle, Position, Style},
     view::View,
     views::{
         container, container_box, label, list, scroll, stack, svg, virtual_list,
@@ -14,7 +14,7 @@ use floem::{
     EventPropagation,
 };
 use lapce_core::selection::Selection;
-use lapce_rpc::file::FileNodeViewData;
+use lapce_rpc::file::{FileNodeViewData, IsRenaming, RenameState};
 use lapce_xi_rope::Rope;
 
 use super::{data::FileExplorerData, node::FileNodeVirtualList};
@@ -28,6 +28,39 @@ use crate::{
     text_input::text_input,
     window_tab::{Focus, WindowTabData},
 };
+
+/// Blends `foreground` with `background`.
+///
+/// Uses the alpha channel from `foreground` - if `foreground` is opaque, `foreground` will be
+/// returned unchanged.
+///
+/// The result is always opaque regardless of the transparency of the inputs.
+fn blend_colors(background: Color, foreground: Color) -> Color {
+    let Color {
+        r: background_r,
+        g: background_g,
+        b: background_b,
+        ..
+    } = background;
+    let Color {
+        r: foreground_r,
+        g: foreground_g,
+        b: foreground_b,
+        a,
+    } = foreground;
+    let a: u16 = a.into();
+
+    let [r, g, b] = [
+        [background_r, foreground_r],
+        [background_g, foreground_g],
+        [background_b, foreground_b],
+    ]
+    .map(|x| x.map(u16::from))
+    .map(|[b, f]| (a * f + (255 - a) * b) / 255)
+    .map(|x| x as u8);
+
+    Color { r, g, b, a: 255 }
+}
 
 pub fn file_explorer_panel(
     window_tab_data: Rc<WindowTabData>,
@@ -58,6 +91,29 @@ pub fn file_explorer_panel(
     })
 }
 
+fn initialize_rename_editor(data: &FileExplorerData, path: &Path) {
+    let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+    // Start with the part of the file or directory name before the extension
+    // selected.
+    let selection_end = {
+        let without_leading_dot = file_name.strip_prefix('.').unwrap_or(&file_name);
+        let idx = without_leading_dot
+            .find('.')
+            .unwrap_or(without_leading_dot.len());
+
+        idx + file_name.len() - without_leading_dot.len()
+    };
+
+    let doc = data.rename_editor_data.view.doc.get_untracked();
+    doc.reload(Rope::from(&file_name), true);
+    data.rename_editor_data
+        .cursor
+        .update(|cursor| cursor.set_insert(Selection::region(0, selection_end)));
+
+    data.rename_state
+        .update(|rename_state| rename_state.set_editor_needs_reset(false));
+}
+
 fn file_node_text_view(
     data: FileExplorerData,
     node: FileNodeViewData,
@@ -65,69 +121,87 @@ fn file_node_text_view(
 ) -> impl View {
     let ui_line_height = data.common.ui_line_height;
 
-    let view = if node.is_renaming {
+    let view = if let IsRenaming::Renaming { err } = node.is_renaming {
         let rename_editor_data = data.rename_editor_data.clone();
         let text_input_file_explorer_data = data.clone();
         let focus = data.common.focus;
         let config = data.common.config;
 
-        let file_name = path.file_name().unwrap_or_default().to_string_lossy();
-        // Start with the part of the file or directory name before the extension
-        // selected.
-        let selection_end = {
-            let without_leading_dot =
-                file_name.strip_prefix('.').unwrap_or(&file_name);
+        if data
+            .rename_state
+            .with_untracked(RenameState::editor_needs_reset)
+        {
+            initialize_rename_editor(&data, path);
+        }
 
-            without_leading_dot.find('.').unwrap_or(file_name.len())
-        };
-
-        let doc = data.rename_editor_data.view.doc.get_untracked();
-        doc.reload(Rope::from(&file_name), true);
-        rename_editor_data
-            .cursor
-            .update(|cursor| cursor.set_insert(Selection::region(0, selection_end)));
-
-        container_box({
-            let text_input_view =
-                text_input(rename_editor_data.clone(), move || {
-                    focus.with_untracked(|focus| {
-                        focus == &Focus::Panel(PanelKind::FileExplorer)
-                    })
-                })
-                .on_event_stop(EventListener::FocusLost, move |_| {
-                    let new_relative_path: String =
-                        rename_editor_data.view.text().into();
-
-                    data.finish_rename(new_relative_path.as_ref());
-                })
-                .on_event(EventListener::KeyDown, move |event| {
-                    if let Event::KeyDown(event) = event {
-                        let keypress =
-                            rename_editor_data.common.keypress.get_untracked();
-                        if keypress.key_down(event, &text_input_file_explorer_data) {
-                            EventPropagation::Stop
-                        } else {
-                            EventPropagation::Continue
-                        }
-                    } else {
-                        EventPropagation::Continue
-                    }
-                })
-                .style(move |s| {
-                    s.flex_grow(1.0)
-                        .height(ui_line_height.get())
-                        .padding(0.0)
-                        .margin(0.0)
-                        .border_radius(6.0)
-                        .border(1.0)
-                        .border_color(config.get().color(LapceColor::LAPCE_BORDER))
-                });
-
-            let text_input_id = text_input_view.id();
-            text_input_id.request_focus();
-
-            text_input_view
+        let text_input_view = text_input(rename_editor_data.clone(), move || {
+            focus.with_untracked(|focus| {
+                focus == &Focus::Panel(PanelKind::FileExplorer)
+            })
         })
+        .on_event_stop(EventListener::FocusLost, move |_| {
+            data.finish_rename();
+            data.rename_state
+                .set(lapce_rpc::file::RenameState::NotRenaming);
+        })
+        .on_event(EventListener::KeyDown, move |event| {
+            if let Event::KeyDown(event) = event {
+                let keypress = rename_editor_data.common.keypress.get_untracked();
+                if keypress.key_down(event, &text_input_file_explorer_data) {
+                    EventPropagation::Stop
+                } else {
+                    EventPropagation::Continue
+                }
+            } else {
+                EventPropagation::Continue
+            }
+        })
+        .style(move |s| {
+            s.width_full()
+                .height(ui_line_height.get())
+                .padding(0.0)
+                .margin(0.0)
+                .border_radius(6.0)
+                .border(1.0)
+                .border_color(config.get().color(LapceColor::LAPCE_BORDER))
+        });
+
+        let text_input_id = text_input_view.id();
+        text_input_id.request_focus();
+
+        if let Some(err) = err {
+            container_box(
+                stack((
+                    text_input_view,
+                    label(move || err.clone()).style(move |s| {
+                        let config = config.get();
+
+                        let editor_background_color =
+                            config.color(LapceColor::PANEL_CURRENT_BACKGROUND);
+                        let error_background_color =
+                            config.color(LapceColor::ERROR_LENS_ERROR_BACKGROUND);
+
+                        let background_color = blend_colors(
+                            editor_background_color,
+                            error_background_color,
+                        );
+
+                        s.position(Position::Absolute)
+                            .inset_top(ui_line_height.get())
+                            .width_full()
+                            .color(
+                                config
+                                    .color(LapceColor::ERROR_LENS_ERROR_FOREGROUND),
+                            )
+                            .background(background_color)
+                            .z_index(100)
+                    }),
+                ))
+                .style(|s| s.flex_grow(1.0)),
+            )
+        } else {
+            container_box(text_input_view)
+        }
     } else {
         container_box(
             label(move || {
@@ -150,13 +224,13 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
     virtual_list(
         VirtualListDirection::Vertical,
         VirtualListItemSize::Fixed(Box::new(move || ui_line_height.get())),
-        move || FileNodeVirtualList::new(root.get(), data.rename_path.get()),
+        move || FileNodeVirtualList::new(root.get(), data.rename_state.get()),
         move |node| {
             (
                 node.path.clone(),
                 node.is_dir,
                 node.open,
-                node.is_renaming,
+                node.is_renaming.clone(),
                 node.level,
             )
         },
@@ -174,7 +248,7 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
             let aux_click_path = path.clone();
             let open = node.open;
             let is_dir = node.is_dir;
-            let is_renaming = node.is_renaming;
+            let is_renaming = node.is_renaming.clone();
 
             let view = stack((
                 svg(move || {
@@ -246,7 +320,7 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                     })
             });
 
-            if !is_renaming {
+            if let IsRenaming::NotRenaming = is_renaming {
                 view.on_click_stop(move |_| {
                     click_data.click(&click_path);
                 })

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -1296,6 +1296,19 @@ impl WindowTabData {
             InternalCommand::OpenFileChanges { path } => {
                 self.main_split.open_file_changes(path);
             }
+            InternalCommand::StartRenameFile { path } => {
+                self.file_explorer.rename_path.set(Some(path));
+                self.file_explorer.root.update(|_| {});
+            }
+            InternalCommand::FinishRenameFile {
+                current_path,
+                new_path,
+            } => {
+                self.file_explorer.rename_path.set(None);
+                self.common
+                    .proxy
+                    .rename_path(current_path, new_path, |_| {})
+            }
             InternalCommand::GoToLocation { location } => {
                 self.main_split.go_to_location(location, None);
             }

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -52,6 +52,7 @@ pub struct FileNodeViewData {
     pub path: PathBuf,
     pub is_dir: bool,
     pub open: bool,
+    pub is_renaming: bool,
     pub level: usize,
 }
 
@@ -223,6 +224,7 @@ impl FileNodeItem {
     pub fn append_view_slice(
         &self,
         view_items: &mut Vec<FileNodeViewData>,
+        rename_path: Option<&Path>,
         min: usize,
         max: usize,
         current: usize,
@@ -241,13 +243,21 @@ impl FileNodeItem {
                 path: self.path.clone(),
                 is_dir: self.is_dir,
                 open: self.open,
+                is_renaming: rename_path == Some(&self.path),
                 level,
             });
         }
 
         if self.open {
             for item in self.sorted_children() {
-                i = item.append_view_slice(view_items, min, max, i + 1, level + 1);
+                i = item.append_view_slice(
+                    view_items,
+                    rename_path,
+                    min,
+                    max,
+                    i + 1,
+                    level + 1,
+                );
                 if i > max {
                     return i;
                 }

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     collections::HashMap,
+    mem,
     path::{Path, PathBuf},
 };
 
@@ -47,12 +48,183 @@ impl PathObject {
     }
 }
 
+/// Stores the state of any in progress rename of a path.
+///
+/// The `editor_needs_reset` field is `true` if the rename editor should have its contents reset
+/// when the view function next runs.
+#[derive(Clone)]
+pub enum RenameState {
+    NotRenaming,
+    Renaming {
+        path: PathBuf,
+        editor_needs_reset: bool,
+    },
+    RenameRequestPending {
+        path: PathBuf,
+        editor_needs_reset: bool,
+    },
+    RenameErr {
+        path: PathBuf,
+        editor_needs_reset: bool,
+        err: String,
+    },
+}
+
+impl RenameState {
+    pub fn is_accepting_input(&self) -> bool {
+        match self {
+            Self::NotRenaming | Self::RenameRequestPending { .. } => false,
+            Self::Renaming { .. } | Self::RenameErr { .. } => true,
+        }
+    }
+
+    pub fn is_err(&self) -> bool {
+        match self {
+            Self::NotRenaming
+            | Self::Renaming { .. }
+            | Self::RenameRequestPending { .. } => false,
+            Self::RenameErr { .. } => true,
+        }
+    }
+
+    pub fn set_ok(&mut self) {
+        if let &mut Self::RenameErr {
+            ref mut path,
+            editor_needs_reset,
+            ..
+        } = self
+        {
+            let path = mem::take(path);
+
+            *self = Self::Renaming {
+                path,
+                editor_needs_reset,
+            };
+        }
+    }
+
+    pub fn set_pending(&mut self) {
+        if let &mut Self::Renaming {
+            ref mut path,
+            editor_needs_reset,
+        }
+        | &mut Self::RenameErr {
+            ref mut path,
+            editor_needs_reset,
+            ..
+        } = self
+        {
+            let path = mem::take(path);
+
+            *self = Self::RenameRequestPending {
+                path,
+                editor_needs_reset,
+            };
+        }
+    }
+
+    pub fn set_err(&mut self, err: String) {
+        if let &mut Self::Renaming {
+            ref mut path,
+            editor_needs_reset,
+        }
+        | &mut Self::RenameRequestPending {
+            ref mut path,
+            editor_needs_reset,
+        }
+        | &mut Self::RenameErr {
+            ref mut path,
+            editor_needs_reset,
+            ..
+        } = self
+        {
+            let path = mem::take(path);
+
+            *self = Self::RenameErr {
+                path,
+                editor_needs_reset,
+                err,
+            };
+        }
+    }
+
+    pub fn set_editor_needs_reset(&mut self, needs_reset: bool) {
+        if let Self::Renaming {
+            editor_needs_reset, ..
+        }
+        | Self::RenameRequestPending {
+            editor_needs_reset, ..
+        }
+        | Self::RenameErr {
+            editor_needs_reset, ..
+        } = self
+        {
+            *editor_needs_reset = needs_reset;
+        }
+    }
+
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::NotRenaming => None,
+            Self::Renaming { path, .. }
+            | Self::RenameRequestPending { path, .. }
+            | Self::RenameErr { path, .. } => Some(path),
+        }
+    }
+
+    pub fn editor_needs_reset(&self) -> bool {
+        match self {
+            Self::NotRenaming => false,
+            &Self::Renaming {
+                editor_needs_reset, ..
+            }
+            | &Self::RenameRequestPending {
+                editor_needs_reset, ..
+            }
+            | &Self::RenameErr {
+                editor_needs_reset, ..
+            } => editor_needs_reset,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum IsRenaming {
+    NotRenaming,
+    Renaming { err: Option<String> },
+}
+
+impl IsRenaming {
+    fn is_node_renaming(rename_state: &RenameState, node_path: &Path) -> Self {
+        match rename_state {
+            RenameState::NotRenaming => Self::NotRenaming,
+            RenameState::Renaming { path, .. }
+            | RenameState::RenameRequestPending { path, .. } => {
+                if path == node_path {
+                    Self::Renaming { err: None }
+                } else {
+                    Self::NotRenaming
+                }
+            }
+            RenameState::RenameErr { path, err, .. } => {
+                if path == node_path {
+                    Self::Renaming {
+                        err: Some(err.clone()),
+                    }
+                } else {
+                    Self::NotRenaming
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct FileNodeViewData {
     pub path: PathBuf,
     pub is_dir: bool,
     pub open: bool,
-    pub is_renaming: bool,
+    pub is_renaming: IsRenaming,
     pub level: usize,
 }
 
@@ -224,7 +396,7 @@ impl FileNodeItem {
     pub fn append_view_slice(
         &self,
         view_items: &mut Vec<FileNodeViewData>,
-        rename_path: Option<&Path>,
+        rename_state: &RenameState,
         min: usize,
         max: usize,
         current: usize,
@@ -243,7 +415,7 @@ impl FileNodeItem {
                 path: self.path.clone(),
                 is_dir: self.is_dir,
                 open: self.open,
-                is_renaming: rename_path == Some(&self.path),
+                is_renaming: IsRenaming::is_node_renaming(rename_state, &self.path),
                 level,
             });
         }
@@ -252,7 +424,7 @@ impl FileNodeItem {
             for item in self.sorted_children() {
                 i = item.append_view_slice(
                     view_items,
-                    rename_path,
+                    rename_state,
                     min,
                     max,
                     i + 1,

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -182,6 +182,9 @@ pub enum ProxyRequest {
         from: PathBuf,
         to: PathBuf,
     },
+    TestCreateAtPath {
+        path: PathBuf,
+    },
     DapVariable {
         dap_id: DapId,
         reference: usize,
@@ -402,6 +405,9 @@ pub enum ProxyResponse {
     },
     DapGetScopesResponse {
         scopes: Vec<(dap_types::Scope, Vec<dap_types::Variable>)>,
+    },
+    CreatePathResponse {
+        path: PathBuf,
     },
     Success {},
     SaveResponse {},
@@ -673,6 +679,14 @@ impl ProxyRpcHandler {
         f: impl ProxyCallback + 'static,
     ) {
         self.request_async(ProxyRequest::RenamePath { from, to }, f);
+    }
+
+    pub fn test_create_at_path(
+        &self,
+        path: PathBuf,
+        f: impl ProxyCallback + 'static,
+    ) {
+        self.request_async(ProxyRequest::TestCreateAtPath { path }, f);
     }
 
     pub fn save_buffer_as(


### PR DESCRIPTION
Implement functionality for renaming files and directories, accessible by right clicking the item in the file explorer and selecting "Rename...".

There was already some functionality in `lapce-proxy` for renaming paths, but there was no UI for using it. This PR adds a UI, and also makes some changes to the existing functionality:
* When renaming a file, any buffers affected by the rename are updated to use the new path.
* Non existing ancestor directories of the new path are created on rename.
* A new request, `TestCreateAtPath`, is added to allow querying whether a rename will succeed without performing it (not all failure reasons are covered - for example, it is not checked whether the user has permission to create a file in the target directory).

Note that this functionality can be used to move items as well as rename them - the user can rename `foo` to `../bar/foo` for example.

Relates to #2822.