### PR TITLE
Remaining file explorer context menu entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2910](https://github.com/lapce/lapce/pull/2910): Files can be compared in the diff editor
 - [#2918](https://github.com/lapce/lapce/pull/2918): Allow searching the shortcuts overview by shortcut (e.g. "Ctrl+P") or when condition (e.g. "list_focus")
 - [#2955](https://github.com/lapce/lapce/pull/2955): Using glob patterns to hide files or directories in explorer
+- [#3026](https://github.com/lapce/lapce/pull/3026): Add missing file explorer context menu entries
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -545,6 +545,7 @@ pub enum InternalCommand {
     OpenFileChanges {
         path: PathBuf,
     },
+    ReloadFileExplorer,
     StartRenamePath {
         path: PathBuf,
     },

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -549,12 +549,21 @@ pub enum InternalCommand {
     StartRenamePath {
         path: PathBuf,
     },
-    TestRenamePath {
+    /// Test whether a file/directory can be created at that path
+    TestPathCreation {
         new_path: PathBuf,
     },
     FinishRenamePath {
         current_path: PathBuf,
         new_path: PathBuf,
+    },
+    FinishNewNode {
+        is_dir: bool,
+        path: PathBuf,
+    },
+    FinishDuplicate {
+        source: PathBuf,
+        path: PathBuf,
     },
     GoToLocation {
         location: EditorLocation,

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -546,9 +546,6 @@ pub enum InternalCommand {
         path: PathBuf,
     },
     ReloadFileExplorer,
-    StartRenamePath {
-        path: PathBuf,
-    },
     /// Test whether a file/directory can be created at that path
     TestPathCreation {
         new_path: PathBuf,

--- a/lapce-app/src/file_explorer/data.rs
+++ b/lapce-app/src/file_explorer/data.rs
@@ -43,8 +43,6 @@ enum RenamedPath {
 
 #[derive(Clone)]
 pub struct FileExplorerData {
-    /// Id for the cache, updated every time the file explorer is modified
-    pub id: RwSignal<usize>,
     pub root: RwSignal<FileNodeItem>,
     pub rename_state: RwSignal<RenameState>,
     pub rename_editor_data: EditorData,
@@ -137,7 +135,6 @@ impl FileExplorerData {
         let rename_state = cx.create_rw_signal(RenameState::NotRenaming);
         let rename_editor_data = EditorData::new_local(cx, editors, common.clone());
         let data = Self {
-            id: cx.create_rw_signal(0),
             root,
             rename_state,
             rename_editor_data,
@@ -161,10 +158,6 @@ impl FileExplorerData {
     /// Toggle whether the directory is expanded or not.  
     /// Does nothing if the path does not exist or is not a directory.
     pub fn toggle_expand(&self, path: &Path) {
-        self.id.update(|id| {
-            *id += 1;
-        });
-
         let Some(read) = self
             .root
             .try_update(|root| {
@@ -197,7 +190,6 @@ impl FileExplorerData {
     /// Read the directory's information and update the file explorer tree.  
     pub fn read_dir(&self, path: &Path) {
         let root = self.root;
-        let id = self.id;
         let data = self.clone();
         let config = self.common.config;
         let send = {
@@ -207,9 +199,6 @@ impl FileExplorerData {
                     return;
                 };
 
-                id.update(|id| {
-                    *id += 1;
-                });
                 root.update(|root| {
                     // Get the node for this path, which should already exist if we're calling
                     // read_dir on it.

--- a/lapce-app/src/file_explorer/node.rs
+++ b/lapce-app/src/file_explorer/node.rs
@@ -1,18 +1,16 @@
 use floem::views::VirtualVector;
-use lapce_rpc::file::{FileNodeItem, FileNodeViewData};
-
-use lapce_rpc::file::RenameState;
+use lapce_rpc::file::{FileNodeItem, FileNodeViewData, Naming};
 
 pub struct FileNodeVirtualList {
     file_node_item: FileNodeItem,
-    rename_state: RenameState,
+    naming: Naming,
 }
 
 impl FileNodeVirtualList {
-    pub fn new(file_node_item: FileNodeItem, rename_state: RenameState) -> Self {
+    pub fn new(file_node_item: FileNodeItem, naming: Naming) -> Self {
         Self {
             file_node_item,
-            rename_state,
+            naming,
         }
     }
 }
@@ -26,21 +24,62 @@ impl VirtualVector<FileNodeViewData> for FileNodeVirtualList {
         &mut self,
         range: std::ops::Range<usize>,
     ) -> impl Iterator<Item = FileNodeViewData> {
+        let naming = &self.naming;
+        let root = &self.file_node_item;
+
         let min = range.start;
         let max = range.end;
         let mut i = 0;
         let mut view_items = Vec::new();
-        for item in self.file_node_item.sorted_children() {
-            i = item.append_view_slice(
-                &mut view_items,
-                &self.rename_state,
-                min,
-                max,
-                i + 1,
-                0,
-            );
+
+        let mut naming_on_root = naming.extra_node(root.is_dir, 0, &root.path);
+
+        let naming_is_dir =
+            naming_on_root.as_ref().map(|n| n.is_dir).unwrap_or(false);
+        // Immediately put the naming entry first if it's a directory
+        if naming_is_dir {
+            if let Some(node) = naming_on_root.take() {
+                // Actually add the node if it's within the range
+                if 0 >= min {
+                    view_items.push(node);
+                    i += 1;
+                }
+            }
+        }
+
+        let mut after_dirs = false;
+
+        for item in root.sorted_children() {
+            // If we're naming a file at the root, then wait until we've added the directories
+            // before adding the input node
+            if naming_on_root.is_some()
+                && !naming_is_dir
+                && !item.is_dir
+                && !after_dirs
+            {
+                after_dirs = true;
+
+                // If we're creating a new file node, then we show it after the directories
+                // TODO(minor): should this be i >= min or i + 1 >= min?
+                if i >= min {
+                    if let Some(node) = naming_on_root.take() {
+                        view_items.push(node);
+                        i += 1;
+                    }
+                }
+            }
+
+            i = item.append_view_slice(&mut view_items, naming, min, max, i + 1, 0);
+
             if i > max {
-                return view_items.into_iter();
+                break;
+            }
+        }
+
+        if i >= min {
+            if let Some(node) = naming_on_root {
+                view_items.push(node);
+                // i += 1;
             }
         }
 

--- a/lapce-app/src/file_explorer/node.rs
+++ b/lapce-app/src/file_explorer/node.rs
@@ -29,59 +29,9 @@ impl VirtualVector<FileNodeViewData> for FileNodeVirtualList {
 
         let min = range.start;
         let max = range.end;
-        let mut i = 0;
         let mut view_items = Vec::new();
 
-        let mut naming_on_root = naming.extra_node(root.is_dir, 0, &root.path);
-
-        let naming_is_dir =
-            naming_on_root.as_ref().map(|n| n.is_dir).unwrap_or(false);
-        // Immediately put the naming entry first if it's a directory
-        if naming_is_dir {
-            if let Some(node) = naming_on_root.take() {
-                // Actually add the node if it's within the range
-                if 0 >= min {
-                    view_items.push(node);
-                    i += 1;
-                }
-            }
-        }
-
-        let mut after_dirs = false;
-
-        for item in root.sorted_children() {
-            // If we're naming a file at the root, then wait until we've added the directories
-            // before adding the input node
-            if naming_on_root.is_some()
-                && !naming_is_dir
-                && !item.is_dir
-                && !after_dirs
-            {
-                after_dirs = true;
-
-                // If we're creating a new file node, then we show it after the directories
-                // TODO(minor): should this be i >= min or i + 1 >= min?
-                if i >= min {
-                    if let Some(node) = naming_on_root.take() {
-                        view_items.push(node);
-                        i += 1;
-                    }
-                }
-            }
-
-            i = item.append_view_slice(&mut view_items, naming, min, max, i + 1, 0);
-
-            if i > max {
-                break;
-            }
-        }
-
-        if i >= min {
-            if let Some(node) = naming_on_root {
-                view_items.push(node);
-                // i += 1;
-            }
-        }
+        root.append_children_view_slice(&mut view_items, naming, min, max, 0, 0);
 
         view_items.into_iter()
     }

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -169,8 +169,8 @@ fn file_node_input_view(data: FileExplorerData, err: Option<String>) -> Containe
 
     let naming_editor_data = data.naming_editor_data.clone();
     let text_input_file_explorer_data = data.clone();
-    let focus = data.common.focus.clone();
-    let config = data.common.config.clone();
+    let focus = data.common.focus;
+    let config = data.common.config;
 
     let is_focused = move || {
         focus.with_untracked(|focus| focus == &Focus::Panel(PanelKind::FileExplorer))
@@ -289,7 +289,7 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                             };
                             config.ui_svg(svg_str)
                         } else if let Some(path) = kind.path() {
-                            config.file_svg(&path).0
+                            config.file_svg(path).0
                         } else {
                             config.ui_svg(LapceIcons::FILE)
                         }
@@ -308,7 +308,7 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                                 s.apply_opt(
                                     kind_for_style
                                         .path()
-                                        .and_then(|p| config.file_svg(&p).1),
+                                        .and_then(|p| config.file_svg(p).1),
                                     Style::color,
                                 )
                             })

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -358,7 +358,12 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
             }
         },
     )
-    .style(|s| s.flex_col().align_items(AlignItems::Stretch).width_full())
+    .style(|s| {
+        s.flex_col()
+            .align_items(AlignItems::Stretch)
+            .width_full()
+            .height_full()
+    })
     .on_secondary_click_stop(move |_| {
         if let Naming::None = naming.get_untracked() {
             if let Some(path) = &secondary_click_data.common.workspace.path {

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -221,6 +221,10 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
     let root = data.root;
     let ui_line_height = data.common.ui_line_height;
     let config = data.common.config;
+    let rename_state = data.rename_state;
+
+    let secondary_click_data = data.clone();
+
     virtual_stack(
         VirtualDirection::Vertical,
         VirtualItemSize::Fixed(Box::new(move || ui_line_height.get())),
@@ -346,6 +350,13 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
         },
     )
     .style(|s| s.flex_col().align_items(AlignItems::Stretch).width_full())
+    .on_secondary_click_stop(move |_| {
+        if let RenameState::NotRenaming = rename_state.get_untracked() {
+            if let Some(path) = &secondary_click_data.common.workspace.path {
+                secondary_click_data.secondary_click(path);
+            }
+        }
+    })
 }
 
 fn open_editors_view(window_tab_data: Rc<WindowTabData>) -> impl View {

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -8,13 +8,12 @@ use floem::{
     style::{AlignItems, CursorStyle, Position, Style},
     view::View,
     views::{
-        container, dyn_stack, label, scroll, stack, svg, virtual_stack, Decorators,
-        VirtualDirection, VirtualItemSize,
+        container, dyn_stack, label, scroll, stack, svg, virtual_stack, Container,
+        Decorators, VirtualDirection, VirtualItemSize,
     },
-    EventPropagation,
 };
 use lapce_core::selection::Selection;
-use lapce_rpc::file::{FileNodeViewData, IsRenaming, RenameState};
+use lapce_rpc::file::{FileNodeViewData, FileNodeViewKind, Naming};
 use lapce_xi_rope::Rope;
 
 use super::{data::FileExplorerData, node::FileNodeVirtualList};
@@ -25,7 +24,7 @@ use crate::{
     editor_tab::{EditorTabChild, EditorTabData},
     panel::{kind::PanelKind, position::PanelPosition, view::panel_header},
     plugin::PluginData,
-    text_input::text_input,
+    text_input::text_input_key_focus,
     window_tab::{Focus, WindowTabData},
 };
 
@@ -87,11 +86,12 @@ pub fn file_explorer_panel(
     ))
     .style(move |s| {
         s.width_pct(100.0)
-            .apply_if(!position.is_bottom(), |s| s.flex_col())
+            .apply_if(!position.is_bottom(), |s: Style| s.flex_col())
     })
 }
 
-fn initialize_rename_editor(data: &FileExplorerData, path: &Path) {
+/// Initialize the file explorer's naming (renaming, creating, etc.) editor with the given path.
+fn initialize_naming_editor_with_path(data: &FileExplorerData, path: &Path) {
     let file_name = path.file_name().unwrap_or_default().to_string_lossy();
     // Start with the part of the file or directory name before the extension
     // selected.
@@ -104,140 +104,144 @@ fn initialize_rename_editor(data: &FileExplorerData, path: &Path) {
         idx + file_name.len() - without_leading_dot.len()
     };
 
-    let doc = data.rename_editor_data.doc();
-    doc.reload(Rope::from(&file_name), true);
-    data.rename_editor_data
+    initialize_naming_editor(data, &file_name, Some(selection_end));
+}
+
+fn initialize_naming_editor(
+    data: &FileExplorerData,
+    text: &str,
+    selection_end: Option<usize>,
+) {
+    let text = Rope::from(text);
+    let selection_end = selection_end.unwrap_or(text.len());
+
+    let doc = data.naming_editor_data.doc();
+    doc.reload(text, true);
+    data.naming_editor_data
         .cursor()
         .update(|cursor| cursor.set_insert(Selection::region(0, selection_end)));
 
-    data.rename_state
-        .update(|rename_state| rename_state.set_editor_needs_reset(false));
+    data.naming
+        .update(|naming| naming.set_editor_needs_reset(false));
 }
 
-fn file_node_text_view(
-    data: FileExplorerData,
-    node: FileNodeViewData,
-    path: &Path,
-) -> impl View {
+fn file_node_text_view(data: FileExplorerData, node: FileNodeViewData) -> impl View {
     let ui_line_height = data.common.ui_line_height;
 
-    let view = if let IsRenaming::Renaming { err } = node.is_renaming {
-        let rename_editor_data = data.rename_editor_data.clone();
-        let text_input_file_explorer_data = data.clone();
-        let focus = data.common.focus;
-        let config = data.common.config;
-
-        if data
-            .rename_state
-            .with_untracked(RenameState::editor_needs_reset)
-        {
-            initialize_rename_editor(&data, path);
-        }
-
-        let text_input_view = text_input(rename_editor_data.clone(), move || {
-            focus.with_untracked(|focus| {
-                focus == &Focus::Panel(PanelKind::FileExplorer)
-            })
-        })
-        .on_event_stop(EventListener::FocusLost, move |_| {
-            data.finish_rename();
-            data.rename_state
-                .set(lapce_rpc::file::RenameState::NotRenaming);
-        })
-        .on_event(EventListener::KeyDown, move |event| {
-            if let Event::KeyDown(event) = event {
-                let keypress = rename_editor_data.common.keypress.get_untracked();
-                if keypress.key_down(event, &text_input_file_explorer_data) {
-                    EventPropagation::Stop
-                } else {
-                    EventPropagation::Continue
-                }
-            } else {
-                EventPropagation::Continue
-            }
-        })
-        .style(move |s| {
-            s.width_full()
-                .height(ui_line_height.get())
-                .padding(0.0)
-                .margin(0.0)
-                .border_radius(6.0)
-                .border(1.0)
-                .border_color(config.get().color(LapceColor::LAPCE_BORDER))
-        });
-
-        let text_input_id = text_input_view.id();
-        text_input_id.request_focus();
-
-        if let Some(err) = err {
-            container(
-                stack((
-                    text_input_view,
-                    label(move || err.clone()).style(move |s| {
-                        let config = config.get();
-
-                        let editor_background_color =
-                            config.color(LapceColor::PANEL_CURRENT_BACKGROUND);
-                        let error_background_color =
-                            config.color(LapceColor::ERROR_LENS_ERROR_BACKGROUND);
-
-                        let background_color = blend_colors(
-                            editor_background_color,
-                            error_background_color,
-                        );
-
-                        s.position(Position::Absolute)
-                            .inset_top(ui_line_height.get())
-                            .width_full()
-                            .color(
-                                config
-                                    .color(LapceColor::ERROR_LENS_ERROR_FOREGROUND),
-                            )
-                            .background(background_color)
-                            .z_index(100)
-                    }),
-                ))
-                .style(|s| s.flex_grow(1.0)),
-            )
-        } else {
-            container(text_input_view)
-        }
-    } else {
-        container(
+    let view = match node.kind {
+        FileNodeViewKind::Path(path) => container(
             label(move || {
-                node.path
-                    .file_name()
+                path.file_name()
                     .map(|f| f.to_string_lossy().to_string())
                     .unwrap_or_default()
             })
             .style(move |s| s.flex_grow(1.0).height(ui_line_height.get())),
-        )
+        ),
+        FileNodeViewKind::Renaming { path, err } => {
+            if data.naming.with_untracked(Naming::editor_needs_reset) {
+                initialize_naming_editor_with_path(&data, &path);
+            }
+
+            file_node_input_view(data, err)
+        }
+        FileNodeViewKind::Naming { err } => {
+            if data.naming.with_untracked(Naming::editor_needs_reset) {
+                initialize_naming_editor(&data, "", None);
+            }
+
+            file_node_input_view(data, err)
+        }
+        FileNodeViewKind::Duplicating { source, err } => {
+            if data.naming.with_untracked(Naming::editor_needs_reset) {
+                initialize_naming_editor_with_path(&data, &source);
+            }
+
+            file_node_input_view(data, err)
+        }
     };
 
     view.style(|s| s.flex_grow(1.0).padding(0.0).margin(0.0))
+}
+
+/// Input used for naming a file/directory
+fn file_node_input_view(data: FileExplorerData, err: Option<String>) -> Container {
+    let ui_line_height = data.common.ui_line_height;
+
+    let naming_editor_data = data.naming_editor_data.clone();
+    let text_input_file_explorer_data = data.clone();
+    let focus = data.common.focus.clone();
+    let config = data.common.config.clone();
+
+    let is_focused = move || {
+        focus.with_untracked(|focus| focus == &Focus::Panel(PanelKind::FileExplorer))
+    };
+    let text_input_view = text_input_key_focus(
+        naming_editor_data.clone(),
+        Some(text_input_file_explorer_data),
+        is_focused,
+    )
+    .on_event_stop(EventListener::FocusLost, move |_| {
+        data.finish_naming();
+        data.naming.set(Naming::None);
+    })
+    .style(move |s| {
+        s.width_full()
+            .height(ui_line_height.get())
+            .padding(0.0)
+            .margin(0.0)
+            .border_radius(6.0)
+            .border(1.0)
+            .border_color(config.get().color(LapceColor::LAPCE_BORDER))
+    });
+
+    let text_input_id = text_input_view.id();
+    text_input_id.request_focus();
+
+    if let Some(err) = err {
+        container(
+            stack((
+                text_input_view,
+                label(move || err.clone()).style(move |s| {
+                    let config = config.get();
+
+                    let editor_background_color =
+                        config.color(LapceColor::PANEL_CURRENT_BACKGROUND);
+                    let error_background_color =
+                        config.color(LapceColor::ERROR_LENS_ERROR_BACKGROUND);
+
+                    let background_color = blend_colors(
+                        editor_background_color,
+                        error_background_color,
+                    );
+
+                    s.position(Position::Absolute)
+                        .inset_top(ui_line_height.get())
+                        .width_full()
+                        .color(config.color(LapceColor::ERROR_LENS_ERROR_FOREGROUND))
+                        .background(background_color)
+                        .z_index(100)
+                }),
+            ))
+            .style(|s| s.flex_grow(1.0)),
+        )
+    } else {
+        container(text_input_view)
+    }
 }
 
 fn new_file_node_view(data: FileExplorerData) -> impl View {
     let root = data.root;
     let ui_line_height = data.common.ui_line_height;
     let config = data.common.config;
-    let rename_state = data.rename_state;
+    let naming = data.naming;
 
     let secondary_click_data = data.clone();
 
     virtual_stack(
         VirtualDirection::Vertical,
         VirtualItemSize::Fixed(Box::new(move || ui_line_height.get())),
-        move || FileNodeVirtualList::new(root.get(), data.rename_state.get()),
-        move |node| {
-            (
-                node.path.clone(),
-                node.is_dir,
-                node.open,
-                node.is_renaming.clone(),
-                node.level,
-            )
-        },
+        move || FileNodeVirtualList::new(root.get(), data.naming.get()),
+        move |node| (node.kind.clone(), node.is_dir, node.open, node.level),
         move |node| {
             let level = node.level;
             let data = data.clone();
@@ -245,14 +249,9 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
             let double_click_data = data.clone();
             let secondary_click_data = data.clone();
             let aux_click_data = data.clone();
-            let path = node.path.clone();
-            let click_path = node.path.clone();
-            let double_click_path = node.path.clone();
-            let secondary_click_path = node.path.clone();
-            let aux_click_path = path.clone();
+            let kind = node.kind.clone();
             let open = node.open;
             let is_dir = node.is_dir;
-            let is_renaming = node.is_renaming.clone();
 
             let view = stack((
                 svg(move || {
@@ -278,8 +277,9 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                         .color(color)
                 }),
                 {
-                    let path = path.clone();
-                    let path_for_style = path.clone();
+                    let kind = kind.clone();
+                    let kind_for_style = kind.clone();
+                    // TODO: use the current naming input as the path for the file svg
                     svg(move || {
                         let config = config.get();
                         if is_dir {
@@ -288,8 +288,10 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                                 false => LapceIcons::DIRECTORY_CLOSED,
                             };
                             config.ui_svg(svg_str)
-                        } else {
+                        } else if let Some(path) = kind.path() {
                             config.file_svg(&path).0
+                        } else {
+                            config.ui_svg(LapceIcons::FILE)
                         }
                     })
                     .style(move |s| {
@@ -304,13 +306,15 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                             })
                             .apply_if(!is_dir, |s| {
                                 s.apply_opt(
-                                    config.file_svg(&path_for_style).1,
+                                    kind_for_style
+                                        .path()
+                                        .and_then(|p| config.file_svg(&p).1),
                                     Style::color,
                                 )
                             })
                     })
                 },
-                file_node_text_view(data, node, &path),
+                file_node_text_view(data, node),
             ))
             .style(move |s| {
                 s.padding_right(5.0)
@@ -324,7 +328,12 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
                     })
             });
 
-            if let IsRenaming::NotRenaming = is_renaming {
+            // Only handle click events if we are not naming the file node
+            if let FileNodeViewKind::Path(path) = kind {
+                let click_path = path.clone();
+                let double_click_path = path.clone();
+                let secondary_click_path = path.clone();
+                let aux_click_path = path;
                 view.on_click_stop(move |_| {
                     click_data.click(&click_path);
                 })
@@ -351,7 +360,7 @@ fn new_file_node_view(data: FileExplorerData) -> impl View {
     )
     .style(|s| s.flex_col().align_items(AlignItems::Stretch).width_full())
     .on_secondary_click_stop(move |_| {
-        if let RenameState::NotRenaming = rename_state.get_untracked() {
+        if let Naming::None = naming.get_untracked() {
             if let Some(path) = &secondary_click_data.common.workspace.path {
                 secondary_click_data.secondary_click(path);
             }

--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -58,6 +58,34 @@ pub trait KeyPressFocus {
 
     fn receive_char(&self, c: &str);
 }
+impl KeyPressFocus for () {
+    fn get_mode(&self) -> Mode {
+        Mode::Normal
+    }
+
+    fn check_condition(&self, _condition: Condition) -> bool {
+        false
+    }
+
+    fn run_command(
+        &self,
+        _command: &LapceCommand,
+        _count: Option<usize>,
+        _mods: ModifiersState,
+    ) -> CommandExecuted {
+        CommandExecuted::No
+    }
+
+    fn expect_char(&self) -> bool {
+        false
+    }
+
+    fn focus_only(&self) -> bool {
+        false
+    }
+
+    fn receive_char(&self, _c: &str) {}
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum EventRef<'a> {
@@ -134,7 +162,7 @@ impl KeyPressData {
         self.commands_without_keymap = Rc::new(commands_without_keymap);
     }
 
-    fn handle_count<T: KeyPressFocus>(
+    fn handle_count<T: KeyPressFocus + ?Sized>(
         &self,
         focus: &T,
         keypress: &KeyPress,
@@ -164,7 +192,7 @@ impl KeyPressData {
         false
     }
 
-    fn run_command<T: KeyPressFocus>(
+    fn run_command<T: KeyPressFocus + ?Sized>(
         &self,
         command: &str,
         count: Option<usize>,
@@ -198,7 +226,7 @@ impl KeyPressData {
         Some(keypress)
     }
 
-    pub fn key_down<'a, T: KeyPressFocus>(
+    pub fn key_down<'a, T: KeyPressFocus + ?Sized>(
         &self,
         event: impl Into<EventRef<'a>>,
         focus: &T,
@@ -314,7 +342,7 @@ impl KeyPressData {
         mods
     }
 
-    fn match_keymap<T: KeyPressFocus>(
+    fn match_keymap<T: KeyPressFocus + ?Sized>(
         &self,
         keypresses: &[KeyPress],
         check: &T,
@@ -365,8 +393,11 @@ impl KeyPressData {
         }
     }
 
-    fn check_condition<T: KeyPressFocus>(condition: &str, check: &T) -> bool {
-        fn check_one_condition<T: KeyPressFocus>(
+    fn check_condition<T: KeyPressFocus + ?Sized>(
+        condition: &str,
+        check: &T,
+    ) -> bool {
+        fn check_one_condition<T: KeyPressFocus + ?Sized>(
             condition: &str,
             check: &T,
         ) -> bool {

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -27,7 +27,7 @@ use lapce_core::{
 use lapce_rpc::{
     core::CoreNotification,
     dap_types::RunDebugConfig,
-    file::{PathObject, RenameState},
+    file::{Naming, PathObject, RenameState},
     proxy::{ProxyResponse, ProxyRpcHandler, ProxyStatus},
     source_control::FileDiff,
     terminal::TermId,
@@ -1317,24 +1317,24 @@ impl WindowTabData {
                 self.file_explorer.reload();
             }
             InternalCommand::StartRenamePath { path } => {
-                self.file_explorer.rename_state.set(RenameState::Renaming {
-                    path,
-                    editor_needs_reset: true,
-                });
+                self.file_explorer.naming.set(Naming::Renaming(
+                    RenameState::Renaming {
+                        path,
+                        editor_needs_reset: true,
+                    },
+                ));
             }
-            InternalCommand::TestRenamePath { new_path } => {
-                let rename_state = self.file_explorer.rename_state;
+            InternalCommand::TestPathCreation { new_path } => {
+                let naming = self.file_explorer.naming;
 
                 let send = create_ext_action(
                     self.scope,
                     move |response: Result<ProxyResponse, RpcError>| match response {
                         Ok(_) => {
-                            rename_state.update(RenameState::set_ok);
+                            naming.update(Naming::set_ok);
                         }
                         Err(err) => {
-                            rename_state.update(|rename_state| {
-                                rename_state.set_err(err.message)
-                            });
+                            naming.update(|naming| naming.set_err(err.message));
                         }
                     },
                 );
@@ -1345,6 +1345,7 @@ impl WindowTabData {
                 current_path,
                 new_path,
             } => {
+                println!("FinishRenamePath");
                 let send_current_path = current_path.clone();
                 let send_new_path = new_path.clone();
                 let file_explorer = self.file_explorer.clone();
@@ -1354,6 +1355,7 @@ impl WindowTabData {
                     self.scope,
                     move |response: Result<ProxyResponse, RpcError>| match response {
                         Ok(response) => {
+                            println!("Got rename path response");
                             // Get the canonicalized new path from the proxy.
                             let new_path =
                                 if let ProxyResponse::CreatePathResponse { path } =
@@ -1403,22 +1405,90 @@ impl WindowTabData {
                             }
 
                             file_explorer.reload();
-                            file_explorer.rename_state.set(RenameState::NotRenaming);
+                            file_explorer.naming.set(Naming::None);
                         }
                         Err(err) => {
-                            file_explorer.rename_state.update(|rename_state| {
-                                rename_state.set_err(err.message)
-                            });
+                            file_explorer
+                                .naming
+                                .update(|naming| naming.set_err(err.message));
                         }
                     },
                 );
 
-                self.file_explorer
-                    .rename_state
-                    .update(RenameState::set_pending);
+                self.file_explorer.naming.update(Naming::set_pending);
                 self.common
                     .proxy
                     .rename_path(current_path.clone(), new_path, send);
+            }
+            InternalCommand::FinishNewNode { is_dir, path } => {
+                let file_explorer = self.file_explorer.clone();
+                let internal_command = self.common.internal_command;
+                // let main_split = self.main_split.clone();
+
+                let send = create_ext_action(
+                    self.scope,
+                    move |response: Result<ProxyResponse, RpcError>| {
+                        match response {
+                            Ok(response) => {
+                                file_explorer.reload();
+                                file_explorer.naming.set(Naming::None);
+
+                                // Open a new file in the editor
+                                if let ProxyResponse::CreatePathResponse { path } =
+                                    response
+                                {
+                                    if !is_dir {
+                                        internal_command.send(
+                                            InternalCommand::OpenFile { path },
+                                        );
+                                        // main_split.jump_to_location(
+                                        //     EditorLocation {
+                                        //         path,
+                                        //         position: None,
+                                        //         scroll_offset: None,
+                                        //         ignore_unconfirmed: false,
+                                        //         same_editor_tab: false,
+                                        //     },
+                                        //     None,
+                                        // );
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                file_explorer
+                                    .naming
+                                    .update(|naming| naming.set_err(err.message));
+                            }
+                        }
+                    },
+                );
+
+                self.file_explorer.naming.update(Naming::set_pending);
+                if is_dir {
+                    self.common.proxy.create_directory(path, send);
+                } else {
+                    self.common.proxy.create_file(path, send);
+                }
+            }
+            InternalCommand::FinishDuplicate { source, path } => {
+                let file_explorer = self.file_explorer.clone();
+
+                let send = create_ext_action(
+                    self.scope,
+                    move |response: Result<_, RpcError>| {
+                        if let Err(err) = response {
+                            file_explorer
+                                .naming
+                                .update(|naming| naming.set_err(err.message));
+                        } else {
+                            file_explorer.reload();
+                            file_explorer.naming.set(Naming::None);
+                        }
+                    },
+                );
+
+                self.file_explorer.naming.update(Naming::set_pending);
+                self.common.proxy.duplicate_path(source, path, send);
             }
             InternalCommand::GoToLocation { location } => {
                 self.main_split.go_to_location(location, None);

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -27,7 +27,7 @@ use lapce_core::{
 use lapce_rpc::{
     core::CoreNotification,
     dap_types::RunDebugConfig,
-    file::{Naming, PathObject, RenameState},
+    file::{Naming, PathObject},
     proxy::{ProxyResponse, ProxyRpcHandler, ProxyStatus},
     source_control::FileDiff,
     terminal::TermId,
@@ -1316,14 +1316,6 @@ impl WindowTabData {
             InternalCommand::ReloadFileExplorer => {
                 self.file_explorer.reload();
             }
-            InternalCommand::StartRenamePath { path } => {
-                self.file_explorer.naming.set(Naming::Renaming(
-                    RenameState::Renaming {
-                        path,
-                        editor_needs_reset: true,
-                    },
-                ));
-            }
             InternalCommand::TestPathCreation { new_path } => {
                 let naming = self.file_explorer.naming;
 
@@ -1423,7 +1415,6 @@ impl WindowTabData {
             InternalCommand::FinishNewNode { is_dir, path } => {
                 let file_explorer = self.file_explorer.clone();
                 let internal_command = self.common.internal_command;
-                // let main_split = self.main_split.clone();
 
                 let send = create_ext_action(
                     self.scope,
@@ -1441,16 +1432,6 @@ impl WindowTabData {
                                         internal_command.send(
                                             InternalCommand::OpenFile { path },
                                         );
-                                        // main_split.jump_to_location(
-                                        //     EditorLocation {
-                                        //         path,
-                                        //         position: None,
-                                        //         scroll_offset: None,
-                                        //         ignore_unconfirmed: false,
-                                        //         same_editor_tab: false,
-                                        //     },
-                                        //     None,
-                                        // );
                                     }
                                 }
                             }

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -1313,6 +1313,9 @@ impl WindowTabData {
             InternalCommand::OpenFileChanges { path } => {
                 self.main_split.open_file_changes(path);
             }
+            InternalCommand::ReloadFileExplorer => {
+                self.file_explorer.reload();
+            }
             InternalCommand::StartRenamePath { path } => {
                 self.file_explorer.rename_state.set(RenameState::Renaming {
                     path,

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -450,7 +450,6 @@ impl FileNodeItem {
             return current + self.children_open_count;
         }
 
-        let mut i = current;
         if current >= min {
             let kind = if let Naming::Renaming(r) = &naming {
                 if r.path == self.path {
@@ -472,6 +471,19 @@ impl FileNodeItem {
             });
         }
 
+        self.append_children_view_slice(view_items, naming, min, max, current, level)
+    }
+
+    /// Append the children of this item with the given level
+    pub fn append_children_view_slice(
+        &self,
+        view_items: &mut Vec<FileNodeViewData>,
+        naming: &Naming,
+        min: usize,
+        max: usize,
+        mut i: usize,
+        level: usize,
+    ) -> usize {
         let mut naming_extra = naming.extra_node(self.is_dir, level, &self.path);
 
         if !self.open {
@@ -531,6 +543,7 @@ impl FileNodeItem {
             }
         }
 
+        // If it has not been added yet, add it now.
         if i >= min {
             if let Some(node) = naming_extra {
                 view_items.push(node);

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -48,22 +48,129 @@ impl PathObject {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum Naming {
+    /// Not naming anything
+    None,
+    Renaming(RenameState),
+    NewNode(NewNodeState),
+    Duplicating(DuplicateState),
+}
+impl Naming {
+    pub fn as_renaming(&self) -> Option<&RenameState> {
+        match self {
+            Naming::Renaming(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    /// Change to error state, if doing any naming
+    pub fn set_err(&mut self, message: String) {
+        match self {
+            Naming::None => {}
+            Naming::Renaming(state) => state.set_err(message),
+            Naming::NewNode(state) => state.set_err(message),
+            Naming::Duplicating(state) => state.set_err(message),
+        }
+    }
+
+    pub fn set_ok(&mut self) {
+        match self {
+            Naming::None => {}
+            Naming::Renaming(state) => state.set_ok(),
+            Naming::NewNode(state) => state.set_ok(),
+            Naming::Duplicating(state) => state.set_ok(),
+        }
+    }
+
+    pub fn set_pending(&mut self) {
+        match self {
+            Naming::None => {}
+            Naming::Renaming(state) => state.set_pending(),
+            Naming::NewNode(state) => state.set_pending(),
+            Naming::Duplicating(state) => state.set_pending(),
+        }
+    }
+
+    pub fn is_accepting_input(&self) -> bool {
+        match self {
+            Naming::None => false,
+            Naming::Renaming(state) => state.is_accepting_input(),
+            Naming::NewNode(state) => state.is_accepting_input(),
+            Naming::Duplicating(state) => state.is_accepting_input(),
+        }
+    }
+
+    pub fn set_editor_needs_reset(&mut self, needs_reset: bool) {
+        match self {
+            Naming::None => {}
+            Naming::Renaming(state) => state.set_editor_needs_reset(needs_reset),
+            Naming::NewNode(state) => state.set_editor_needs_reset(needs_reset),
+            Naming::Duplicating(state) => state.set_editor_needs_reset(needs_reset),
+        }
+    }
+
+    pub fn editor_needs_reset(&self) -> bool {
+        match self {
+            Naming::None => false,
+            Naming::Renaming(rename) => rename.editor_needs_reset(),
+            Naming::NewNode(state) => state.editor_needs_reset(),
+            Naming::Duplicating(state) => state.editor_needs_reset(),
+        }
+    }
+
+    /// The extra node that should be added after the node at `path`
+    pub fn extra_node(
+        &self,
+        is_dir: bool,
+        level: usize,
+        path: &Path,
+    ) -> Option<FileNodeViewData> {
+        match self {
+            Naming::NewNode(state) if state.base_path() == path => {
+                Some(FileNodeViewData {
+                    kind: FileNodeViewKind::Naming {
+                        err: state.err().map(ToString::to_string),
+                    },
+                    is_dir: state.is_dir(),
+                    open: false,
+                    level: level + 1,
+                })
+            }
+            Naming::Duplicating(state) if state.path() == path => {
+                Some(FileNodeViewData {
+                    kind: FileNodeViewKind::Duplicating {
+                        source: state.path().to_path_buf(),
+                        err: state.err().map(ToString::to_string),
+                    },
+                    is_dir,
+                    open: false,
+                    level: level + 1,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
 /// Stores the state of any in progress rename of a path.
 ///
 /// The `editor_needs_reset` field is `true` if the rename editor should have its contents reset
 /// when the view function next runs.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum RenameState {
-    NotRenaming,
     Renaming {
+        /// Original path
         path: PathBuf,
         editor_needs_reset: bool,
     },
     RenameRequestPending {
+        /// Original path
         path: PathBuf,
         editor_needs_reset: bool,
     },
     RenameErr {
+        /// Original path
         path: PathBuf,
         editor_needs_reset: bool,
         err: String,
@@ -73,17 +180,22 @@ pub enum RenameState {
 impl RenameState {
     pub fn is_accepting_input(&self) -> bool {
         match self {
-            Self::NotRenaming | Self::RenameRequestPending { .. } => false,
+            Self::RenameRequestPending { .. } => false,
             Self::Renaming { .. } | Self::RenameErr { .. } => true,
         }
     }
 
     pub fn is_err(&self) -> bool {
         match self {
-            Self::NotRenaming
-            | Self::Renaming { .. }
-            | Self::RenameRequestPending { .. } => false,
+            Self::Renaming { .. } | Self::RenameRequestPending { .. } => false,
             Self::RenameErr { .. } => true,
+        }
+    }
+
+    pub fn err(&self) -> Option<&str> {
+        match self {
+            Self::RenameErr { err, .. } => Some(err.as_str()),
+            _ => None,
         }
     }
 
@@ -124,57 +236,58 @@ impl RenameState {
     }
 
     pub fn set_err(&mut self, err: String) {
-        if let &mut Self::Renaming {
-            ref mut path,
-            editor_needs_reset,
-        }
-        | &mut Self::RenameRequestPending {
-            ref mut path,
-            editor_needs_reset,
-        }
-        | &mut Self::RenameErr {
-            ref mut path,
-            editor_needs_reset,
-            ..
-        } = self
-        {
-            let path = mem::take(path);
-
-            *self = Self::RenameErr {
+        match self {
+            Self::Renaming {
                 path,
                 editor_needs_reset,
-                err,
-            };
+            }
+            | Self::RenameRequestPending {
+                path,
+                editor_needs_reset,
+            }
+            | Self::RenameErr {
+                path,
+                editor_needs_reset,
+                ..
+            } => {
+                let path = mem::take(path);
+
+                *self = Self::RenameErr {
+                    path,
+                    editor_needs_reset: *editor_needs_reset,
+                    err,
+                };
+            }
         }
     }
 
     pub fn set_editor_needs_reset(&mut self, needs_reset: bool) {
-        if let Self::Renaming {
-            editor_needs_reset, ..
-        }
-        | Self::RenameRequestPending {
-            editor_needs_reset, ..
-        }
-        | Self::RenameErr {
-            editor_needs_reset, ..
-        } = self
-        {
-            *editor_needs_reset = needs_reset;
+        match self {
+            Self::Renaming {
+                editor_needs_reset, ..
+            }
+            | Self::RenameRequestPending {
+                editor_needs_reset, ..
+            }
+            | Self::RenameErr {
+                editor_needs_reset, ..
+            } => {
+                *editor_needs_reset = needs_reset;
+            }
         }
     }
 
-    pub fn path(&self) -> Option<&Path> {
+    /// Get the path for the target file we're renaming
+    pub fn path(&self) -> &Path {
         match self {
-            Self::NotRenaming => None,
             Self::Renaming { path, .. }
             | Self::RenameRequestPending { path, .. }
-            | Self::RenameErr { path, .. } => Some(path),
+            | Self::RenameErr { path, .. } => path,
         }
     }
 
     pub fn editor_needs_reset(&self) -> bool {
         match self {
-            Self::NotRenaming => false,
             &Self::Renaming {
                 editor_needs_reset, ..
             }
@@ -188,43 +301,335 @@ impl RenameState {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum IsRenaming {
-    NotRenaming,
-    Renaming { err: Option<String> },
+#[derive(Debug, Clone)]
+pub enum NewNodeState {
+    /// We are naming the uncreated node
+    Naming {
+        /// If true, then we are creating a directory
+        is_dir: bool,
+        /// The folder that the file/directory is being created within
+        base_path: PathBuf,
+        editor_needs_reset: bool,
+    },
+    /// We are waiting for the node to be created
+    CreationPending {
+        base_path: PathBuf,
+        is_dir: bool,
+        editor_needs_reset: bool,
+    },
+    /// There is or would be an error in creating the node there
+    Err {
+        base_path: PathBuf,
+        is_dir: bool,
+        editor_needs_reset: bool,
+        err: String,
+    },
+}
+impl NewNodeState {
+    pub fn is_dir(&self) -> bool {
+        match self {
+            Self::Naming { is_dir, .. }
+            | Self::CreationPending { is_dir, .. }
+            | Self::Err { is_dir, .. } => *is_dir,
+        }
+    }
+
+    pub fn is_accepting_input(&self) -> bool {
+        match self {
+            Self::Naming { .. } | Self::Err { .. } => true,
+            Self::CreationPending { .. } => false,
+        }
+    }
+
+    pub fn is_err(&self) -> bool {
+        match self {
+            Self::Naming { .. } | Self::CreationPending { .. } => false,
+            Self::Err { .. } => true,
+        }
+    }
+
+    pub fn err(&self) -> Option<&str> {
+        match self {
+            Self::Err { err, .. } => Some(err.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn set_ok(&mut self) {
+        if let &mut Self::Err {
+            ref mut base_path,
+            is_dir,
+            editor_needs_reset,
+            ..
+        } = self
+        {
+            let base_path = mem::take(base_path);
+
+            *self = Self::Naming {
+                is_dir,
+                base_path,
+                editor_needs_reset,
+            };
+        }
+    }
+
+    pub fn set_pending(&mut self) {
+        if let &mut Self::Naming {
+            ref mut base_path,
+            is_dir,
+            editor_needs_reset,
+        } = self
+        {
+            let base_path = mem::take(base_path);
+
+            *self = Self::CreationPending {
+                base_path,
+                is_dir,
+                editor_needs_reset,
+            };
+        }
+    }
+
+    pub fn set_err(&mut self, err: String) {
+        match self {
+            Self::Naming {
+                base_path,
+                is_dir,
+                editor_needs_reset,
+            }
+            | Self::CreationPending {
+                base_path,
+                is_dir,
+                editor_needs_reset,
+            }
+            | Self::Err {
+                base_path,
+                is_dir,
+                editor_needs_reset,
+                ..
+            } => {
+                let base_path = mem::take(base_path);
+
+                *self = Self::Err {
+                    base_path,
+                    is_dir: *is_dir,
+                    editor_needs_reset: *editor_needs_reset,
+                    err,
+                };
+            }
+        }
+    }
+
+    pub fn base_path(&self) -> &Path {
+        match self {
+            Self::Naming { base_path, .. }
+            | Self::CreationPending { base_path, .. }
+            | Self::Err { base_path, .. } => base_path,
+        }
+    }
+
+    pub fn set_editor_needs_reset(&mut self, needs_reset: bool) {
+        match self {
+            Self::Naming {
+                editor_needs_reset, ..
+            }
+            | Self::CreationPending {
+                editor_needs_reset, ..
+            }
+            | Self::Err {
+                editor_needs_reset, ..
+            } => {
+                *editor_needs_reset = needs_reset;
+            }
+        }
+    }
+
+    pub fn editor_needs_reset(&self) -> bool {
+        match self {
+            &Self::Naming {
+                editor_needs_reset, ..
+            }
+            | &Self::CreationPending {
+                editor_needs_reset, ..
+            }
+            | &Self::Err {
+                editor_needs_reset, ..
+            } => editor_needs_reset,
+        }
+    }
 }
 
-impl IsRenaming {
-    fn is_node_renaming(rename_state: &RenameState, node_path: &Path) -> Self {
-        match rename_state {
-            RenameState::NotRenaming => Self::NotRenaming,
-            RenameState::Renaming { path, .. }
-            | RenameState::RenameRequestPending { path, .. } => {
-                if path == node_path {
-                    Self::Renaming { err: None }
-                } else {
-                    Self::NotRenaming
-                }
+/// State for duplicating a file/directory in the same folder
+#[derive(Debug, Clone)]
+pub enum DuplicateState {
+    /// We are naming the uncreated node
+    Naming {
+        /// Path to the item being duplicated
+        path: PathBuf,
+        editor_needs_reset: bool,
+    },
+    /// We are waiting for the node to be created
+    CreationPending {
+        /// Path to the item being duplicated
+        path: PathBuf,
+        editor_needs_reset: bool,
+    },
+    /// There is or would be an error in creating the node there
+    Err {
+        /// Path to the item being duplicated
+        path: PathBuf,
+        editor_needs_reset: bool,
+        err: String,
+    },
+}
+impl DuplicateState {
+    pub fn is_accepting_input(&self) -> bool {
+        match self {
+            Self::Naming { .. } | Self::Err { .. } => true,
+            Self::CreationPending { .. } => false,
+        }
+    }
+
+    pub fn is_err(&self) -> bool {
+        match self {
+            Self::Naming { .. } | Self::CreationPending { .. } => false,
+            Self::Err { .. } => true,
+        }
+    }
+
+    pub fn err(&self) -> Option<&str> {
+        match self {
+            Self::Err { err, .. } => Some(err.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn set_ok(&mut self) {
+        if let &mut Self::Err {
+            ref mut path,
+            editor_needs_reset,
+            ..
+        } = self
+        {
+            let path = mem::take(path);
+
+            *self = Self::Naming {
+                path,
+                editor_needs_reset,
+            };
+        }
+    }
+
+    pub fn set_pending(&mut self) {
+        if let &mut Self::Naming {
+            ref mut path,
+            editor_needs_reset,
+        } = self
+        {
+            let path = mem::take(path);
+
+            *self = Self::CreationPending {
+                path,
+                editor_needs_reset,
+            };
+        }
+    }
+
+    pub fn set_err(&mut self, err: String) {
+        match self {
+            Self::Naming {
+                path,
+                editor_needs_reset,
             }
-            RenameState::RenameErr { path, err, .. } => {
-                if path == node_path {
-                    Self::Renaming {
-                        err: Some(err.clone()),
-                    }
-                } else {
-                    Self::NotRenaming
-                }
+            | Self::CreationPending {
+                path,
+                editor_needs_reset,
             }
+            | Self::Err {
+                path,
+                editor_needs_reset,
+                ..
+            } => {
+                let path = mem::take(path);
+
+                *self = Self::Err {
+                    path,
+                    editor_needs_reset: *editor_needs_reset,
+                    err,
+                };
+            }
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Naming { path, .. }
+            | Self::CreationPending { path, .. }
+            | Self::Err { path, .. } => path,
+        }
+    }
+
+    pub fn set_editor_needs_reset(&mut self, needs_reset: bool) {
+        match self {
+            Self::Naming {
+                editor_needs_reset, ..
+            }
+            | Self::CreationPending {
+                editor_needs_reset, ..
+            }
+            | Self::Err {
+                editor_needs_reset, ..
+            } => {
+                *editor_needs_reset = needs_reset;
+            }
+        }
+    }
+
+    pub fn editor_needs_reset(&self) -> bool {
+        match self {
+            &Self::Naming {
+                editor_needs_reset, ..
+            }
+            | &Self::CreationPending {
+                editor_needs_reset, ..
+            }
+            | &Self::Err {
+                editor_needs_reset, ..
+            } => editor_needs_reset,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FileNodeViewKind {
+    /// An actual file/directory
+    Path(PathBuf),
+    /// We are renaming the file at this path
+    Renaming { path: PathBuf, err: Option<String> },
+    /// We are naming a new file/directory
+    Naming { err: Option<String> },
+    Duplicating {
+        /// The path that is being duplicated
+        source: PathBuf,
+        err: Option<String>,
+    },
+}
+impl FileNodeViewKind {
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::Path(path)
+            | Self::Renaming { path, .. }
+            | Self::Duplicating { source: path, .. } => Some(path),
+            Self::Naming { .. } => None,
         }
     }
 }
 
 #[derive(Debug)]
 pub struct FileNodeViewData {
-    pub path: PathBuf,
+    pub kind: FileNodeViewKind,
     pub is_dir: bool,
     pub open: bool,
-    pub is_renaming: IsRenaming,
     pub level: usize,
 }
 
@@ -414,7 +819,7 @@ impl FileNodeItem {
     pub fn append_view_slice(
         &self,
         view_items: &mut Vec<FileNodeViewData>,
-        rename_state: &RenameState,
+        naming: &Naming,
         min: usize,
         max: usize,
         current: usize,
@@ -429,30 +834,92 @@ impl FileNodeItem {
 
         let mut i = current;
         if current >= min {
+            let kind = if let Naming::Renaming(state) = &naming {
+                if state.path() == self.path {
+                    FileNodeViewKind::Renaming {
+                        path: self.path.clone(),
+                        err: state.err().map(ToString::to_string),
+                    }
+                } else {
+                    FileNodeViewKind::Path(self.path.clone())
+                }
+            } else {
+                FileNodeViewKind::Path(self.path.clone())
+            };
             view_items.push(FileNodeViewData {
-                path: self.path.clone(),
+                kind,
                 is_dir: self.is_dir,
                 open: self.open,
-                is_renaming: IsRenaming::is_node_renaming(rename_state, &self.path),
                 level,
             });
         }
 
-        if self.open {
-            for item in self.sorted_children() {
-                i = item.append_view_slice(
-                    view_items,
-                    rename_state,
-                    min,
-                    max,
-                    i + 1,
-                    level + 1,
-                );
-                if i > max {
-                    return i;
+        let mut naming_extra = naming.extra_node(self.is_dir, level, &self.path);
+
+        if !self.open {
+            // If the folder isn't open, then we just put it right at the top
+            if i >= min {
+                if let Some(naming_extra) = naming_extra {
+                    view_items.push(naming_extra);
+                    i += 1;
+                }
+            }
+            return i;
+        }
+
+        let naming_is_dir = naming_extra.as_ref().map(|n| n.is_dir).unwrap_or(false);
+        // Immediately put the naming entry first if it's a directory
+        if naming_is_dir {
+            if let Some(node) = naming_extra.take() {
+                // Actually add the node if it's within the range
+                if i >= min {
+                    view_items.push(node);
+                    i += 1;
                 }
             }
         }
+
+        let mut after_dirs = false;
+
+        for item in self.sorted_children() {
+            // If we're naming a file at the root, then wait until we've added the directories
+            // before adding the input node
+            if naming_extra.is_some()
+                && !naming_is_dir
+                && !item.is_dir
+                && !after_dirs
+            {
+                after_dirs = true;
+
+                // If we're creating a new file node, then we show it after the directories
+                // TODO(minor): should this be i >= min or i + 1 >= min?
+                if i >= min {
+                    if let Some(node) = naming_extra.take() {
+                        view_items.push(node);
+                        i += 1;
+                    }
+                }
+            }
+            i = item.append_view_slice(
+                view_items,
+                naming,
+                min,
+                max,
+                i + 1,
+                level + 1,
+            );
+            if i > max {
+                return i;
+            }
+        }
+
+        if i >= min {
+            if let Some(node) = naming_extra {
+                view_items.push(node);
+                i += 1;
+            }
+        }
+
         i
     }
 }

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -195,15 +195,21 @@ impl Naming {
     }
 
     pub fn set_ok(&mut self) {
-        self.state_mut().map(NamingState::set_ok);
+        if let Some(state) = self.state_mut() {
+            state.set_ok();
+        }
     }
 
     pub fn set_pending(&mut self) {
-        self.state_mut().map(NamingState::set_pending);
+        if let Some(state) = self.state_mut() {
+            state.set_pending();
+        }
     }
 
     pub fn set_err(&mut self, err: String) {
-        self.state_mut().map(|state| state.set_err(err));
+        if let Some(state) = self.state_mut() {
+            state.set_err(err);
+        }
     }
 
     pub fn as_renaming(&self) -> Option<&Renaming> {


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users
This PR is primarily for adding back the file explorer context menu items.  
Fixes #2873  #2953   
Commits:  
- Add some comments, use `let Some(x) = ... else { return; }` to avoid some over-indented code
- Remove unused `id` field.  
The `id` field was not used anywhere.  
While it could have been useful in some cases (ex: logic that wants to simply know when the file explorer was updated), I'm not sure it would have been that useful as it is changed before the updating of the explorer. It would be simple enough to add back in later, with whatever form is useful when actually needed.  

-  Initial adding of missing context menu commands
- Main commit, actually implement new file / new directory / duplicate
  - Also fixes a bug we apparently had where typing in the input box would cause multiple characters to appear
- Simplify the state machine logic to share more between the state
- Simplify the creation of children
  - Most editors have so if you create a new file the input box shows *after* all the folders. And if you are creating a new directory then it should show *before* all the folders. I wonder if there's a way to make that logic less ugly.
- Make so you can right-click anywhere in file explorer, which is nicer than requiring a file/dir to be right-clicked

Adds:
- New file
- New directory
- Reveal in file explorer
- Duplicate
- Move directory to trash
- Copy path
- Copy relative path
- Refresh

Current Issues:
- I'm getting a problem where the context menu does not show all the entries. I think there's a max size for the context menu that causes problems... I get this on normal floem as well so it is a problem there.