### PR TITLE
source-build fix for Fedora and add-path instructions for Ubuntu and Fedora

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -18,7 +18,7 @@ home/YOURNAME/lapse/target/release/lapce
 ```
 
 2.3  Create a symbolic link:
-   - Open a terminal and run the following command to create a symbolic link from the executable to the chosen directory:
+- Open a terminal and run the following command to create a symbolic link from the executable to the chosen directory:
      ```bash
      ln -s home/YOURNAME/lapse/target/release/lapce ~/.local/bin/
      ```
@@ -29,12 +29,12 @@ home/YOURNAME/lapse/target/release/lapce
      ```
 
 2.5  Refresh the shell:
-   - Run the following command to reload the shell configuration:
+- Run the following command to reload the shell configuration:
      ```
      source ~/.bashrc
      ```
 
-2.6  Now you can call "lapce ." or "lapce --version" from cli
+- Now you can call "lapce ." or "lapce --version" from cli
 
 #### Fedora
 2.1  install dependencies
@@ -62,7 +62,7 @@ mkdir -p ~/.local/bin
 ```
 
 2.3  Create a symbolic link:
-   - Open a terminal and run the following command to create a symbolic link from the executable to the chosen directory:
+- Open a terminal and run the following command to create a symbolic link from the executable to the chosen directory:
      ```bash
      ln -s home/YOURNAME/lapse/target/release/lapce ~/.local/bin/lapce
      ```
@@ -73,12 +73,12 @@ mkdir -p ~/.local/bin
      ```
 
 2.5  Refresh the shell:
-   - Run the following command to reload the shell configuration:
+- Run the following command to reload the shell configuration:
      ```
      source ~/.bashrc
      ```
 
-Now you can call "lapce ." or "lapce --version" from cli
+- Now you can call "lapce ." or "lapce --version" from cli
 
 #### Void Linux
 ```sh

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -53,7 +53,6 @@ home/YOURNAME/lapse/target/release/lapce
 https://developer.fedoraproject.org/tech/languages/perl/perl-installation.html
 ```bash
 $ sudo dnf install perl-core
-mkdir -p ~/.local/bin
 ```
 
 

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -7,13 +7,80 @@ It is easy to build Lapce from source on a GNU/Linux distribution. Cargo handles
 2. Install dependencies for your operating system:
 
 #### Ubuntu
+2.1  install dependencies
 ```sh
 sudo apt install clang libxkbcommon-x11-dev pkg-config libvulkan-dev libwayland-dev xorg-dev libxcb-shape0-dev libxcb-xfixes0-dev
 ```
+2.2  Follow instructions below to set path to lapce, where path to 
+lapce is like: 
+```
+home/YOURNAME/lapse/target/release/lapce
+```
+
+2.3  Create a symbolic link:
+   - Open a terminal and run the following command to create a symbolic link from the executable to the chosen directory:
+     ```bash
+     ln -s home/YOURNAME/lapse/target/release/lapce ~/.local/bin/
+     ```
+
+2.4 Add the directory to PATH (if necessary):
+     ```bash
+     export PATH="home/YOURNAME/lapse/target/release/lapce:$PATH"
+     ```
+
+2.5  Refresh the shell:
+   - Run the following command to reload the shell configuration:
+     ```
+     source ~/.bashrc
+     ```
+
+2.6  Now you can call "lapce ." or "lapce --version" from cli
+
 #### Fedora
+2.1  install dependencies
 ```sh
 sudo dnf install clang libxkbcommon-x11-devel libxcb-devel vulkan-loader-devel wayland-devel perl-File-Compare perl-FindBin
 ```
+
+Follow instructions below to set path to lapce, where path to 
+lapce is like: 
+```
+home/YOURNAME/lapse/target/release/lapce
+```
+
+2.1  Install Pearl (from official fedora source) to avoid a build-fail
+
+https://developer.fedoraproject.org/tech/languages/perl/perl-installation.html
+```bash
+$ sudo dnf install perl-core
+mkdir -p ~/.local/bin
+```
+
+
+2.2 Create the ~/.local/bin directory
+```bash
+mkdir -p ~/.local/bin
+```
+
+2.3  Create a symbolic link:
+   - Open a terminal and run the following command to create a symbolic link from the executable to the chosen directory:
+     ```bash
+     ln -s home/YOURNAME/lapse/target/release/lapce ~/.local/bin/lapce
+     ```
+
+2.4  Add the directory to PATH (if necessary):
+     ```bash
+     export PATH="$PATH:$HOME/.local/bin"
+     ```
+
+2.5  Refresh the shell:
+   - Run the following command to reload the shell configuration:
+     ```
+     source ~/.bashrc
+     ```
+
+Now you can call "lapce ." or "lapce --version" from cli
+
 #### Void Linux
 ```sh
 sudo xbps-install -S base-devel clang libxkbcommon-devel vulkan-loader wayland-devel


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Adding step to install pearl for fedora, and adding instructions for add-path etc. so Lapce can be used and called from cli normally.

https://github.com/lineality/fork_lapce/blob/geo_build_fix/docs/building-from-source.md