### PR TITLE
Implement comparing files in the diff editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 - [#2723](https://github.com/lapce/lapce/pull/2723): Line wrapping based on width (no column-based yet)
 - [#1277](https://github.com/lapce/lapce/pull/1277): Error message prompted on missing git user.email and/or user.name
+- [#2910](https://github.com/lapce/lapce/pull/2910): Files can be compared in the diff editor
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -507,6 +507,10 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "previous_error")]
     PreviousError,
 
+    #[strum(message = "Diff Files")]
+    #[strum(serialize = "diff_files")]
+    DiffFiles,
+
     #[strum(serialize = "quit")]
     #[strum(message = "Quit Editor")]
     Quit,
@@ -666,6 +670,10 @@ pub enum InternalCommand {
         volt_id: VoltID,
     },
     ResetBlinkCursor,
+    OpenDiffFiles {
+        left_path: PathBuf,
+        right_path: PathBuf,
+    },
 }
 
 #[derive(Clone)]

--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -1,3 +1,4 @@
+use ::core::slice;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -556,11 +557,12 @@ impl LapceConfig {
         })
     }
 
-    pub fn file_svg(&self, path: &Path) -> (String, Option<Color>) {
+    pub fn files_svg(&self, paths: &[&Path]) -> (String, Option<Color>) {
         let svg = self
             .icon_theme
-            .resolve_path_to_icon(path)
+            .resolve_path_to_icon(paths)
             .and_then(|p| self.svg_store.write().get_svg_on_disk(&p));
+
         if let Some(svg) = svg {
             let color = if self.icon_theme.use_editor_color.unwrap_or(false) {
                 Some(self.color(LapceColor::LAPCE_ICON_ACTIVE))
@@ -574,6 +576,10 @@ impl LapceConfig {
                 Some(self.color(LapceColor::LAPCE_ICON_ACTIVE)),
             )
         }
+    }
+
+    pub fn file_svg(&self, path: &Path) -> (String, Option<Color>) {
+        self.files_svg(slice::from_ref(&path))
     }
 
     pub fn symbol_svg(&self, kind: &SymbolKind) -> Option<String> {

--- a/lapce-app/src/config/icon_theme.rs
+++ b/lapce-app/src/config/icon_theme.rs
@@ -1,7 +1,23 @@
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+
+/// Returns the first item yielded from `items` if at least one item is yielded, all yielded items
+/// are `Some`, and all yielded items compare equal, else returns `None`.
+fn try_all_equal_value<T: PartialEq, I: IntoIterator<Item = Option<T>>>(
+    items: I,
+) -> Option<T> {
+    let mut items = items.into_iter();
+    let first = items.next().flatten()?;
+
+    items.try_fold(first, |initial_item, item| {
+        item.and_then(|item| (item == initial_item).then_some(initial_item))
+    })
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -17,23 +33,212 @@ pub struct IconThemeConfig {
 }
 
 impl IconThemeConfig {
-    pub fn resolve_path_to_icon(&self, path: &Path) -> Option<PathBuf> {
-        if let Some((_, icon)) = self.filename.get_key_value(
-            path.file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default(),
-        ) {
-            Some(self.path.join(icon))
-        } else if let Some((_, icon)) = self.extension.get_key_value(
-            path.extension()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default(),
-        ) {
-            Some(self.path.join(icon))
-        } else {
-            None
+    /// If all paths in `paths` have the same file type (as determined by the file name or
+    /// extension), and there is an icon associated with that file type, returns the path of the
+    /// icon.
+    pub fn resolve_path_to_icon(&self, paths: &[&Path]) -> Option<PathBuf> {
+        let file_names = paths
+            .iter()
+            .map(|path| path.file_name().and_then(OsStr::to_str));
+        let file_name_icon = try_all_equal_value(file_names)
+            .and_then(|file_name| self.filename.get(file_name));
+
+        file_name_icon
+            .or_else(|| {
+                let extensions = paths
+                    .iter()
+                    .map(|path| path.extension().and_then(OsStr::to_str));
+
+                try_all_equal_value(extensions)
+                    .and_then(|extension| self.extension.get(extension))
+            })
+            .map(|icon| self.path.join(icon))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::icon_theme::try_all_equal_value;
+
+    use super::IconThemeConfig;
+
+    #[test]
+    fn try_all_equal_value_empty_none() {
+        assert_eq!(Option::<u32>::None, try_all_equal_value([]));
+    }
+
+    #[test]
+    fn try_all_equal_value_any_none_none() {
+        assert_eq!(Option::<u32>::None, try_all_equal_value([None]));
+        assert_eq!(
+            Option::<i32>::None,
+            try_all_equal_value([None, Some(1), Some(1)])
+        );
+        assert_eq!(Option::<u64>::None, try_all_equal_value([Some(0), None]));
+        assert_eq!(
+            Option::<u8>::None,
+            try_all_equal_value([Some(3), Some(3), None, Some(3)])
+        );
+    }
+
+    #[test]
+    fn try_all_equal_value_any_different_none() {
+        assert_eq!(Option::<u32>::None, try_all_equal_value([Some(1), Some(2)]));
+        assert_eq!(
+            Option::<u128>::None,
+            try_all_equal_value([Some(1), Some(10), Some(1)])
+        );
+        assert_eq!(
+            Option::<i16>::None,
+            try_all_equal_value([Some(3), Some(3), Some(3), Some(3), Some(2)])
+        );
+        assert_eq!(
+            Option::<i64>::None,
+            try_all_equal_value([Some(5), Some(4), Some(4), Some(4), Some(4)])
+        );
+        assert_eq!(
+            Option::<i128>::None,
+            try_all_equal_value([Some(3), Some(0), Some(9), Some(20), Some(1)])
+        );
+    }
+
+    #[test]
+    fn try_all_equal_value_all_same_some() {
+        assert_eq!(Option::<u32>::Some(1), try_all_equal_value([Some(1)]));
+        assert_eq!(Option::<i16>::Some(-2), try_all_equal_value([Some(-2); 2]));
+        assert_eq!(Option::<i128>::Some(0), try_all_equal_value([Some(0); 3]));
+        assert_eq!(Option::<u8>::Some(30), try_all_equal_value([Some(30); 57]));
+    }
+
+    fn get_icon_theme_config() -> IconThemeConfig {
+        IconThemeConfig {
+            path: "icons".to_owned().into(),
+            filename: [("Makefile", "makefile.svg"), ("special.rs", "special.svg")]
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .into(),
+            extension: [("rs", "rust.svg"), ("c", "c.svg"), ("py", "python.svg")]
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .into(),
+            ..Default::default()
         }
+    }
+
+    #[test]
+    fn resolve_path_to_icon_no_paths_none() {
+        let icon_theme_config = get_icon_theme_config();
+
+        assert_eq!(None, icon_theme_config.resolve_path_to_icon(&[]));
+    }
+
+    #[test]
+    fn resolve_path_to_icon_different_none() {
+        let icon_theme_config = get_icon_theme_config();
+
+        assert_eq!(
+            None,
+            icon_theme_config
+                .resolve_path_to_icon(&["foo.rs", "bar.c"].map(AsRef::as_ref))
+        );
+        assert_eq!(
+            None,
+            icon_theme_config.resolve_path_to_icon(
+                &["/some/path/main.py", "other/path.py", "dir1/./dir2/file.rs"]
+                    .map(AsRef::as_ref)
+            )
+        );
+        assert_eq!(
+            None,
+            icon_theme_config.resolve_path_to_icon(
+                &["/root/Makefile", "dir/dir/special.rs", "../../main.rs"]
+                    .map(AsRef::as_ref)
+            )
+        );
+        assert_eq!(
+            None,
+            icon_theme_config
+                .resolve_path_to_icon(&["main.c", "foo.txt"].map(AsRef::as_ref))
+        );
+    }
+
+    #[test]
+    fn resolve_path_to_icon_no_match_none() {
+        let icon_theme_config = get_icon_theme_config();
+
+        assert_eq!(
+            None,
+            icon_theme_config.resolve_path_to_icon(&["foo"].map(AsRef::as_ref))
+        );
+        assert_eq!(
+            None,
+            icon_theme_config.resolve_path_to_icon(
+                &["/some/path/file.txt", "other/path.txt"].map(AsRef::as_ref)
+            )
+        );
+        assert_eq!(
+            None,
+            icon_theme_config.resolve_path_to_icon(
+                &["folder/file", "/home/user/file", "../../file"].map(AsRef::as_ref)
+            )
+        );
+        assert_eq!(
+            None,
+            icon_theme_config.resolve_path_to_icon(&[".."].map(AsRef::as_ref))
+        );
+        assert_eq!(
+            None,
+            icon_theme_config.resolve_path_to_icon(&["."].map(AsRef::as_ref))
+        );
+    }
+
+    #[test]
+    fn resolve_path_to_icon_file_name_match_some() {
+        let icon_theme_config = get_icon_theme_config();
+
+        assert_eq!(
+            Some("icons/makefile.svg".to_owned().into()),
+            icon_theme_config.resolve_path_to_icon(&["Makefile"].map(AsRef::as_ref))
+        );
+        assert_eq!(
+            Some("icons/makefile.svg".to_owned().into()),
+            icon_theme_config.resolve_path_to_icon(
+                &[
+                    "baz/Makefile",
+                    "/foo/bar/dir/Makefile",
+                    ".././/././Makefile"
+                ]
+                .map(AsRef::as_ref)
+            )
+        );
+        assert_eq!(
+            Some("icons/special.svg".to_owned().into()),
+            icon_theme_config.resolve_path_to_icon(
+                &["dir/special.rs", "/dir1/dir2/..//./special.rs"]
+                    .map(AsRef::as_ref)
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_path_to_icon_extension_match_some() {
+        let icon_theme_config = get_icon_theme_config();
+
+        assert_eq!(
+            Some("icons/python.svg".to_owned().into()),
+            icon_theme_config
+                .resolve_path_to_icon(&["source.py"].map(AsRef::as_ref))
+        );
+        assert_eq!(
+            Some("icons/rust.svg".to_owned().into()),
+            icon_theme_config.resolve_path_to_icon(
+                &["/home/user/main.rs", "../../special.rs.rs", "special.rs"]
+                    .map(AsRef::as_ref)
+            )
+        );
+        assert_eq!(
+            Some("icons/c.svg".to_owned().into()),
+            icon_theme_config.resolve_path_to_icon(
+                &["/dir1/Makefile.c", "../main.c"].map(AsRef::as_ref)
+            )
+        );
     }
 }

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -103,6 +103,7 @@ impl EditorInfo {
                     None,
                     editor_id,
                     doc,
+                    None,
                     data.common,
                 );
                 editor_data.go_to_location(
@@ -155,6 +156,7 @@ impl EditorInfo {
                     None,
                     editor_id,
                     doc,
+                    None,
                     data.common,
                 )
             }
@@ -205,6 +207,7 @@ impl EditorData {
         diff_editor_id: Option<(EditorTabId, DiffEditorId)>,
         editor_id: EditorId,
         doc: Rc<Document>,
+        confirmed: Option<RwSignal<bool>>,
         common: Rc<CommonData>,
     ) -> Self {
         let cx = cx.create_child();
@@ -236,6 +239,7 @@ impl EditorData {
                 internal_comamnd.send(InternalCommand::ResetBlinkCursor);
             });
         }
+        let confirmed = confirmed.unwrap_or_else(|| cx.create_rw_signal(false));
         Self {
             scope: cx,
             editor_tab_id: cx.create_rw_signal(editor_tab_id),
@@ -243,7 +247,7 @@ impl EditorData {
             editor_id,
             view,
             cursor,
-            confirmed: cx.create_rw_signal(false),
+            confirmed,
             snippet: cx.create_rw_signal(None),
             window_origin: cx.create_rw_signal(Point::ZERO),
             viewport,
@@ -266,7 +270,7 @@ impl EditorData {
     ) -> Self {
         let cx = cx.create_child();
         let doc = Rc::new(Document::new_local(cx, common.clone()));
-        Self::new(cx, None, None, editor_id, doc, common)
+        Self::new(cx, None, None, editor_id, doc, None, common)
     }
 
     pub fn editor_info(&self, _data: &WindowTabData) -> EditorInfo {
@@ -290,6 +294,7 @@ impl EditorData {
         editor_tab_id: Option<EditorTabId>,
         diff_editor_id: Option<(EditorTabId, DiffEditorId)>,
         editor_id: EditorId,
+        confirmed: Option<RwSignal<bool>>,
     ) -> Self {
         let cx = cx.create_child();
         let cursor = cx.create_rw_signal(self.cursor.get_untracked());
@@ -301,6 +306,7 @@ impl EditorData {
             });
         }
         let viewport = cx.create_rw_signal(self.viewport.get_untracked());
+        let confirmed = confirmed.unwrap_or_else(|| cx.create_rw_signal(true));
 
         EditorData {
             scope: cx,
@@ -315,7 +321,7 @@ impl EditorData {
                 self.viewport.get_untracked().origin().to_vec2(),
             )),
             window_origin: cx.create_rw_signal(Point::ZERO),
-            confirmed: cx.create_rw_signal(true),
+            confirmed,
             snippet: cx.create_rw_signal(None),
             last_movement: cx.create_rw_signal(self.last_movement.get_untracked()),
             inline_find: cx.create_rw_signal(None),
@@ -2956,7 +2962,7 @@ fn compute_screen_lines(
 
                             // Skip over the lines
                             if let Some(skip) = bothinfo.skip.as_ref() {
-                                if skip.start == line - start {
+                                if Some(skip.start) == line.checked_sub(start) {
                                     y_idx += 1;
                                     // Skip by `skip` count, which is skip - 1 because we will
                                     // go to the next vline on the next iter

--- a/lapce-app/src/editor_tab.rs
+++ b/lapce-app/src/editor_tab.rs
@@ -267,25 +267,34 @@ impl EditorTabChild {
                 let config = config.get();
                 let diff_editor_data = diff_editors
                     .with(|diff_editors| diff_editors.get(&diff_editor_id).cloned());
-                let confirmed = diff_editor_data.as_ref().map(|d| d.right.confirmed);
-                let path = if let Some(diff_editor_data) = diff_editor_data {
-                    let (content, is_pristine) =
-                        diff_editor_data.right.view.doc.with(|doc| {
-                            (doc.content.get(), doc.buffer.with(|b| b.is_pristine()))
-                        });
-                    match content {
-                        DocContent::File { path, .. } => Some((path, is_pristine)),
-                        DocContent::Local => None,
-                        DocContent::History(_) => None,
-                        DocContent::Scratch { name, .. } => {
-                            Some((PathBuf::from(name), is_pristine))
-                        }
-                    }
-                } else {
-                    None
-                };
-                let (icon, color, path, is_pristine) = match path {
-                    Some((path, is_pritine)) => {
+                let confirmed = diff_editor_data.as_ref().map(|d| d.confirmed);
+
+                let info = diff_editor_data
+                    .map(|diff_editor_data| {
+                        [diff_editor_data.left, diff_editor_data.right].map(|data| {
+                            let (content, is_pristine) = data.view.doc.with(|doc| {
+                                (
+                                    doc.content.get(),
+                                    doc.buffer.with(|b| b.is_pristine()),
+                                )
+                            });
+                            match content {
+                                DocContent::File { path, .. } => {
+                                    Some((path, is_pristine))
+                                }
+                                DocContent::Local => None,
+                                DocContent::History(_) => None,
+                                DocContent::Scratch { name, .. } => {
+                                    Some((PathBuf::from(name), is_pristine))
+                                }
+                            }
+                        })
+                    })
+                    .unwrap_or([None, None]);
+
+                let (icon, color, path, is_pristine) = match info {
+                    [Some((path, is_pristine)), None]
+                    | [None, Some((path, is_pristine))] => {
                         let (svg, color) = config.file_svg(&path);
                         (
                             svg,
@@ -296,10 +305,27 @@ impl EditorTabChild {
                                     .unwrap_or_default()
                                     .to_string_lossy()
                             ),
-                            is_pritine,
+                            is_pristine,
                         )
                     }
-                    None => (
+                    [Some((left_path, left_is_pristine)), Some((right_path, right_is_pristine))] =>
+                    {
+                        let (svg, color) =
+                            config.files_svg(&[&left_path, &right_path]);
+                        let [left_file_name, right_file_name] =
+                            [&left_path, &right_path].map(|path| {
+                                path.file_name()
+                                    .unwrap_or_default()
+                                    .to_string_lossy()
+                            });
+                        (
+                            svg,
+                            color,
+                            format!("{left_file_name} - {right_file_name} (Diff)"),
+                            left_is_pristine && right_is_pristine,
+                        )
+                    }
+                    [None, None] => (
                         config.ui_svg(LapceIcons::FILE),
                         Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
                         "local".to_string(),
@@ -429,34 +455,13 @@ impl EditorTabData {
                 }
                 EditorTabChild::DiffEditor(diff_editor_id) => {
                     if let Some(diff_editor) = diff_editors.get(diff_editor_id) {
-                        let left_confirmed =
-                            diff_editor.left.confirmed.get_untracked();
-                        let right_confirmed =
-                            diff_editor.right.confirmed.get_untracked();
-                        if !left_confirmed && !right_confirmed {
+                        let confirmed = diff_editor.confirmed.get_untracked();
+                        if !confirmed {
                             return Some((i, child.clone()));
                         }
                     }
                 }
                 _ => (),
-            }
-        }
-        None
-    }
-
-    pub fn get_unconfirmed_editor(
-        &self,
-        editors: &im::HashMap<EditorId, RwSignal<EditorData>>,
-    ) -> Option<(usize, RwSignal<EditorData>)> {
-        for (i, child) in self.children.iter().enumerate() {
-            if let (_, _, EditorTabChild::Editor(editor_id)) = child {
-                if let Some(editor) = editors.get(editor_id) {
-                    let e = editor.get_untracked();
-                    let confirmed = e.confirmed.get_untracked();
-                    if !confirmed {
-                        return Some((i, *editor));
-                    }
-                }
             }
         }
         None

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -550,6 +550,16 @@ impl MainSplitData {
         );
     }
 
+    pub fn open_diff_files(&self, left_path: PathBuf, right_path: PathBuf) {
+        let [left, right] = [left_path, right_path].map(|path| self.get_doc(path).0);
+
+        self.get_editor_tab_child(
+            EditorTabChildSource::DiffEditor { left, right },
+            false,
+            false,
+        );
+    }
+
     fn new_editor_tab(
         &self,
         editor_tab_id: EditorTabId,
@@ -884,6 +894,7 @@ impl MainSplitData {
                         None,
                         editor_id,
                         doc.clone(),
+                        None,
                         self.common.clone(),
                     );
                     let editor = Rc::new(editor);
@@ -914,6 +925,7 @@ impl MainSplitData {
                         None,
                         editor_id,
                         doc,
+                        None,
                         self.common.clone(),
                     );
                     let editor = Rc::new(editor);
@@ -1394,6 +1406,7 @@ impl MainSplitData {
                     Some(editor_tab_id),
                     None,
                     new_editor_id,
+                    None,
                 );
                 let editor = Rc::new(editor);
                 self.editors.update(|editors| {

--- a/lapce-app/src/palette/kind.rs
+++ b/lapce-app/src/palette/kind.rs
@@ -21,6 +21,7 @@ pub enum PaletteKind {
     Language,
     SCMReferences,
     TerminalProfile,
+    DiffFiles,
 }
 
 impl PaletteKind {
@@ -42,7 +43,8 @@ impl PaletteKind {
             | PaletteKind::ColorTheme
             | PaletteKind::IconTheme
             | PaletteKind::Language
-            | PaletteKind::SCMReferences => "",
+            | PaletteKind::SCMReferences
+            | PaletteKind::DiffFiles => "",
             #[cfg(windows)]
             PaletteKind::WslHost => "",
         }
@@ -90,6 +92,7 @@ impl PaletteKind {
                 Some(LapceWorkbenchCommand::PaletteSCMReferences)
             }
             PaletteKind::TerminalProfile => None, // InternalCommand::NewTerminal
+            PaletteKind::DiffFiles => Some(LapceWorkbenchCommand::DiffFiles),
         }
     }
 
@@ -115,7 +118,8 @@ impl PaletteKind {
             | PaletteKind::ColorTheme
             | PaletteKind::IconTheme
             | PaletteKind::Language
-            | PaletteKind::SCMReferences => input,
+            | PaletteKind::SCMReferences
+            | PaletteKind::DiffFiles => input,
             PaletteKind::PaletteHelp
             | PaletteKind::Command
             | PaletteKind::Workspace

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -999,6 +999,7 @@ impl WindowTabData {
             ChangeFileLanguage => {
                 self.palette.run(PaletteKind::Language);
             }
+            DiffFiles => self.palette.run(PaletteKind::DiffFiles),
 
             // ==== Running / Debugging ====
             RunAndDebugRestart => {
@@ -1630,6 +1631,10 @@ impl WindowTabData {
                     self.common.config,
                 );
             }
+            InternalCommand::OpenDiffFiles {
+                left_path,
+                right_path,
+            } => self.main_split.open_diff_files(left_path, right_path),
         }
     }
 


### PR DESCRIPTION
The user can either:

* Select the files to compare by right clicking on them in the file explorer.

* Invoke the `diff_files` command and select the files to compare from the palette.

Fix double clicking on an unconfirmed diff editor tab not confirming it.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users