### PR TITLE
Move line up/down keybinds in insert to macos

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -238,28 +238,6 @@ when = "!inline_completion_visible && !search_focus && !modal_focus && !list_foc
 mode = "i"
 
 [[keymaps]]
-key = "ctrl+b"
-command = "left"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+f"
-command = "right"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+p"
-command = "up"
-when = "!list_focus"
-mode = "i"
-
-[[keymaps]]
-key = "ctrl+n"
-command = "down"
-when = "!list_focus"
-mode = "i"
-
-[[keymaps]]
 key = "right"
 command = "right"
 mode = "inv"

--- a/defaults/keymaps-macos.toml
+++ b/defaults/keymaps-macos.toml
@@ -276,6 +276,28 @@ key = "meta+down"
 command = "document_end"
 
 [[keymaps]]
+key = "ctrl+f"
+command = "right"
+mode = "i"
+
+[[keymaps]]
+key = "ctrl+p"
+command = "up"
+when = "!list_focus"
+mode = "i"
+
+[[keymaps]]
+key = "ctrl+n"
+command = "down"
+when = "!list_focus"
+mode = "i"
+
+[[keymaps]]
+key = "right"
+command = "right"
+mode = "inv"
+
+[[keymaps]]
 key = "meta+shift+o"
 command = "palette.symbol"
 

--- a/defaults/keymaps-nonmacos.toml
+++ b/defaults/keymaps-nonmacos.toml
@@ -276,6 +276,28 @@ key = "Ctrl+End"
 command = "document_end"
 
 [[keymaps]]
+key = "ctrl+b"
+command = "left"
+mode = "n"
+
+[[keymaps]]
+key = "ctrl+f"
+command = "right"
+mode = "n"
+
+[[keymaps]]
+key = "ctrl+p"
+command = "up"
+when = "!list_focus"
+mode = "n"
+
+[[keymaps]]
+key = "ctrl+n"
+command = "down"
+when = "!list_focus"
+mode = "n"
+
+[[keymaps]]
 key = "ctrl+shift+o"
 command = "palette.symbol"
 


### PR DESCRIPTION
~~- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users~~

This changes what #2698 added to instead put the up/down in insert mode into the MacOS file, as Ctrl+n/Ctrl+p are not for movement on Windows/Linux. (Ctrl+n is typically used for new file, which we already have bound)  
This also moves Ctrl+b/Ctrl+f movement to MacOS too, though I need someone who actually uses MacOS to say whether those are standard. (Not that you can use Ctrl+f in insert mode since the find command takes precedence)   
But I move Ctrl+n/Ctrl+p/Ctrl+b/Ctrl+f to `normal` mode for nonmacos, though nvim seems to only allow Ctrl+n/Ctrl+p?  

(Overall I'm kinda confused about which keybinds go where, but at least Ctrl+n/Ctrl+p in insert mode should be MacOS specific)