### PR TITLE
ci: always publish nightly builds even if some fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,6 +336,7 @@ jobs:
 
   publish:
     needs: [linux, linux-musl, debian, windows, macos]
+    if: ${{ always() && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users