### PR TITLE
Foldable panel sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#3047](https://github.com/lapce/lapce/pull/3047): Add support for different CrLf/Lf line endings per-file
 - [#3053](https://github.com/lapce/lapce/pull/3053): Add tooltips to various places
 - [#3069](https://github.com/lapce/lapce/pull/3069): Allow color variables for themes
+- [#3086](https://github.com/lapce/lapce/pull/3086): Add folding to panels
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/defaults/icon-theme.toml
+++ b/defaults/icon-theme.toml
@@ -65,6 +65,9 @@ name = "Lapce Codicons"
 
 "dropdown.arrow" = "chevron-down.svg"
 
+"panel.fold-down" = "chevron-down.svg"
+"panel.fold-up" = "chevron-up.svg"
+
 "location.forward" = "arrow-right.svg"
 "location.backward" = "arrow-left.svg"
 

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -1835,57 +1835,64 @@ fn main_split(window_tab_data: Rc<WindowTabData>) -> impl View {
 pub fn clickable_icon<S: std::fmt::Display + 'static>(
     icon: impl Fn() -> &'static str + 'static,
     on_click: impl Fn() + 'static,
-    active_fn: impl Fn() -> bool + 'static + Copy,
+    active_fn: impl Fn() -> bool + 'static,
     disabled_fn: impl Fn() -> bool + 'static + Copy,
     tooltip_: impl Fn() -> S + 'static + Clone,
     config: ReadSignal<Arc<LapceConfig>>,
 ) -> impl View {
     tooltip_label(
         config,
-        container(
-            container(
-                svg(move || config.get().ui_svg(icon()))
-                    .style(move |s| {
-                        let config = config.get();
-                        let size = config.ui.icon_size() as f32;
-                        s.size(size, size)
-                            .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
-                            .disabled(|s| {
-                                s.color(
-                                    config.color(LapceColor::LAPCE_ICON_INACTIVE),
-                                )
-                                .cursor(CursorStyle::Default)
-                            })
-                    })
-                    .disabled(disabled_fn),
-            )
-            .on_click_stop(move |_| {
-                on_click();
-            })
-            .disabled(disabled_fn)
-            .style(move |s| {
-                let config = config.get();
-                s.padding(4.0)
-                    .border_radius(6.0)
-                    .border(1.0)
-                    .border_color(Color::TRANSPARENT)
-                    .apply_if(active_fn(), |s| {
-                        s.border_color(config.color(LapceColor::EDITOR_CARET))
-                    })
-                    .hover(|s| {
-                        s.cursor(CursorStyle::Pointer).background(
-                            config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
-                        )
-                    })
-                    .active(|s| {
-                        s.background(
-                            config
-                                .color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
-                        )
-                    })
-            }),
-        ),
+        clickable_icon_base(icon, on_click, active_fn, disabled_fn, config),
         tooltip_,
+    )
+}
+
+pub fn clickable_icon_base(
+    icon: impl Fn() -> &'static str + 'static,
+    on_click: impl Fn() + 'static,
+    active_fn: impl Fn() -> bool + 'static,
+    disabled_fn: impl Fn() -> bool + 'static + Copy,
+    config: ReadSignal<Arc<LapceConfig>>,
+) -> impl View {
+    container(
+        container(
+            svg(move || config.get().ui_svg(icon()))
+                .style(move |s| {
+                    let config = config.get();
+                    let size = config.ui.icon_size() as f32;
+                    s.size(size, size)
+                        .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
+                        .disabled(|s| {
+                            s.color(config.color(LapceColor::LAPCE_ICON_INACTIVE))
+                                .cursor(CursorStyle::Default)
+                        })
+                })
+                .disabled(disabled_fn),
+        )
+        .on_click_stop(move |_| {
+            on_click();
+        })
+        .disabled(disabled_fn)
+        .style(move |s| {
+            let config = config.get();
+            s.padding(4.0)
+                .border_radius(6.0)
+                .border(1.0)
+                .border_color(Color::TRANSPARENT)
+                .apply_if(active_fn(), |s| {
+                    s.border_color(config.color(LapceColor::EDITOR_CARET))
+                })
+                .hover(|s| {
+                    s.cursor(CursorStyle::Pointer).background(
+                        config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                    )
+                })
+                .active(|s| {
+                    s.background(
+                        config.color(LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND),
+                    )
+                })
+        }),
     )
 }
 

--- a/lapce-app/src/config/icon.rs
+++ b/lapce-app/src/config/icon.rs
@@ -62,6 +62,9 @@ impl LapceIcons {
 
     pub const DROPDOWN_ARROW: &'static str = "dropdown.arrow";
 
+    pub const PANEL_FOLD_UP: &'static str = "panel.fold-up";
+    pub const PANEL_FOLD_DOWN: &'static str = "panel.fold-down";
+
     pub const LOCATION_BACKWARD: &'static str = "location.backward";
     pub const LOCATION_FORWARD: &'static str = "location.forward";
 

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -22,7 +22,7 @@ use crate::{
     command::InternalCommand,
     config::{color::LapceColor, icon::LapceIcons},
     editor_tab::{EditorTabChild, EditorTabData},
-    panel::{kind::PanelKind, position::PanelPosition, view::panel_header},
+    panel::{kind::PanelKind, position::PanelPosition, view::PanelBuilder},
     plugin::PluginData,
     text_input::text_input_key_focus,
     window_tab::{Focus, WindowTabData},
@@ -67,24 +67,19 @@ pub fn file_explorer_panel(
 ) -> impl View {
     let config = window_tab_data.common.config;
     let data = window_tab_data.file_explorer.clone();
-    stack((
-        stack((
-            panel_header("Open Editors".to_string(), config),
+    PanelBuilder::new(config, position)
+        .add_height(
+            "Open Editors",
+            150.0,
             container(open_editors_view(window_tab_data.clone()))
-                .style(|s| s.size_pct(100.0, 100.0)),
-        ))
-        .style(|s| s.width_pct(100.0).flex_col().height(150.0)),
-        stack((
-            panel_header("File Explorer".to_string(), config),
+                .style(|s| s.size_full()),
+        )
+        .add(
+            "File Explorer",
             container(new_file_node_view(data).style(|s| s.absolute()))
-                .style(|s| s.size_pct(100.0, 100.0).line_height(1.6)),
-        ))
-        .style(|s| s.width_pct(100.0).height_pct(100.0).flex_col()),
-    ))
-    .style(move |s| {
-        s.width_pct(100.0)
-            .apply_if(!position.is_bottom(), |s: Style| s.flex_col())
-    })
+                .style(|s| s.size_full().line_height(1.6)),
+        )
+        .build()
 }
 
 /// Initialize the file explorer's naming (renaming, creating, etc.) editor with the given path.

--- a/lapce-app/src/panel/debug_view.rs
+++ b/lapce-app/src/panel/debug_view.rs
@@ -17,7 +17,7 @@ use lapce_rpc::{
     terminal::TermId,
 };
 
-use super::{position::PanelPosition, view::panel_header};
+use super::{position::PanelPosition, view::PanelBuilder};
 use crate::{
     app::clickable_icon,
     command::InternalCommand,
@@ -38,35 +38,23 @@ pub fn debug_panel(
     let terminal = window_tab_data.terminal.clone();
     let internal_command = window_tab_data.common.internal_command;
 
-    stack((
-        {
-            let terminal = terminal.clone();
-            stack((
-                panel_header("Processes".to_string(), config),
-                debug_processes(terminal, config),
-            ))
-            .style(|s| s.width_pct(100.0).flex_col().height(150.0))
-        },
-        stack((
-            panel_header("Variables".to_string(), config),
-            variables_view(window_tab_data.clone()),
-        ))
-        .style(|s| s.width_pct(100.0).flex_grow(1.0).flex_basis(0.0).flex_col()),
-        stack((
-            panel_header("Stack Frames".to_string(), config),
-            debug_stack_traces(terminal, internal_command, config),
-        ))
-        .style(|s| s.width_pct(100.0).flex_grow(1.0).flex_basis(0.0).flex_col()),
-        stack((
-            panel_header("Breakpoints".to_string(), config),
+    PanelBuilder::new(config, position)
+        .add_height(
+            "Processes",
+            150.0,
+            debug_processes(terminal.clone(), config),
+        )
+        .add("Variables", variables_view(window_tab_data.clone()))
+        .add(
+            "Stack Frames",
+            debug_stack_traces(terminal.clone(), internal_command, config),
+        )
+        .add_height(
+            "Breakpoints",
+            150.0,
             breakpoints_view(window_tab_data.clone()),
-        ))
-        .style(|s| s.width_pct(100.0).flex_col().height(150.0)),
-    ))
-    .style(move |s| {
-        s.width_pct(100.0)
-            .apply_if(!position.is_bottom(), |s| s.flex_col())
-    })
+        )
+        .build()
 }
 
 fn debug_process_icons(

--- a/lapce-app/src/panel/plugin_view.rs
+++ b/lapce-app/src/panel/plugin_view.rs
@@ -14,7 +14,7 @@ use floem::{
 use indexmap::IndexMap;
 use lapce_rpc::plugin::{VoltID, VoltInfo};
 
-use super::{kind::PanelKind, position::PanelPosition, view::panel_header};
+use super::{kind::PanelKind, position::PanelPosition, view::PanelBuilder};
 use crate::{
     app::clickable_icon,
     command::InternalCommand,
@@ -65,22 +65,10 @@ pub fn plugin_panel(
     let config = window_tab_data.common.config;
     let plugin = window_tab_data.plugin.clone();
 
-    stack((
-        stack((
-            panel_header("Installed".to_string(), config),
-            installed_view(plugin.clone()),
-        ))
-        .style(|s| s.flex_col().width_pct(100.0).flex_grow(1.0).flex_basis(0.0)),
-        stack((
-            panel_header("Available".to_string(), config),
-            available_view(plugin.clone()),
-        ))
-        .style(|s| s.flex_col().width_pct(100.0).flex_grow(1.0).flex_basis(0.0)),
-    ))
-    .style(move |s| {
-        s.width_pct(100.0)
-            .apply_if(!position.is_bottom(), |s| s.flex_col())
-    })
+    PanelBuilder::new(config, position)
+        .add("Installed", installed_view(plugin.clone()))
+        .add("Available", available_view(plugin.clone()))
+        .build()
 }
 
 fn installed_view(plugin: PluginData) -> impl View {

--- a/lapce-app/src/panel/problem_view.rs
+++ b/lapce-app/src/panel/problem_view.rs
@@ -9,7 +9,7 @@ use floem::{
 };
 use lsp_types::{DiagnosticRelatedInformation, DiagnosticSeverity};
 
-use super::{position::PanelPosition, view::panel_header};
+use super::{position::PanelPosition, view::PanelBuilder};
 use crate::{
     command::InternalCommand,
     config::{color::LapceColor, icon::LapceIcons, LapceConfig},
@@ -27,30 +27,21 @@ pub fn problem_panel(
 ) -> impl View {
     let config = window_tab_data.common.config;
     let is_bottom = position.is_bottom();
-    stack((
-        stack((
-            panel_header("Errors".to_string(), config),
+    PanelBuilder::new(config, position)
+        .add_style(
+            "Errors",
             problem_section(window_tab_data.clone(), DiagnosticSeverity::ERROR),
-        ))
-        .style(move |s| {
-            let config = config.get();
-            s.flex_col()
-                .flex_basis(0.0)
-                .flex_grow(1.0)
-                .border_color(config.color(LapceColor::LAPCE_BORDER))
-                .apply_if(is_bottom, |s| s.border_right(1.0))
-                .apply_if(!is_bottom, |s| s.border_bottom(1.0))
-        }),
-        stack((
-            panel_header("Warnings".to_string(), config),
-            problem_section(window_tab_data, DiagnosticSeverity::WARNING),
-        ))
-        .style(|s| s.flex_col().flex_basis(0.0).flex_grow(1.0)),
-    ))
-    .style(move |s| {
-        s.size_pct(100.0, 100.0)
-            .apply_if(!is_bottom, |s| s.flex_col())
-    })
+            move |s| {
+                s.border_color(config.get().color(LapceColor::LAPCE_BORDER))
+                    .apply_if(is_bottom, |s| s.border_right(1.0))
+                    .apply_if(!is_bottom, |s| s.border_bottom(1.0))
+            },
+        )
+        .add(
+            "Warnings",
+            problem_section(window_tab_data.clone(), DiagnosticSeverity::WARNING),
+        )
+        .build()
 }
 
 fn problem_section(

--- a/lapce-app/src/panel/source_control_view.rs
+++ b/lapce-app/src/panel/source_control_view.rs
@@ -11,13 +11,15 @@ use floem::{
     views::{
         container, dyn_stack,
         editor::view::{cursor_caret, LineRegion},
-        label, scroll, stack, svg, Decorators,
+        label, scroll, stack, svg, text, Decorators,
     },
 };
 use lapce_core::buffer::rope_text::RopeText;
 use lapce_rpc::source_control::FileDiff;
 
-use super::{kind::PanelKind, position::PanelPosition, view::panel_header};
+use super::{
+    kind::PanelKind, position::PanelPosition, view::foldable_panel_section,
+};
 use crate::{
     command::{CommandKind, InternalCommand, LapceCommand, LapceWorkbenchCommand},
     config::{color::LapceColor, icon::LapceIcons},
@@ -175,10 +177,11 @@ pub fn source_control_panel(
             },
         ))
         .style(|s| s.flex_col().width_pct(100.0).padding(10.0)),
-        stack((
-            panel_header("Changes".to_string(), config),
+        foldable_panel_section(
+            text("Changes"),
             file_diffs_view(source_control),
-        ))
+            config,
+        )
         .style(|s| s.flex_col().size_pct(100.0, 100.0)),
     ))
     .on_event_stop(EventListener::PointerDown, move |_| {


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This PR allows you to fold panel sections. It also introduces a `PanelBuilder` structure to share the logic between different panels, which can hopefully be extended in the future to allow resizing panel sections.

![image](https://github.com/lapce/lapce/assets/13157904/2f44a586-7282-41bd-b7a5-5730e6dad6a8)

![image](https://github.com/lapce/lapce/assets/13157904/7807f39e-7383-4ca0-9288-907e16a19087)

~~This does have an issue when folding the panel when it is on the bottom that I'm not 100% on how to fix. It makes so the one that is folded takes more space...~~