### PR TITLE
Add text color if file is changed according to source control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3069](https://github.com/lapce/lapce/pull/3069): Allow color variables for themes
 - [#3086](https://github.com/lapce/lapce/pull/3086): Add folding to panels
 - [#3095](https://github.com/lapce/lapce/pull/3095): Add option to hide the Open Editors section in the explorer
+- [#3096](https://github.com/lapce/lapce/pull/3096): Add source control status coloring to file explorer
 
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository

--- a/lapce-rpc/src/file.rs
+++ b/lapce-rpc/src/file.rs
@@ -249,7 +249,7 @@ impl Naming {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileNodeViewData {
     pub kind: FileNodeViewKind,
     pub is_dir: bool,

--- a/lapce-rpc/src/source_control.rs
+++ b/lapce-rpc/src/source_control.rs
@@ -27,4 +27,21 @@ impl FileDiff {
             | FileDiff::Renamed(_, p) => p,
         }
     }
+
+    pub fn kind(&self) -> FileDiffKind {
+        match self {
+            FileDiff::Modified(_) => FileDiffKind::Modified,
+            FileDiff::Added(_) => FileDiffKind::Added,
+            FileDiff::Deleted(_) => FileDiffKind::Deleted,
+            FileDiff::Renamed(_, _) => FileDiffKind::Renamed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileDiffKind {
+    Modified,
+    Added,
+    Deleted,
+    Renamed,
 }


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users
![image](https://github.com/lapce/lapce/assets/13157904/c6dcea00-7465-4475-88fc-b0a59914bc2b)

(Re)implements  color highlighting if the file has been changed/renamed/added according to source control.

Implements part of #3044 