### PR TITLE
Tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2955](https://github.com/lapce/lapce/pull/2955): Using glob patterns to hide files or directories in explorer
 - [#3026](https://github.com/lapce/lapce/pull/3026): Add missing file explorer context menu entries
 - [#3047](https://github.com/lapce/lapce/pull/3047): Add support for different CrLf/Lf line endings per-file
+- [#3053](https://github.com/lapce/lapce/pull/3053): Add tooltips to various places
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/defaults/dark-theme.toml
+++ b/defaults/dark-theme.toml
@@ -131,6 +131,9 @@ yellow = "#E5C07B"
 "source_control.removed" = "#FF5266CC"
 "source_control.modified" = "#0184BCCC"
 
+"tooltip.background" = "#4B4D51"
+"tooltip.foreground" = "$white"
+
 "palette.background" = "#21252B"
 "palette.foreground" = "$white"
 "palette.current.background" = "#2C313A"

--- a/defaults/light-theme.toml
+++ b/defaults/light-theme.toml
@@ -157,6 +157,9 @@ yellow = "#C18401"
 "source_control.removed" = "#FF5266CC"
 "source_control.modified" = "#0184BCCC"
 
+"tooltip.background" = "#D6D6D6"
+"tooltip.foreground" = "$black"
+
 "palette.background" = "#EAEAEB"
 "palette.foreground" = "$black"
 "palette.current.background" = "#DBDBDC"

--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -207,7 +207,7 @@ impl LapceConfig {
 
     fn default_lapce_config() -> LapceConfig {
         let mut default_lapce_config: LapceConfig =
-            DEFAULT_CONFIG.clone().try_deserialize().unwrap();
+            DEFAULT_CONFIG.clone().try_deserialize().expect("Failed to deserialize default config, this likely indicates a missing or misnamed field in settings.toml");
         default_lapce_config.resolve_colors(None);
         default_lapce_config
     }

--- a/lapce-app/src/config/color.rs
+++ b/lapce-app/src/config/color.rs
@@ -138,6 +138,9 @@ impl LapceColor {
     pub const DEBUG_BREAKPOINT: &'static str = "debug.breakpoint";
     pub const DEBUG_BREAKPOINT_HOVER: &'static str = "debug.breakpoint.hover";
 
+    pub const TOOLTIP_BACKGROUND: &'static str = "tooltip.background";
+    pub const TOOLTIP_FOREGROUND: &'static str = "tooltip.foreground";
+
     pub const PANEL_BACKGROUND: &'static str = "panel.background";
     pub const PANEL_FOREGROUND: &'static str = "panel.foreground";
     pub const PANEL_FOREGROUND_DIM: &'static str = "panel.foreground.dim";

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -1995,14 +1995,14 @@ impl EditorData {
         }
     }
 
-    fn do_save(&self, after_action: impl Fn() + 'static) {
+    fn do_save(&self, after_action: impl FnOnce() + 'static) {
         self.doc().save(after_action);
     }
 
     pub fn save(
         &self,
         allow_formatting: bool,
-        after_action: impl Fn() + 'static + Copy,
+        after_action: impl FnOnce() + 'static,
     ) {
         let doc = self.doc();
         let rev = doc.rev();

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -1794,6 +1794,7 @@ fn search_editor_view(
             },
             move || case_matching.get() == CaseMatching::Exact,
             || false,
+            || "Case Sensitive",
             config,
         )
         .style(|s| s.padding_vert(4.0)),
@@ -1806,6 +1807,7 @@ fn search_editor_view(
             },
             move || whole_word.get(),
             || false,
+            || "Whole Word",
             config,
         )
         .style(|s| s.padding_left(6.0)),
@@ -1818,6 +1820,7 @@ fn search_editor_view(
             },
             move || is_regex.get(),
             || false,
+            || "Use Regex",
             config,
         )
         .style(|s| s.padding_horiz(6.0)),
@@ -1923,6 +1926,7 @@ fn find_view(
                     },
                     move || false,
                     || false,
+                    || "Toggle Replace",
                     config,
                 )
                 .style(|s| s.padding_horiz(6.0)),
@@ -1950,6 +1954,7 @@ fn find_view(
                     },
                     move || false,
                     || false,
+                    || "Previous Match",
                     config,
                 )
                 .style(|s| s.padding_left(6.0)),
@@ -1962,6 +1967,7 @@ fn find_view(
                     },
                     move || false,
                     || false,
+                    || "Next Match",
                     config,
                 )
                 .style(|s| s.padding_left(6.0)),
@@ -1972,6 +1978,7 @@ fn find_view(
                     },
                     move || false,
                     || false,
+                    || "Close",
                     config,
                 )
                 .style(|s| s.padding_horiz(6.0)),
@@ -2001,6 +2008,7 @@ fn find_view(
                     },
                     move || false,
                     || false,
+                    || "Replace Next",
                     config,
                 )
                 .style(|s| s.padding_left(6.0)),
@@ -2015,6 +2023,7 @@ fn find_view(
                     },
                     move || false,
                     || false,
+                    || "Replace All",
                     config,
                 )
                 .style(|s| s.padding_left(6.0)),

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -411,6 +411,7 @@ fn open_editors_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                 },
                 || false,
                 || false,
+                || "Close",
                 config,
             )
             .on_event_stop(EventListener::PointerEnter, move |_| {

--- a/lapce-app/src/panel/debug_view.rs
+++ b/lapce-app/src/panel/debug_view.rs
@@ -95,6 +95,7 @@ fn debug_process_icons(
                     },
                     || false,
                     || false,
+                    || "Restart",
                     config,
                 )
                 .style(|s| s.margin_horiz(4.0))
@@ -108,6 +109,7 @@ fn debug_process_icons(
                     },
                     || false,
                     move || stopped,
+                    || "Stop",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -121,6 +123,7 @@ fn debug_process_icons(
                     },
                     || false,
                     || false,
+                    || "Close",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -136,6 +139,7 @@ fn debug_process_icons(
                     },
                     || false,
                     move || !paused() || stopped,
+                    || "Continue",
                     config,
                 )
                 .style(|s| s.margin_horiz(6.0))
@@ -149,6 +153,7 @@ fn debug_process_icons(
                     },
                     || false,
                     move || paused() || stopped,
+                    || "Pause",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -162,6 +167,7 @@ fn debug_process_icons(
                     },
                     || false,
                     move || !paused() || stopped,
+                    || "Step Over",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -175,6 +181,7 @@ fn debug_process_icons(
                     },
                     || false,
                     move || !paused() || stopped,
+                    || "Step Into",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -188,6 +195,7 @@ fn debug_process_icons(
                     },
                     || false,
                     move || !paused() || stopped,
+                    || "Step Out",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -201,6 +209,7 @@ fn debug_process_icons(
                     },
                     || false,
                     || false,
+                    || "Restart",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -214,6 +223,7 @@ fn debug_process_icons(
                     },
                     || false,
                     move || stopped,
+                    || "Stop",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -227,6 +237,7 @@ fn debug_process_icons(
                     },
                     || false,
                     || false,
+                    || "Close",
                     config,
                 )
                 .style(|s| s.margin_right(4.0))
@@ -668,6 +679,7 @@ fn breakpoints_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                             },
                             || false,
                             || false,
+                            || "Remove",
                             config,
                         )
                         .on_event_stop(EventListener::PointerDown, |_| {}),

--- a/lapce-app/src/panel/global_search_view.rs
+++ b/lapce-app/src/panel/global_search_view.rs
@@ -57,6 +57,7 @@ pub fn global_search_panel(
                     },
                     move || case_matching.get() == CaseMatching::Exact,
                     || false,
+                    || "Case Sensitive",
                     config,
                 )
                 .style(|s| s.padding_vert(4.0)),
@@ -69,6 +70,7 @@ pub fn global_search_panel(
                     },
                     move || whole_word.get(),
                     || false,
+                    || "Whole Word",
                     config,
                 )
                 .style(|s| s.padding_left(6.0)),
@@ -81,6 +83,7 @@ pub fn global_search_panel(
                     },
                     move || is_regex.get(),
                     || false,
+                    || "Use Regex",
                     config,
                 )
                 .style(|s| s.padding_left(6.0)),

--- a/lapce-app/src/panel/plugin_view.rs
+++ b/lapce-app/src/panel/plugin_view.rs
@@ -153,6 +153,7 @@ fn installed_view(plugin: PluginData) -> impl View {
                         || {},
                         || false,
                         || false,
+                        || "Options",
                         config,
                     )
                     .style(|s| s.padding_left(6.0))

--- a/lapce-app/src/panel/terminal_view.rs
+++ b/lapce-app/src/panel/terminal_view.rs
@@ -136,6 +136,7 @@ fn terminal_tab_header(window_tab_data: Rc<WindowTabData>) -> impl View {
                                 },
                                 || false,
                                 || false,
+                                || "Close",
                                 config,
                             )
                             .style(|s| s.margin_horiz(6.0)),
@@ -218,6 +219,7 @@ fn terminal_tab_header(window_tab_data: Rc<WindowTabData>) -> impl View {
             },
             || false,
             || false,
+            || "New Terminal",
             config,
         ))
         .on_resize(move |rect| {

--- a/lapce-app/src/panel/view.rs
+++ b/lapce-app/src/panel/view.rs
@@ -354,14 +354,16 @@ fn panel_picker(
         |p| *p,
         move |p| {
             let window_tab_data = window_tab_data.clone();
-            let icon = match p {
-                PanelKind::Terminal => LapceIcons::TERMINAL,
-                PanelKind::FileExplorer => LapceIcons::FILE_EXPLORER,
-                PanelKind::SourceControl => LapceIcons::SCM,
-                PanelKind::Plugin => LapceIcons::EXTENSIONS,
-                PanelKind::Search => LapceIcons::SEARCH,
-                PanelKind::Problem => LapceIcons::PROBLEM,
-                PanelKind::Debug => LapceIcons::DEBUG_ALT,
+            let (icon, tooltip) = match p {
+                PanelKind::Terminal => (LapceIcons::TERMINAL, "Terminal"),
+                PanelKind::FileExplorer => {
+                    (LapceIcons::FILE_EXPLORER, "File Explorer")
+                }
+                PanelKind::SourceControl => (LapceIcons::SCM, "Source Control"),
+                PanelKind::Plugin => (LapceIcons::EXTENSIONS, "Plugins"),
+                PanelKind::Search => (LapceIcons::SEARCH, "Search"),
+                PanelKind::Problem => (LapceIcons::PROBLEM, "Problems"),
+                PanelKind::Debug => (LapceIcons::DEBUG_ALT, "Debug"),
             };
             let is_active = {
                 let window_tab_data = window_tab_data.clone();
@@ -384,6 +386,7 @@ fn panel_picker(
                     },
                     || false,
                     || false,
+                    move || tooltip,
                     config,
                 )
                 .draggable()

--- a/lapce-app/src/status.rs
+++ b/lapce-app/src/status.rs
@@ -230,6 +230,7 @@ pub fn status(
                     },
                     || false,
                     || false,
+                    || "Toggle Left Panel",
                     config,
                 )
             },
@@ -256,6 +257,7 @@ pub fn status(
                     },
                     || false,
                     || false,
+                    || "Toggle Bottom Panel",
                     config,
                 )
             },
@@ -280,6 +282,7 @@ pub fn status(
                     },
                     || false,
                     || false,
+                    || "Toggle Right Panel",
                     config,
                 )
             },

--- a/lapce-app/src/title.rs
+++ b/lapce-app/src/title.rs
@@ -50,13 +50,20 @@ fn left(
             },
         ))
         .style(move |s| s.margin_horiz(10.0).apply_if(is_macos, |s| s.hide())),
-        clickable_icon(|| LapceIcons::MENU, move || {}, || false, || false, config)
-            .popout_menu(move || window_menu(lapce_command, workbench_command))
-            .style(move |s| {
-                s.margin_left(4.0)
-                    .margin_right(6.0)
-                    .apply_if(is_macos, |s| s.hide())
-            }),
+        clickable_icon(
+            || LapceIcons::MENU,
+            move || {},
+            || false,
+            || false,
+            || "Menu",
+            config,
+        )
+        .popout_menu(move || window_menu(lapce_command, workbench_command))
+        .style(move |s| {
+            s.margin_left(4.0)
+                .margin_right(6.0)
+                .apply_if(is_macos, |s| s.hide())
+        }),
         container(svg(move || config.get().ui_svg(LapceIcons::REMOTE)).style(
             move |s| {
                 let config = config.get();
@@ -155,6 +162,7 @@ fn middle(
             },
             || false,
             move || !can_jump_backward.get(),
+            || "Jump Backward",
             config,
         )
         .style(move |s| s.margin_horiz(6.0))
@@ -167,6 +175,7 @@ fn middle(
             },
             || false,
             move || !can_jump_forward.get(),
+            || "Jump Forward",
             config,
         )
         .style(move |s| s.margin_right(6.0))
@@ -178,6 +187,7 @@ fn middle(
             move || {},
             || false,
             || false,
+            || "Open Folder / Recent Workspace",
             config,
         )
         .popout_menu(move || {
@@ -255,6 +265,7 @@ fn middle(
                 },
                 || false,
                 || false,
+                || "Run and Debug",
                 config,
             )
             .style(move |s| s.margin_horiz(6.0)),
@@ -308,6 +319,7 @@ fn right(
                 || {},
                 || false,
                 || false,
+                || "Settings",
                 config,
             )
             .popout_menu(move || {
@@ -455,6 +467,7 @@ pub fn window_controls_view(
             },
             || false,
             || false,
+            || "Minimize",
             config,
         )
         .style(|s| s.margin_right(16.0).margin_left(10.0)),
@@ -473,6 +486,7 @@ pub fn window_controls_view(
             },
             || false,
             || false,
+            || "Maximize",
             config,
         )
         .style(|s| s.margin_right(16.0)),
@@ -483,6 +497,7 @@ pub fn window_controls_view(
             },
             || false,
             || false,
+            || "Close Window",
             config,
         )
         .style(|s| s.margin_right(6.0)),


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users~~

The first commit on this PR does a few minor changes.  
- save functions now take `FnOnce` for `after_action` as it is only ever called once
- Make `on_update` and friends use the simpler `Option<&SyntaxEdit>` instead of `Option<SmallVec<[SyntaxEdit; 3]>>` as they have no need for the full type
- `default_lapce_config` will use `.expect` if it fails to deserialize the default config, mentioning the common error of forgetting to add the field to `settings.toml`
  - Not that you can see this due to the panic hook not being able to log the `message` because `PanicInfo::message` is still unstable :(

The second commit does the main thing, which is using the floem `tooltip` widget in places that used `clickable_icon` (basically adding it as a requirement, because most if not ~all icons should have a basic tooltip to make surprises less common).  
This also has the tooltip function `pub` so other places can use it to be consistent with the style.

One thing I'm not sure on is the colors.
![image](https://github.com/lapce/lapce/assets/13157904/dd0d121b-f33f-4cd7-ae91-e9a71959cf25)
![image](https://github.com/lapce/lapce/assets/13157904/7246cc4a-1841-4d6c-99fd-ff0378c4a11c)
