### PR TITLE
Fix/git commit silently fail missing username email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features/Changes
 - [#2723](https://github.com/lapce/lapce/pull/2723): Line wrapping based on width (no column-based yet)
+- [#1277](https://github.com/lapce/lapce/pull/1277): Error message prompted on missing git user.email and/or user.name
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -1206,7 +1206,11 @@ fn git_commit(
     let tree = index.write_tree()?;
     let tree = repo.find_tree(tree)?;
     let signature = repo.signature()?;
-    let parent = repo.head()?.peel_to_commit()?;
+    let parents = repo
+        .head()
+        .and_then(|head| Ok(vec![head.peel_to_commit()?]))
+        .unwrap_or(vec![]);
+    let parents_refs = parents.iter().collect::<Vec<_>>();
 
     repo.commit(
         Some("HEAD"),
@@ -1214,7 +1218,7 @@ fn git_commit(
         &signature,
         message,
         &tree,
-        &[&parent],
+        &parents_refs,
     )?;
     Ok(())
 }

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -13,6 +13,7 @@ use std::{
 use alacritty_terminal::{event::WindowSize, event_loop::Msg};
 use anyhow::{anyhow, Context, Result};
 use crossbeam_channel::Sender;
+use git2::ErrorCode::NotFound;
 use git2::{build::CheckoutBuilder, DiffOptions, Oid, Repository};
 use grep_matcher::Matcher;
 use grep_regex::RegexMatcherBuilder;
@@ -31,7 +32,9 @@ use lapce_rpc::{
     RequestId, RpcError,
 };
 use lapce_xi_rope::Rope;
-use lsp_types::{Position, Range, TextDocumentItem, Url};
+use lsp_types::{
+    MessageType, Position, Range, ShowMessageParams, TextDocumentItem, Url,
+};
 use parking_lot::Mutex;
 
 use crate::{
@@ -284,7 +287,15 @@ impl ProxyHandler for Dispatcher {
                 if let Some(workspace) = self.workspace.as_ref() {
                     match git_commit(workspace, &message, diffs) {
                         Ok(()) => (),
-                        Err(e) => eprintln!("{e:?}"),
+                        Err(e) => {
+                            self.core_rpc.show_message(
+                                "Git Commit failure".to_owned(),
+                                ShowMessageParams {
+                                    typ: MessageType::ERROR,
+                                    message: e.to_string(),
+                                },
+                            );
+                        }
                     }
                 }
             }
@@ -1205,22 +1216,35 @@ fn git_commit(
     index.write()?;
     let tree = index.write_tree()?;
     let tree = repo.find_tree(tree)?;
-    let signature = repo.signature()?;
-    let parents = repo
-        .head()
-        .and_then(|head| Ok(vec![head.peel_to_commit()?]))
-        .unwrap_or(vec![]);
-    let parents_refs = parents.iter().collect::<Vec<_>>();
 
-    repo.commit(
-        Some("HEAD"),
-        &signature,
-        &signature,
-        message,
-        &tree,
-        &parents_refs,
-    )?;
-    Ok(())
+    match repo.signature() {
+        Ok(signature) => {
+            let parents = repo
+                .head()
+                .and_then(|head| Ok(vec![head.peel_to_commit()?]))
+                .unwrap_or(vec![]);
+            let parents_refs = parents.iter().collect::<Vec<_>>();
+
+            repo.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                message,
+                &tree,
+                &parents_refs,
+            )?;
+            Ok(())
+        }
+        Err(e) => match e.code() {
+            NotFound => Err(anyhow!(
+                "No user.name and/or user.email configured for this git repository."
+            )),
+            _ => Err(anyhow!(
+                "Error while creating commit's signature: {}",
+                e.message()
+            )),
+        },
+    }
 }
 
 fn git_checkout(workspace_path: &Path, reference: &str) -> Result<()> {


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This pull request fixes 2 behaviors, I recommend looking commit by commit. 

1. Fixes a missing piece when committing on a fresh repository having no `HEAD` or previous commit. Relates to #2779 . 
2. Prompts an error when the `user.name` and/or `user.email` is missing from any configuration (repo/system/xdg). `Repository::signature` already makes these checks for us. This should fix #1277

![Screenshot 2024-01-01 214236](https://github.com/lapce/lapce/assets/5321539/ab18f848-2112-4ad9-ae17-79ce35aa6dfd)
