### PR TITLE
Improve keyinput on non us layouts

### DIFF
--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -294,21 +294,23 @@ impl KeyPressData {
         false
     }
 
-
-    fn get_keyinput_from_event<'a>(event: &'a KeyEvent) -> KeyInput {
-        // when the KeyEvent is of type Character use its string value to get 
+    fn get_keyinput_from_event(event: &KeyEvent) -> KeyInput {
+        // when the KeyEvent is of type Character use its string value to get
         // the corresponding KeyInput. On non english keyboard layouts
-        // the logical_key and physical_key may not match and the key mapping won't 
+        // the logical_key and physical_key may not match and the key mapping won't
         // work when using both values from the event directly
         match &event.key.logical_key {
-            Key::Character(key) => KeyInput::from_str(
-                key.as_str(),
-            ).unwrap(),
+            Key::Character(key) => {
+                KeyInput::from_str(key.as_str()).unwrap_or(KeyInput::Keyboard(
+                    event.key.logical_key.clone(),
+                    event.key.physical_key,
+                ))
+            }
             _ => KeyInput::Keyboard(
                 event.key.logical_key.clone(),
                 event.key.physical_key,
             ),
-        }   
+        }
     }
 
     fn get_key_modifiers(key_event: &KeyEvent) -> ModifiersState {


### PR DESCRIPTION
Improves keymapping for non english keyboard layouts (https://github.com/lapce/lapce/issues/2731)

On non english keyboard layouts the logical_key and the physical_key of the KeyEvent may differ e.g. 

	physical_key: Code(KeyZ), logical_key: Character("y")

which is mapped to a KeyPress struct with values

	KeyPress { key: Keyboard(Character("y"), Code(KeyZ)), mods: ModifiersState(CONTROL) }

This PR uses the value of the logical_key to get a KeyInput with a matching Keycode which leads to 
a KeyPress with matching Character and Code:

 	KeyPress { key: Keyboard(Character("y"), Code(KeyY)), mods: ModifiersState(CONTROL) }

or
	
	KeyPress { key: Keyboard(Character("z"), Code(KeyZ)), mods: ModifiersState(CONTROL) }


This fixes many keybindings like Ctrl+Z (https://github.com/lapce/lapce/issues/2775).

Unfortunately not all keybindings are fixed. For example Ctrl+= is still not working. 
On a german keyboard the equal sign "=" is reached by pressing Shift+0.
The KeyEvent for this case will be Ctrl+Shift+= which obiously doesn't match the keybind Ctrl+=.



