### PR TITLE
fix: detect git changes when no commit in repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2723](https://github.com/lapce/lapce/pull/2723): Line wrapping based on width (no column-based yet)
 
 ### Bug Fixes
+- [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository
 
 ## 0.3.1
 
@@ -13,7 +14,7 @@
 
 ### Bug Fixes
 - [#2754](https://github.com/lapce/lapce/pull/2754): Don't mark nonexistent files as read only (fix saving new files)
-- [#2819](https://github.com/lapce/lapce/issues/2819): `Save Witohut Formatting` doesn't save the file
+- [#2819](https://github.com/lapce/lapce/issues/2819): `Save Without Formatting` doesn't save the file
 
 ## 0.3.0
 

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -2350,7 +2350,7 @@ fn palette_content(
 
                         cmd_kind
                             .and_then(|kind| keymaps.get(kind.str()))
-                            .and_then(|maps| maps.get(0))
+                            .and_then(|maps| maps.first())
                     };
                     container(palette_item(
                         workspace,

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -2656,12 +2656,12 @@ fn show_completion(
         | EditCommand::DeleteWordBackward
         | EditCommand::DeleteWordForward
         | EditCommand::DeleteForwardAndInsert => {
-            let start = match deltas.get(0).and_then(|delta| delta.0.els.get(0)) {
+            let start = match deltas.first().and_then(|delta| delta.0.els.first()) {
                 Some(lapce_xi_rope::DeltaElement::Copy(_, start)) => *start,
                 _ => 0,
             };
 
-            let end = match deltas.get(0).and_then(|delta| delta.0.els.get(1)) {
+            let end = match deltas.first().and_then(|delta| delta.0.els.get(1)) {
                 Some(lapce_xi_rope::DeltaElement::Copy(end, _)) => *end,
                 _ => 0,
             };

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -1573,7 +1573,7 @@ impl MainSplitData {
         let split = splits.get(&split_id).copied()?;
 
         let split_chilren = split.with_untracked(|split| split.children.clone());
-        let content = split_chilren.get(0)?;
+        let content = split_chilren.first()?;
         self.split_content_focus(&content.1);
 
         Some(())
@@ -2027,7 +2027,7 @@ impl MainSplitData {
                         None
                     } else {
                         edits
-                            .get(0)
+                            .first()
                             .map(|edit| EditorPosition::Position(edit.range.start))
                     };
                     let location = EditorLocation {

--- a/lapce-core/src/cursor.rs
+++ b/lapce-core/src/cursor.rs
@@ -445,7 +445,7 @@ impl Cursor {
                     return None;
                 }
 
-                let x = selection.regions().get(0).unwrap();
+                let x = selection.regions().first().unwrap();
                 let v = buffer.offset_to_line_col(x.start);
 
                 Some((v.0, v.1, x.start))

--- a/lapce-core/src/selection.rs
+++ b/lapce-core/src/selection.rs
@@ -226,7 +226,7 @@ impl Selection {
 
     /// Get the leftmost [`SelRegion`] in this selection if present.
     pub fn first(&self) -> Option<&SelRegion> {
-        self.regions.get(0)
+        self.regions.first()
     }
 
     /// Get the rightmost [`SelRegion`] in this selection if present.

--- a/lapce-proxy/src/plugin/catalog.rs
+++ b/lapce-proxy/src/plugin/catalog.rs
@@ -376,7 +376,7 @@ impl PluginCatalog {
                     match result {
                         Ok(resp) => {
                             let scopes = resp.scopes.clone();
-                            if let Some(scope) = resp.scopes.get(0) {
+                            if let Some(scope) = resp.scopes.first() {
                                 let scope = scope.to_owned();
                                 thread::spawn(move || {
                                     local_dap.variables_async(

--- a/lapce-proxy/src/plugin/dap.rs
+++ b/lapce-proxy/src/plugin/dap.rs
@@ -243,7 +243,7 @@ impl DapClient {
 
                 let active_frame = current_thread
                     .and_then(|thread_id| stack_frames.get(&thread_id))
-                    .and_then(|stack_frames| stack_frames.get(0));
+                    .and_then(|stack_frames| stack_frames.first());
 
                 let mut vars = Vec::new();
                 if let Some(frame) = active_frame {


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This pull request enables Lapce to see untracked files in a fresh git repository. See issue #2779. 

![image](https://github.com/lapce/lapce/assets/5321539/c0864073-b617-4c39-9990-a49a7da4a8c1)

After applying this fix, I've noticed that files that have no history will have an empty diff like this: 
![image](https://github.com/lapce/lapce/assets/5321539/a533fbe8-3e5f-4e71-bdaa-84a1e76fe505)

It does seem like a different scope of fix and in a different area. There's a pull request that does seem to be related to this: https://github.com/lapce/lapce/pull/2017 . I am not sure about the implications here, and would love to see this being addressed/discussed separately. 