### PR TITLE
Cargo.toml: Add license to metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "lapce"
 version = "0.3.1"
 authors = ["Dongdong Zhou <dzhou121@gmail.com>"]
 edition = "2021"
+license = "Apache-2.0"
 rust-version = "1.65"
 default-run = "lapce"
 


### PR DESCRIPTION
The README lists the license as Apache-2.0, but the `Cargo.toml` doesn't
contain license metadata. Add the license to `Cargo.toml` as well.
