### PR TITLE
Focus on app_view so that find receives keypresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository
+- [#3031](https://github.com/lapce/lapce/pull/3031): Fix find not receiving inputs when clicked
 
 ## 0.3.1
 

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -420,8 +420,10 @@ impl AppData {
     }
 
     fn app_view(&self, window_id: WindowId, info: WindowInfo) -> impl View {
+        let app_view_id = create_rw_signal(floem::id::Id::next());
         let window_data = WindowData::new(
             window_id,
+            app_view_id,
             info,
             self.window_scale,
             self.latest_release.read_only(),
@@ -521,6 +523,8 @@ impl AppData {
             ))
             .style(|s| s.flex_col().size_full());
         let view_id = view.id();
+        app_view_id.set(view_id);
+
         view.window_scale(move || window_scale.get())
             .keyboard_navigatable()
             .on_event(EventListener::KeyDown, move |event| {

--- a/lapce-app/src/window.rs
+++ b/lapce-app/src/window.rs
@@ -47,6 +47,7 @@ pub struct WindowCommonData {
     pub cursor_blink_timer: RwSignal<TimerToken>,
     // the value to be update by curosr blinking
     pub hide_cursor: RwSignal<bool>,
+    pub app_view_id: RwSignal<floem::id::Id>,
 }
 
 /// `WindowData` is the application model for a top-level window.
@@ -80,6 +81,7 @@ pub struct WindowData {
 impl WindowData {
     pub fn new(
         window_id: WindowId,
+        app_view_id: RwSignal<floem::id::Id>,
         info: WindowInfo,
         window_scale: RwSignal<f64>,
         latest_release: ReadSignal<Arc<Option<ReleaseInfo>>>,
@@ -113,6 +115,7 @@ impl WindowData {
             ime_allowed,
             cursor_blink_timer,
             hide_cursor,
+            app_view_id,
         });
 
         for w in info.tabs.workspaces {


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users  

Fixes #3012   
  
The issue was that `find_view` stops the pointer down event from propagating up to `app_view`, and so `app_view` lost the focus. Our current code dispatches (all?) keybinds from `app_view` to the locations, and so if `app_view` lost the focus then the find view would never receive the inputs (because it doesn't actually take the focus for itself).  
(The reason the `find_view` stops the input is because `app_view` also dispatches pointer down events! And so its naive code would let the pointer-down go through the find view and click on the editor itself)  
  
My fix for this is to simply store the `app_view_id` similarly to other stored ids so that the find view can manually focus it when clicked.  
  
-----
  
I'd like a better solution to this manual management of the focus, but I don't know of a good one. Maybe we could get around some of this if floem provided a way to listen to all keydown events, so then the editors handle their events when they're `focus`'d (like a normal view!) and just call out to keybinding handling, then app view handles the non-editor-focus case? I'm unsure.