### PR TITLE
Add plugin-path for launching with a plugin in a folder

### DIFF
--- a/lapce-app/src/plugin.rs
+++ b/lapce-app/src/plugin.rs
@@ -172,6 +172,9 @@ impl PluginData {
 
         {
             let plugin = plugin.clone();
+            let extra_plugin_paths =
+                plugin.common.window_common.extra_plugin_paths.clone();
+
             let send = create_ext_action(
                 cx,
                 move |volts: Vec<(Option<Vec<u8>>, VoltMetadata)>| {
@@ -181,7 +184,7 @@ impl PluginData {
                 },
             );
             std::thread::spawn(move || {
-                let volts = find_all_volts();
+                let volts = find_all_volts(&extra_plugin_paths);
                 let volts = volts
                     .into_iter()
                     .filter_map(|meta| {

--- a/lapce-app/src/proxy.rs
+++ b/lapce-app/src/proxy.rs
@@ -45,6 +45,7 @@ impl ProxyData {
 pub fn new_proxy(
     workspace: Arc<LapceWorkspace>,
     disabled_volts: Vec<VoltID>,
+    extra_plugin_paths: Vec<PathBuf>,
     plugin_configurations: HashMap<String, HashMap<String, serde_json::Value>>,
     term_tx: Sender<(TermId, TermEvent)>,
 ) -> ProxyData {
@@ -61,6 +62,7 @@ pub fn new_proxy(
             proxy_rpc.initialize(
                 workspace.path.clone(),
                 disabled_volts,
+                extra_plugin_paths,
                 plugin_configurations,
                 1,
                 1,

--- a/lapce-app/src/terminal/data.rs
+++ b/lapce-app/src/terminal/data.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, rc::Rc, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, rc::Rc, sync::Arc};
 
 use alacritty_terminal::{
     grid::{Dimensions, Scroll},
@@ -7,6 +7,7 @@ use alacritty_terminal::{
     vi_mode::ViMotion,
     Term,
 };
+use anyhow::anyhow;
 use floem::{
     keyboard::{Key, KeyEvent, ModifiersState, NamedKey},
     reactive::{RwSignal, Scope},
@@ -23,6 +24,7 @@ use lapce_rpc::{
     terminal::{TermId, TerminalProfile},
 };
 use parking_lot::RwLock;
+use url::Url;
 
 use super::{
     event::TermEvent,
@@ -305,6 +307,15 @@ impl TerminalData {
     pub fn new(
         cx: Scope,
         workspace: Arc<LapceWorkspace>,
+        profile: Option<TerminalProfile>,
+        common: Rc<CommonData>,
+    ) -> Self {
+        Self::new_run_debug(cx, workspace, None, profile, common)
+    }
+
+    pub fn new_run_debug(
+        cx: Scope,
+        workspace: Arc<LapceWorkspace>,
         run_debug: Option<RunDebugProcess>,
         profile: Option<TerminalProfile>,
         common: Rc<CommonData>,
@@ -318,19 +329,21 @@ impl TerminalData {
             cx.create_rw_signal(String::from("Default"))
         };
 
+        let launch_error = cx.create_rw_signal(None);
+
         let raw = Self::new_raw_terminal(
-            workspace.clone(),
+            &workspace,
             term_id,
-            run_debug.as_ref().map(|r| (&r.config, r.is_prelaunch)),
+            run_debug.as_ref(),
             profile,
             common.clone(),
+            launch_error,
         );
 
         let run_debug = cx.create_rw_signal(run_debug);
         let mode = cx.create_rw_signal(Mode::Terminal);
         let visual_mode = cx.create_rw_signal(VisualMode::Normal);
         let raw = cx.create_rw_signal(raw);
-        let launch_error = cx.create_rw_signal(None);
 
         Self {
             scope: cx,
@@ -346,12 +359,13 @@ impl TerminalData {
         }
     }
 
-    pub fn new_raw_terminal(
-        workspace: Arc<LapceWorkspace>,
+    fn new_raw_terminal(
+        workspace: &LapceWorkspace,
         term_id: TermId,
-        run_debug: Option<(&RunDebugConfig, bool)>,
+        run_debug: Option<&RunDebugProcess>,
         profile: Option<TerminalProfile>,
         common: Rc<CommonData>,
+        launch_error: RwSignal<Option<String>>,
     ) -> Arc<RwLock<RawTerminal>> {
         let raw = Arc::new(RwLock::new(RawTerminal::new(
             term_id,
@@ -371,51 +385,37 @@ impl TerminalData {
             };
         }
 
-        if let Some((run_debug, is_prelaunch)) = run_debug {
-            if let Some(path) = run_debug.cwd.as_ref() {
-                if let Ok(as_url) = url::Url::from_file_path(PathBuf::from(path)) {
-                    profile.workdir = Some(as_url);
-                }
-                if path.contains("${workspace}") {
-                    if let Some(workspace) = workspace
-                        .path
-                        .as_ref()
-                        .and_then(|workspace| workspace.to_str())
-                    {
-                        if let Ok(as_url) = url::Url::from_file_path(PathBuf::from(
-                            &path.replace("${workspace}", workspace),
-                        )) {
-                            profile.workdir = Some(as_url);
-                        }
-                    }
-                }
+        let exp_run_debug = run_debug
+            .as_ref()
+            .map(|run_debug| {
+                ExpandedRunDebug::expand(
+                    workspace,
+                    &run_debug.config,
+                    run_debug.is_prelaunch,
+                )
+            })
+            .transpose();
+
+        let exp_run_debug = exp_run_debug.unwrap_or_else(|e| {
+            let r_name = run_debug
+                .as_ref()
+                .map(|r| r.config.name.as_str())
+                .unwrap_or("Unknown");
+            launch_error.set(Some(format!(
+                "Failed to expand variables in run debug definition {r_name}: {e}"
+            )));
+            None
+        });
+
+        if let Some(run_debug) = exp_run_debug {
+            if let Some(work_dir) = run_debug.work_dir {
+                profile.workdir = Some(work_dir);
             }
 
-            let prelaunch = if is_prelaunch {
-                run_debug.prelaunch.clone()
-            } else {
-                None
-            };
+            profile.environment = run_debug.env;
 
-            profile.environment = run_debug.env.clone();
-
-            if let Some(debug_command) = run_debug.debug_command.as_ref() {
-                let mut args = debug_command.to_owned();
-                let command = args.first().cloned().unwrap_or_default();
-                if !args.is_empty() {
-                    args.remove(0);
-                }
-                profile.command = Some(command);
-                if !args.is_empty() {
-                    profile.arguments = Some(args);
-                }
-            } else if let Some(prelaunch) = prelaunch {
-                profile.command = Some(prelaunch.program);
-                profile.arguments = prelaunch.args;
-            } else {
-                profile.command = Some(run_debug.program.clone());
-                profile.arguments = run_debug.args.clone();
-            }
+            profile.command = Some(run_debug.program);
+            profile.arguments = run_debug.args;
         }
 
         {
@@ -423,6 +423,7 @@ impl TerminalData {
             let _ = common.term_tx.send((term_id, TermEvent::NewTerminal(raw)));
             common.proxy.new_terminal(term_id, profile);
         }
+
         raw
     }
 
@@ -712,11 +713,12 @@ impl TerminalData {
         };
 
         let raw = Self::new_raw_terminal(
-            self.workspace.clone(),
+            &self.workspace,
             self.term_id,
-            run_debug.as_ref().map(|r| (&r.config, r.is_prelaunch)),
+            run_debug.as_ref(),
             None,
             self.common.clone(),
+            self.launch_error,
         );
 
         self.raw.set(raw);
@@ -727,5 +729,94 @@ impl TerminalData {
         self.common
             .proxy
             .terminal_resize(self.term_id, width, height);
+    }
+}
+
+/// [`RunDebugConfig`] with expanded out program/arguments/etc. Used for creating the terminal.
+#[derive(Debug, Clone)]
+pub struct ExpandedRunDebug {
+    pub work_dir: Option<Url>,
+    pub env: Option<HashMap<String, String>>,
+    pub program: String,
+    pub args: Option<Vec<String>>,
+}
+impl ExpandedRunDebug {
+    pub fn expand(
+        workspace: &LapceWorkspace,
+        run_debug: &RunDebugConfig,
+        is_prelaunch: bool,
+    ) -> anyhow::Result<Self> {
+        // Get the current working directory variable, which can container ${workspace}
+        let work_dir = Self::expand_work_dir(workspace, run_debug);
+
+        let prelaunch = is_prelaunch
+            .then_some(run_debug.prelaunch.as_ref())
+            .flatten();
+
+        let env = run_debug.env.clone();
+
+        // TODO: replace some variables in the args
+        let (program, mut args) =
+            if let Some(debug_command) = run_debug.debug_command.as_ref() {
+                let mut args = debug_command.to_owned();
+                let command = args.first().cloned().unwrap_or_default();
+                if !args.is_empty() {
+                    args.remove(0);
+                }
+
+                let args = if !args.is_empty() { Some(args) } else { None };
+                (command, args)
+            } else if let Some(prelaunch) = prelaunch {
+                (prelaunch.program.clone(), prelaunch.args.clone())
+            } else {
+                (run_debug.program.clone(), run_debug.args.clone())
+            };
+
+        let program = if program == "${lapce}" {
+            std::env::current_exe().map_err(|e| {
+                anyhow!("Failed to get current exe for ${{lapce}} run and debug: {e}")
+            })?.to_str().ok_or_else(|| anyhow!("Failed to convert ${{lapce}} path to str"))?.to_string()
+        } else {
+            program
+        };
+
+        if let Some(args) = &mut args {
+            for arg in args {
+                // Replace all mentions of ${workspace} with the current workspace path
+                if arg.contains("${workspace}") {
+                    if let Some(workspace) =
+                        workspace.path.as_ref().and_then(|x| x.to_str())
+                    {
+                        *arg = arg.replace("${workspace}", workspace);
+                    }
+                }
+            }
+        }
+
+        Ok(ExpandedRunDebug {
+            work_dir,
+            env,
+            program,
+            args,
+        })
+    }
+
+    fn expand_work_dir(
+        workspace: &LapceWorkspace,
+        run_debug: &RunDebugConfig,
+    ) -> Option<Url> {
+        let path = run_debug.cwd.as_ref()?;
+
+        if path.contains("${workspace}") {
+            if let Some(workspace) = workspace.path.as_ref().and_then(|x| x.to_str())
+            {
+                let path = path.replace("${workspace}", workspace);
+                if let Ok(as_url) = Url::from_file_path(PathBuf::from(path)) {
+                    return Some(as_url);
+                }
+            }
+        }
+
+        Url::from_file_path(PathBuf::from(path)).ok()
     }
 }

--- a/lapce-app/src/terminal/panel.rs
+++ b/lapce-app/src/terminal/panel.rs
@@ -44,16 +44,11 @@ pub struct TerminalPanelData {
 impl TerminalPanelData {
     pub fn new(
         workspace: Arc<LapceWorkspace>,
-        run_debug: Option<RunDebugProcess>,
         profile: Option<TerminalProfile>,
         common: Rc<CommonData>,
     ) -> Self {
-        let terminal_tab = TerminalTabData::new(
-            workspace.clone(),
-            run_debug,
-            profile,
-            common.clone(),
-        );
+        let terminal_tab =
+            TerminalTabData::new(workspace.clone(), profile, common.clone());
 
         let cx = common.scope;
 
@@ -142,7 +137,7 @@ impl TerminalPanelData {
         keypress: &KeyPressData,
     ) -> bool {
         if self.tab_info.with_untracked(|info| info.tabs.is_empty()) {
-            self.new_tab(None, None);
+            self.new_tab(None);
         }
 
         let tab = self.active_tab(false);
@@ -164,12 +159,18 @@ impl TerminalPanelData {
         }
     }
 
-    pub fn new_tab(
+    pub fn new_tab(&self, profile: Option<TerminalProfile>) {
+        self.new_tab_run_debug(None, profile);
+    }
+
+    /// Create a new terminal tab with the given run debug process.  
+    /// Errors if expanding out the run debug process failed.
+    pub fn new_tab_run_debug(
         &self,
         run_debug: Option<RunDebugProcess>,
         profile: Option<TerminalProfile>,
     ) -> TerminalTabData {
-        let terminal_tab = TerminalTabData::new(
+        let terminal_tab = TerminalTabData::new_run_debug(
             self.workspace.clone(),
             run_debug,
             profile,
@@ -280,7 +281,6 @@ impl TerminalPanelData {
             let terminal_data = TerminalData::new(
                 tab.scope,
                 self.workspace.clone(),
-                None,
                 None,
                 self.common.clone(),
             );
@@ -445,7 +445,7 @@ impl TerminalPanelData {
                 let mut run_debug = run_debug;
                 run_debug.stopped = false;
                 run_debug.is_prelaunch = true;
-                let new_terminal = TerminalData::new(
+                let new_terminal = TerminalData::new_run_debug(
                     terminal_tab.scope,
                     self.workspace.clone(),
                     Some(run_debug),

--- a/lapce-app/src/terminal/tab.rs
+++ b/lapce-app/src/terminal/tab.rs
@@ -20,13 +20,22 @@ pub struct TerminalTabData {
 impl TerminalTabData {
     pub fn new(
         workspace: Arc<LapceWorkspace>,
+        profile: Option<TerminalProfile>,
+        common: Rc<CommonData>,
+    ) -> Self {
+        TerminalTabData::new_run_debug(workspace, None, profile, common)
+    }
+
+    /// Create the information for a terminal tab, which can contain multiple terminals.  
+    pub fn new_run_debug(
+        workspace: Arc<LapceWorkspace>,
         run_debug: Option<RunDebugProcess>,
         profile: Option<TerminalProfile>,
         common: Rc<CommonData>,
     ) -> Self {
         let cx = common.scope.create_child();
         let terminal_data =
-            TerminalData::new(cx, workspace, run_debug, profile, common);
+            TerminalData::new_run_debug(cx, workspace, run_debug, profile, common);
         let terminals = im::vector![(cx.create_rw_signal(0), terminal_data)];
         let terminals = cx.create_rw_signal(terminals);
         let active = cx.create_rw_signal(0);

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -66,6 +66,7 @@ impl ProxyHandler for Dispatcher {
             Initialize {
                 workspace,
                 disabled_volts,
+                extra_plugin_paths,
                 plugin_configurations,
                 window_id,
                 tab_id,
@@ -89,6 +90,7 @@ impl ProxyHandler for Dispatcher {
                     let mut plugin = PluginCatalog::new(
                         workspace,
                         disabled_volts,
+                        extra_plugin_paths,
                         plugin_configurations,
                         plugin_rpc.clone(),
                     );

--- a/lapce-proxy/src/plugin/catalog.rs
+++ b/lapce-proxy/src/plugin/catalog.rs
@@ -52,6 +52,7 @@ impl PluginCatalog {
     pub fn new(
         workspace: Option<PathBuf>,
         disabled_volts: Vec<VoltID>,
+        extra_plugin_paths: Vec<PathBuf>,
         plugin_configurations: HashMap<String, HashMap<String, serde_json::Value>>,
         plugin_rpc: PluginCatalogRpcHandler,
     ) -> Self {
@@ -67,7 +68,7 @@ impl PluginCatalog {
         };
 
         thread::spawn(move || {
-            load_all_volts(plugin_rpc, disabled_volts);
+            load_all_volts(plugin_rpc, &extra_plugin_paths, disabled_volts);
         });
 
         plugin

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -202,6 +202,8 @@ pub enum ProxyNotification {
     Initialize {
         workspace: Option<PathBuf>,
         disabled_volts: Vec<VoltID>,
+        /// Paths to extra plugins that should be loaded
+        extra_plugin_paths: Vec<PathBuf>,
         plugin_configurations: HashMap<String, HashMap<String, serde_json::Value>>,
         window_id: usize,
         tab_id: usize,
@@ -571,6 +573,7 @@ impl ProxyRpcHandler {
         &self,
         workspace: Option<PathBuf>,
         disabled_volts: Vec<VoltID>,
+        extra_plugin_paths: Vec<PathBuf>,
         plugin_configurations: HashMap<String, HashMap<String, serde_json::Value>>,
         window_id: usize,
         tab_id: usize,
@@ -578,6 +581,7 @@ impl ProxyRpcHandler {
         self.notification(ProxyNotification::Initialize {
             workspace,
             disabled_volts,
+            extra_plugin_paths,
             plugin_configurations,
             window_id,
             tab_id,


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR adds a command line flag for launching with a specific folder as an extra plugin. This is intended to be used for plugin/theme development, as it serves as a much nicer alternative to either developing inside the plugins folder or copying your project to that folder everytime.

Though this isn't perfect, it gets the essential part.

One thing I'd like to have in the future is automatically switching to the in-development color theme, and having that setting disconnected from saving the config. (Or perhaps make so when you launch lapce with a plugin-development flag it uses a different config file)