### PR TITLE
Improve search in keyboard shortcuts overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2723](https://github.com/lapce/lapce/pull/2723): Line wrapping based on width (no column-based yet)
 - [#1277](https://github.com/lapce/lapce/pull/1277): Error message prompted on missing git user.email and/or user.name
 - [#2910](https://github.com/lapce/lapce/pull/2910): Files can be compared in the diff editor
+- [#2918](https://github.com/lapce/lapce/pull/2918): Allow searching the shortcuts overview by shortcut (e.g. "Ctrl+P") or when condition (e.g. "list_focus")
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/lapce-app/src/keymap.rs
+++ b/lapce-app/src/keymap.rs
@@ -57,17 +57,33 @@ pub fn keymap_view(common: Rc<CommonData>) -> impl View {
             .iter()
             .filter_map(|keymap| {
                 let cmd = keypress.commands.get(&keymap.command).cloned()?;
-                let match_pattern =
-                    cmd.kind.str().replace('_', " ").contains(&pattern)
-                        || cmd
-                            .kind
-                            .desc()
-                            .map(|desc| desc.to_lowercase().contains(&pattern))
-                            .unwrap_or(false);
-                if !match_pattern {
-                    return None;
+
+                let cmd_name_contains_pattern =
+                    cmd.kind.str().replace('_', " ").contains(&pattern);
+                let cmd_desc_contains_pattern = cmd
+                    .kind
+                    .desc()
+                    .map(|desc| desc.to_lowercase().contains(&pattern))
+                    .unwrap_or(false);
+                let shortcut_contains_pattern = keymap
+                    .key
+                    .iter()
+                    .any(|k| k.label().trim().to_lowercase().contains(&pattern));
+                let when_contains_pattern = keymap
+                    .when
+                    .as_ref()
+                    .map(|when| when.to_lowercase().contains(&pattern))
+                    .unwrap_or(false);
+
+                if cmd_name_contains_pattern
+                    || cmd_desc_contains_pattern
+                    || shortcut_contains_pattern
+                    || when_contains_pattern
+                {
+                    Some((cmd, Some(keymap.clone())))
+                } else {
+                    None
                 }
-                Some((cmd, Some(keymap.clone())))
             })
             .collect::<im::Vector<(LapceCommand, Option<KeyMap>)>>();
         items.extend(keypress.commands_without_keymap.iter().filter_map(|cmd| {


### PR DESCRIPTION
Allows searching for shortcuts (e.g. "ctrl+p") and when conditions (e.g. "in_snippet") in the keyboard shortcuts overview

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users