### PR TITLE
Fix unicode path handling on windows LSPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository
+- [#2920](https://github.com/lapce/lapce/pull/2920): Fix unicode path handling on windows LSPs
 
 ## 0.3.1
 

--- a/lapce-app/src/proxy.rs
+++ b/lapce-app/src/proxy.rs
@@ -143,24 +143,6 @@ impl CoreHandler for Proxy {
     }
 }
 
-// Rust-analyzer returns paths in the form of "file:///<drive>:/...", which gets parsed into URL
-// as "/<drive>://" which is then interpreted by PathBuf::new() as a UNIX-like path from root.
-// This function strips the additional / from the beginning, if the first segment is a drive letter.
-#[cfg(windows)]
-pub fn path_from_url(url: &Url) -> PathBuf {
-    let path = url.path();
-    if let Some(path) = path.strip_prefix('/') {
-        if let Some((maybe_drive_letter, _)) = path.split_once(['/', '\\']) {
-            let b = maybe_drive_letter.as_bytes();
-            if b.len() == 2 && b[0].is_ascii_alphabetic() && b[1] == b':' {
-                return PathBuf::from(path);
-            }
-        }
-    }
-    PathBuf::from(path)
-}
-
-#[cfg(not(windows))]
 pub fn path_from_url(url: &Url) -> PathBuf {
     url.to_file_path()
         .unwrap_or_else(|_| PathBuf::from(url.path()))


### PR DESCRIPTION
Closes #2920 

Tested with Rust analyzer. `to_file_path()` properly converts `file:///c:/...` style URIs into properly drive rooted windows paths.