### PR TITLE
Feat: add `files_exclude` option (Fixes #811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1277](https://github.com/lapce/lapce/pull/1277): Error message prompted on missing git user.email and/or user.name
 - [#2910](https://github.com/lapce/lapce/pull/2910): Files can be compared in the diff editor
 - [#2918](https://github.com/lapce/lapce/pull/2918): Allow searching the shortcuts overview by shortcut (e.g. "Ctrl+P") or when condition (e.g. "list_focus")
+- [#2955](https://github.com/lapce/lapce/pull/2955): Using glob patterns to hide files or directories in explorer
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,6 +3029,7 @@ dependencies = [
  "floem",
  "fs_extra",
  "futures",
+ "globset",
  "im",
  "include_dir",
  "indexmap 2.0.2",

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -19,14 +19,14 @@ scroll-beyond-last-line = true
 cursor-surrounding-lines = 1
 wrap-style = "editor-width"
 wrap-column = 80
-wrap-width = 600                        # px
+wrap-width = 600                                             # px
 sticky-header = true
 completion-show-documentation = true
 show-signature = true
 signature-label-code-block = true
 auto-closing-matching-pairs = true
 auto-surround = true
-hover-delay = 300                       # ms
+hover-delay = 300                                            # ms
 modal-mode-relative-line-numbers = true
 format-on-save = false
 highlight-matching-brackets = true
@@ -46,7 +46,7 @@ enable-completion-lens = false
 enable-inline-completion = true
 completion-lens-font-family = ""
 completion-lens-font-size = 0
-blink-interval = 500                    # ms
+blink-interval = 500                                         # ms
 multicursor-case-sensitive = true
 multicursor-whole-words = true
 render-whitespace = "none"
@@ -54,18 +54,20 @@ show-indent-guide = true
 atomic-soft-tabs = false
 double-click = "single"
 move-focus-while-search = true
-diff-context-lines=3
-scroll-speed-modifier=1
+diff-context-lines = 3
+scroll-speed-modifier = 1
 bracket-pair-colorization = false
 bracket-colorization-limit = 30000
+files-exclude = "**/{.git,.svn,.hg,CVS,.DS_Store,Thumbs.db}" # Glob patterns
+
 [terminal]
 font-family = ""
 font-size = 0
 line-height = 0
 
 [terminal.default-profile]
-macos   = "default"
-linux   = "default"
+macos = "default"
+linux = "default"
 windows = "default"
 
 [terminal.profiles]

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -51,13 +51,16 @@ sled = "0.34.7"
 bytemuck = "1.14.0"
 tokio = { version = "1.21", features = ["full"] }
 futures = "0.3.26"
-floem = { git = "https://github.com/lapce/floem", rev = "c45e8e8ab6ab85e12bd98527e34db4a9397c3764", features = ["serde"] }
+floem = { git = "https://github.com/lapce/floem", rev = "c45e8e8ab6ab85e12bd98527e34db4a9397c3764", features = [
+    "serde",
+] }
 # floem = { path = "../../workspaces/floem", features = ["serde"] }
 config = { version = "0.13.2", default-features = false, features = ["toml"] }
 structdesc = { git = "https://github.com/lapce/structdesc" }
 base64 = "0.21.5"
 sha2 = "0.10.6"
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+globset = "0.4.9"
 
 [target.'cfg(target_os="macos")'.dependencies]
 fs_extra = "1.2.0"

--- a/lapce-app/src/config/editor.rs
+++ b/lapce-app/src/config/editor.rs
@@ -221,6 +221,10 @@ pub struct EditorConfig {
     pub bracket_pair_colorization: bool,
     #[field_names(desc = "Bracket colorization Limit")]
     pub bracket_colorization_limit: u64,
+    #[field_names(
+        desc = "Glob patterns for excluding files and folders (in file explorer)"
+    )]
+    pub files_exclude: String,
 }
 
 impl EditorConfig {

--- a/lapce-app/src/file_explorer/data.rs
+++ b/lapce-app/src/file_explorer/data.rs
@@ -201,10 +201,7 @@ impl FileExplorerData {
                             match Glob::new(&config.get().editor.files_exclude) {
                                 Ok(glob) => {
                                     let matcher = glob.compile_matcher();
-                                    items = items
-                                        .into_iter()
-                                        .filter(|i| !matcher.is_match(&i.path))
-                                        .collect();
+                                    items.retain(|i| !matcher.is_match(&i.path));
                                 }
                                 Err(e) => tracing::error!(
                                     target:"files_exclude",

--- a/lapce-app/src/file_explorer/data.rs
+++ b/lapce-app/src/file_explorer/data.rs
@@ -15,6 +15,7 @@ use floem::{
     views::editor::id::EditorId,
     EventPropagation,
 };
+use globset::Glob;
 use lapce_core::{
     command::{EditCommand, FocusCommand},
     mode::Mode,
@@ -187,15 +188,31 @@ impl FileExplorerData {
         let root = self.root;
         let id = self.id;
         let data = self.clone();
+        let config = self.common.config;
         let send = {
             let path = path.to_path_buf();
             create_ext_action(self.common.scope, move |result| {
-                if let Ok(ProxyResponse::ReadDirResponse { items }) = result {
+                if let Ok(ProxyResponse::ReadDirResponse { mut items }) = result {
                     id.update(|id| {
                         *id += 1;
                     });
                     root.update(|root| {
                         if let Some(node) = root.get_file_node_mut(&path) {
+                            match Glob::new(&config.get().editor.files_exclude) {
+                                Ok(glob) => {
+                                    let matcher = glob.compile_matcher();
+                                    items = items
+                                        .into_iter()
+                                        .filter(|i| !matcher.is_match(&i.path))
+                                        .collect();
+                                }
+                                Err(e) => tracing::error!(
+                                    target:"files_exclude",
+                                    "Failed to compile glob: {}",
+                                    e
+                                ),
+                            }
+
                             node.read = true;
                             let removed_paths: Vec<PathBuf> = node
                                 .children
@@ -214,6 +231,7 @@ impl FileExplorerData {
                                         data.read_dir(&existing.path);
                                     }
                                 } else {
+                                    // Add new paths
                                     node.children.insert(item.path.clone(), item);
                                 }
                             }


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR fixes #811 by providing a `files_exclude` string option which using blob patterns to blacklist files and directories.

Currently using default value of `"**/{.git,.svn,.hg,CVS,.DS_Store,Thumbs.db}"` (Referenced from VSCode)

<img width="812" alt="image" src="https://github.com/lapce/lapce/assets/49438478/3c9d1003-cb23-4c15-9805-7f1e2201e341">
