### PR TITLE
Editors struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
  "nom",
  "pathdiff",
  "serde",
- "toml 0.5.11",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -2479,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2824,7 +2824,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -4063,12 +4063,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
+ "hermit-abi 0.3.9",
  "pin-project-lite",
  "rustix",
  "tracing 0.1.37",
@@ -5487,9 +5488,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
@@ -5555,7 +5556,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tracing-attributes 0.1.23",
- "tracing-core 0.1.32",
+ "tracing-core 0.1.30",
 ]
 
 [[package]]
@@ -5602,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -6276,7 +6277,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.5.11",
+ "toml 0.5.9",
  "windows-sys 0.48.0",
  "zstd",
 ]

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -89,7 +89,7 @@ use crate::{
     plugin::{plugin_info_view, PluginData},
     settings::{settings_view, theme_color_settings_view},
     status::status,
-    text_input::text_input,
+    text_input::TextInputBuilder,
     title::{title, window_controls_view},
     update::ReleaseInfo,
     window::{TabsInfo, WindowData, WindowInfo},
@@ -1195,7 +1195,7 @@ fn editor_tab_content(
                                 &diff_editor_data.right,
                             ),
                         ))
-                        .style(|s| s.size_full()),
+                        .style(|s: Style| s.size_full()),
                     )
                     .on_cleanup(move || {
                         diff_editor_scope.dispose();
@@ -2383,7 +2383,9 @@ fn palette_input(window_tab_data: Rc<WindowTabData>) -> impl View {
     let focus = window_tab_data.common.focus;
     let is_focused = move || focus.get() == Focus::Palette;
 
-    let input = text_input(editor, is_focused)
+    let input = TextInputBuilder::new()
+        .is_focused(is_focused)
+        .build_editor(editor)
         .placeholder(move || window_tab_data.palette.placeholder_text().to_owned())
         .style(|s| s.width_full());
 
@@ -2970,7 +2972,10 @@ fn rename(window_tab_data: Rc<WindowTabData>) -> impl View {
 
     container(
         container(
-            text_input(editor, move || active.get()).style(|s| s.width(150.0)),
+            TextInputBuilder::new()
+                .is_focused(move || active.get())
+                .build_editor(editor)
+                .style(|s| s.width(150.0)),
         )
         .style(move |s| {
             let config = config.get();

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -712,11 +712,9 @@ fn editor_tab_header(
         };
 
         let confirmed = match local_child {
-            EditorTabChild::Editor(editor_id) => editors.with_untracked(|editors| {
-                editors
-                    .get(&editor_id)
-                    .map(|editor_data| editor_data.confirmed)
-            }),
+            EditorTabChild::Editor(editor_id) => {
+                editors.editor_untracked(editor_id).map(|e| e.confirmed)
+            }
             EditorTabChild::DiffEditor(diff_editor_id) => diff_editors
                 .with_untracked(|diff_editors| {
                     diff_editors
@@ -1057,9 +1055,7 @@ fn editor_tab_content(
         let common = common.clone();
         let child = match child {
             EditorTabChild::Editor(editor_id) => {
-                let editor_data = editors
-                    .with_untracked(|editors| editors.get(&editor_id).cloned());
-                if let Some(editor_data) = editor_data {
+                if let Some(editor_data) = editors.editor_untracked(editor_id) {
                     let editor_scope = editor_data.scope;
                     let editor_tab_id = editor_data.editor_tab_id;
                     let is_active = move |tracked: bool| {
@@ -1195,8 +1191,8 @@ fn editor_tab_content(
                                 s.height_full().flex_grow(1.0).flex_basis(0.0)
                             }),
                             diff_show_more_section_view(
-                                diff_editor_data.left.clone(),
-                                diff_editor_data.right.clone(),
+                                &diff_editor_data.left,
+                                &diff_editor_data.right,
                             ),
                         ))
                         .style(|s| s.size_full()),

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -76,6 +76,7 @@ use crate::{
     find::{Find, FindProgress, FindResult},
     history::DocumentHistory,
     keypress::KeyPressFocus,
+    main_split::Editors,
     panel::kind::PanelKind,
     window_tab::{CommonData, Focus},
     workspace::LapceWorkspace,
@@ -195,7 +196,7 @@ pub struct Doc {
     /// The diagnostics for the document
     pub diagnostics: DiagnosticData,
 
-    editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+    editors: Editors,
     pub common: Rc<CommonData>,
 }
 impl Doc {
@@ -203,7 +204,7 @@ impl Doc {
         cx: Scope,
         path: PathBuf,
         diagnostics: DiagnosticData,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+        editors: Editors,
         common: Rc<CommonData>,
     ) -> Self {
         let syntax = Syntax::init(&path);
@@ -243,18 +244,14 @@ impl Doc {
         }
     }
 
-    pub fn new_local(
-        cx: Scope,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
-        common: Rc<CommonData>,
-    ) -> Doc {
+    pub fn new_local(cx: Scope, editors: Editors, common: Rc<CommonData>) -> Doc {
         Self::new_content(cx, DocContent::Local, editors, common)
     }
 
     pub fn new_content(
         cx: Scope,
         content: DocContent,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+        editors: Editors,
         common: Rc<CommonData>,
     ) -> Doc {
         let cx = cx.create_child();
@@ -297,7 +294,7 @@ impl Doc {
     pub fn new_history(
         cx: Scope,
         content: DocContent,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+        editors: Editors,
         common: Rc<CommonData>,
     ) -> Doc {
         let config = common.config.get_untracked();
@@ -420,9 +417,8 @@ impl Doc {
         editor
     }
 
-    fn editor_data(&self, id: EditorId) -> Option<Rc<EditorData>> {
-        self.editors
-            .with_untracked(|editors| editors.get(&id).cloned())
+    fn editor_data(&self, id: EditorId) -> Option<EditorData> {
+        self.editors.editor_untracked(id)
     }
 
     pub fn syntax(&self) -> ReadSignal<Syntax> {
@@ -1987,6 +1983,8 @@ impl Styling for DocStyling {
             EditorColor::Scrollbar => LapceColor::LAPCE_SCROLL_BAR,
             EditorColor::DropdownShadow => LapceColor::LAPCE_DROPDOWN_SHADOW,
             EditorColor::PreeditUnderline => LapceColor::EDITOR_FOREGROUND,
+            EditorColor::Foreground => return Color::WHITE,
+            EditorColor::Background => return Color::BLACK,
             _ => color.into(),
         };
 

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -1983,8 +1983,6 @@ impl Styling for DocStyling {
             EditorColor::Scrollbar => LapceColor::LAPCE_SCROLL_BAR,
             EditorColor::DropdownShadow => LapceColor::LAPCE_DROPDOWN_SHADOW,
             EditorColor::PreeditUnderline => LapceColor::EDITOR_FOREGROUND,
-            EditorColor::Foreground => return Color::WHITE,
-            EditorColor::Background => return Color::BLACK,
             _ => color.into(),
         };
 

--- a/lapce-app/src/editor/diff.rs
+++ b/lapce-app/src/editor/diff.rs
@@ -137,8 +137,8 @@ pub struct DiffEditorData {
     pub id: DiffEditorId,
     pub editor_tab_id: RwSignal<EditorTabId>,
     pub scope: Scope,
-    pub left: Rc<EditorData>,
-    pub right: Rc<EditorData>,
+    pub left: EditorData,
+    pub right: EditorData,
     pub confirmed: RwSignal<bool>,
     pub focus_right: RwSignal<bool>,
 }
@@ -156,16 +156,14 @@ impl DiffEditorData {
         let confirmed = cx.create_rw_signal(false);
 
         let [left, right] = [left_doc, right_doc].map(|doc| {
-            let editor_data = EditorData::new_doc(
+            EditorData::new_doc(
                 cx,
                 doc,
                 None,
                 Some((editor_tab_id, id)),
                 Some(confirmed),
                 common.clone(),
-            );
-
-            Rc::new(editor_data)
+            )
         });
 
         let data = Self {
@@ -200,14 +198,12 @@ impl DiffEditorData {
         let confirmed = cx.create_rw_signal(true);
 
         let [left, right] = [&self.left, &self.right].map(|editor_data| {
-            let editor_data = editor_data.copy(
+            editor_data.copy(
                 cx,
                 None,
                 Some((editor_tab_id, diff_editor_id)),
                 Some(confirmed),
-            );
-
-            Rc::new(editor_data)
+            )
         });
 
         let diff_editor = DiffEditorData {
@@ -311,8 +307,8 @@ struct DiffShowMoreSection {
 }
 
 pub fn diff_show_more_section_view(
-    left_editor: Rc<EditorData>,
-    right_editor: Rc<EditorData>,
+    left_editor: &EditorData,
+    right_editor: &EditorData,
 ) -> impl View {
     let left_editor_view = left_editor.kind;
     let right_editor_view = right_editor.kind;

--- a/lapce-app/src/editor/gutter.rs
+++ b/lapce-app/src/editor/gutter.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use floem::{
     context::PaintCx,
     cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
@@ -17,11 +15,11 @@ use super::{view::changes_colors_screen, EditorData};
 pub struct EditorGutterView {
     id: Id,
     data: ViewData,
-    editor: Rc<EditorData>,
+    editor: EditorData,
     width: f64,
 }
 
-pub fn editor_gutter_view(editor: Rc<EditorData>) -> EditorGutterView {
+pub fn editor_gutter_view(editor: EditorData) -> EditorGutterView {
     let id = Id::next();
 
     EditorGutterView {

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -58,7 +58,7 @@ struct StickyHeaderInfo {
 
 pub struct EditorView {
     data: ViewData,
-    editor: Rc<EditorData>,
+    editor: EditorData,
     is_active: Memo<bool>,
     inner_node: Option<NodeId>,
     viewport: RwSignal<Rect>,
@@ -67,7 +67,7 @@ pub struct EditorView {
 }
 
 pub fn editor_view(
-    e_data: Rc<EditorData>,
+    e_data: EditorData,
     debug_breakline: Memo<Option<(usize, PathBuf)>>,
     is_active: impl Fn(bool) -> bool + 'static + Copy,
 ) -> EditorView {
@@ -1131,7 +1131,7 @@ pub fn editor_container_view(
     window_tab_data: Rc<WindowTabData>,
     workspace: Arc<LapceWorkspace>,
     is_active: impl Fn(bool) -> bool + 'static + Copy,
-    editor: RwSignal<Rc<EditorData>>,
+    editor: RwSignal<EditorData>,
 ) -> impl View {
     let (editor_id, find_focus, sticky_header_height, editor_view, config) = editor
         .with_untracked(|editor| {
@@ -1197,7 +1197,7 @@ pub fn editor_container_view(
         .style(|s| s.size_pct(100.0, 100.0)),
     ))
     .on_cleanup(move || {
-        if editors.with_untracked(|editors| editors.contains_key(&editor_id)) {
+        if editors.contains_untracked(editor_id) {
             // editor still exist, so it might be moved to a different editor tab
             return;
         }
@@ -1224,7 +1224,7 @@ pub fn editor_container_view(
 
 fn editor_gutter(
     window_tab_data: Rc<WindowTabData>,
-    e_data: RwSignal<Rc<EditorData>>,
+    e_data: RwSignal<EditorData>,
     is_active: impl Fn(bool) -> bool + 'static + Copy,
 ) -> impl View {
     let breakpoints = window_tab_data.terminal.debug.breakpoints;
@@ -1526,7 +1526,7 @@ fn editor_gutter(
 
 fn editor_breadcrumbs(
     workspace: Arc<LapceWorkspace>,
-    e_data: Rc<EditorData>,
+    e_data: EditorData,
     config: ReadSignal<Arc<LapceConfig>>,
 ) -> impl View {
     let doc = e_data.doc_signal();
@@ -1638,7 +1638,7 @@ fn editor_breadcrumbs(
 }
 
 fn editor_content(
-    e_data: RwSignal<Rc<EditorData>>,
+    e_data: RwSignal<EditorData>,
     debug_breakline: Memo<Option<(usize, PathBuf)>>,
     is_active: impl Fn(bool) -> bool + 'static + Copy,
 ) -> impl View {
@@ -1880,7 +1880,7 @@ fn replace_editor_view(
 }
 
 fn find_view(
-    editor: RwSignal<Rc<EditorData>>,
+    editor: RwSignal<EditorData>,
     find_editor: EditorData,
     find_focus: RwSignal<bool>,
     replace_editor: EditorData,

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -45,7 +45,7 @@ use crate::{
     config::{color::LapceColor, icon::LapceIcons, LapceConfig},
     debug::LapceBreakpoint,
     doc::DocContent,
-    text_input::text_input,
+    text_input::TextInputBuilder,
     window_tab::{Focus, WindowTabData},
     workspace::LapceWorkspace,
 };
@@ -1772,17 +1772,19 @@ fn search_editor_view(
     let visual = find_editor.common.find.visual;
 
     stack((
-        text_input(find_editor, move || {
-            is_active(true)
-                && visual.get()
-                && find_focus.get()
-                && !replace_focus.get()
-        })
-        .on_event_cont(EventListener::PointerDown, move |_| {
-            find_focus.set(true);
-            replace_focus.set(false);
-        })
-        .style(|s| s.width_pct(100.0)),
+        TextInputBuilder::new()
+            .is_focused(move || {
+                is_active(true)
+                    && visual.get()
+                    && find_focus.get()
+                    && !replace_focus.get()
+            })
+            .build_editor(find_editor)
+            .on_event_cont(EventListener::PointerDown, move |_| {
+                find_focus.set(true);
+                replace_focus.set(false);
+            })
+            .style(|s| s.width_pct(100.0)),
         clickable_icon(
             || LapceIcons::SEARCH_CASE_SENSITIVE,
             move || {
@@ -1850,18 +1852,20 @@ fn replace_editor_view(
     let visual = replace_editor.common.find.visual;
 
     stack((
-        text_input(replace_editor, move || {
-            is_active(true)
-                && visual.get()
-                && find_focus.get()
-                && replace_active.get()
-                && replace_focus.get()
-        })
-        .on_event_cont(EventListener::PointerDown, move |_| {
-            find_focus.set(true);
-            replace_focus.set(true);
-        })
-        .style(|s| s.width_pct(100.0)),
+        TextInputBuilder::new()
+            .is_focused(move || {
+                is_active(true)
+                    && visual.get()
+                    && find_focus.get()
+                    && replace_active.get()
+                    && replace_focus.get()
+            })
+            .build_editor(replace_editor)
+            .on_event_cont(EventListener::PointerDown, move |_| {
+                find_focus.set(true);
+                replace_focus.set(true);
+            })
+            .style(|s| s.width_pct(100.0)),
         empty().style(move |s| {
             let config = config.get();
             let size = config.ui.icon_size() as f32 + 10.0;

--- a/lapce-app/src/editor_tab.rs
+++ b/lapce-app/src/editor_tab.rs
@@ -27,7 +27,7 @@ use crate::{
         DiffEditorId, EditorTabId, KeymapId, SettingsId, SplitId,
         ThemeColorSettingsId, VoltViewId,
     },
-    main_split::MainSplitData,
+    main_split::{Editors, MainSplitData},
     plugin::PluginData,
     window_tab::WindowTabData,
 };
@@ -171,9 +171,7 @@ impl EditorTabChild {
                 let editor_data = data
                     .main_split
                     .editors
-                    .get_untracked()
-                    .get(editor_id)
-                    .cloned()
+                    .editor_untracked(*editor_id)
                     .unwrap();
                 EditorTabChildInfo::Editor(editor_data.editor_info(data))
             }
@@ -198,7 +196,7 @@ impl EditorTabChild {
 
     pub fn view_info(
         &self,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+        editors: Editors,
         diff_editors: RwSignal<im::HashMap<DiffEditorId, DiffEditorData>>,
         plugin: PluginData,
         config: ReadSignal<Arc<LapceConfig>>,
@@ -206,8 +204,7 @@ impl EditorTabChild {
         match self.clone() {
             EditorTabChild::Editor(editor_id) => create_memo(move |_| {
                 let config = config.get();
-                let editor_data =
-                    editors.with(|editors| editors.get(&editor_id).cloned());
+                let editor_data = editors.editor(editor_id);
                 let path = if let Some(editor_data) = editor_data {
                     let doc = editor_data.doc_signal().get();
                     let (content, is_pristine, confirmed) = (
@@ -409,12 +406,12 @@ pub struct EditorTabData {
 impl EditorTabData {
     pub fn get_editor(
         &self,
-        editors: &im::HashMap<EditorId, Rc<EditorData>>,
+        editors: Editors,
         path: &Path,
-    ) -> Option<(usize, Rc<EditorData>)> {
+    ) -> Option<(usize, EditorData)> {
         for (i, child) in self.children.iter().enumerate() {
             if let (_, _, EditorTabChild::Editor(editor_id)) = child {
-                if let Some(editor) = editors.get(editor_id) {
+                if let Some(editor) = editors.editor_untracked(*editor_id) {
                     let is_path = editor.doc().content.with_untracked(|content| {
                         if let DocContent::File { path: p, .. } = content {
                             p == path
@@ -423,7 +420,7 @@ impl EditorTabData {
                         }
                     });
                     if is_path {
-                        return Some((i, editor.clone()));
+                        return Some((i, editor));
                     }
                 }
             }
@@ -433,13 +430,13 @@ impl EditorTabData {
 
     pub fn get_unconfirmed_editor_tab_child(
         &self,
-        editors: &im::HashMap<EditorId, Rc<EditorData>>,
+        editors: Editors,
         diff_editors: &im::HashMap<EditorId, DiffEditorData>,
     ) -> Option<(usize, EditorTabChild)> {
         for (i, (_, _, child)) in self.children.iter().enumerate() {
             match child {
                 EditorTabChild::Editor(editor_id) => {
-                    if let Some(editor) = editors.get(editor_id) {
+                    if let Some(editor) = editors.editor_untracked(*editor_id) {
                         let confirmed = editor.confirmed.get_untracked();
                         if !confirmed {
                             return Some((i, child.clone()));

--- a/lapce-app/src/editor_tab.rs
+++ b/lapce-app/src/editor_tab.rs
@@ -50,8 +50,8 @@ impl EditorTabChildInfo {
     ) -> EditorTabChild {
         match &self {
             EditorTabChildInfo::Editor(editor_info) => {
-                let editor_data = editor_info.to_data(data, editor_tab_id);
-                EditorTabChild::Editor(editor_data.id())
+                let editor_id = editor_info.to_data(data, editor_tab_id);
+                EditorTabChild::Editor(editor_id)
             }
             EditorTabChildInfo::DiffEditor(diff_editor_info) => {
                 let diff_editor_data = diff_editor_info.to_data(data, editor_tab_id);

--- a/lapce-app/src/file_explorer/data.rs
+++ b/lapce-app/src/file_explorer/data.rs
@@ -122,7 +122,7 @@ impl FileExplorerData {
             children_open_count: 0,
         });
         let naming = cx.create_rw_signal(Naming::None);
-        let naming_editor_data = EditorData::new_local(cx, editors, common.clone());
+        let naming_editor_data = editors.make_local(cx, common.clone());
         let data = Self {
             root,
             naming,

--- a/lapce-app/src/file_explorer/data.rs
+++ b/lapce-app/src/file_explorer/data.rs
@@ -12,7 +12,7 @@ use floem::{
     keyboard::ModifiersState,
     menu::{Menu, MenuItem},
     reactive::{RwSignal, Scope},
-    views::editor::{id::EditorId, text::SystemClipboard},
+    views::editor::text::SystemClipboard,
     EventPropagation,
 };
 use globset::Glob;
@@ -30,6 +30,7 @@ use crate::{
     command::{CommandExecuted, CommandKind, InternalCommand, LapceCommand},
     editor::EditorData,
     keypress::{condition::Condition, KeyPressFocus},
+    main_split::Editors,
     window_tab::CommonData,
 };
 
@@ -110,11 +111,7 @@ impl KeyPressFocus for FileExplorerData {
 }
 
 impl FileExplorerData {
-    pub fn new(
-        cx: Scope,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
-        common: Rc<CommonData>,
-    ) -> Self {
+    pub fn new(cx: Scope, editors: Editors, common: Rc<CommonData>) -> Self {
         let path = common.workspace.path.clone().unwrap_or_default();
         let root = cx.create_rw_signal(FileNodeItem {
             path: path.clone(),

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -28,7 +28,7 @@ use crate::{
     panel::{kind::PanelKind, position::PanelPosition, view::PanelBuilder},
     plugin::PluginData,
     source_control::SourceControlData,
-    text_input::text_input_key_focus,
+    text_input::TextInputBuilder,
     window_tab::{Focus, WindowTabData},
 };
 
@@ -220,24 +220,23 @@ fn file_node_input_view(data: FileExplorerData, err: Option<String>) -> Containe
     let is_focused = move || {
         focus.with_untracked(|focus| focus == &Focus::Panel(PanelKind::FileExplorer))
     };
-    let text_input_view = text_input_key_focus(
-        naming_editor_data.clone(),
-        Some(text_input_file_explorer_data),
-        is_focused,
-    )
-    .on_event_stop(EventListener::FocusLost, move |_| {
-        data.finish_naming();
-        data.naming.set(Naming::None);
-    })
-    .style(move |s| {
-        s.width_full()
-            .height(ui_line_height.get())
-            .padding(0.0)
-            .margin(0.0)
-            .border_radius(6.0)
-            .border(1.0)
-            .border_color(config.get().color(LapceColor::LAPCE_BORDER))
-    });
+    let text_input_view = TextInputBuilder::new()
+        .is_focused(is_focused)
+        .key_focus(text_input_file_explorer_data)
+        .build_editor(naming_editor_data.clone())
+        .on_event_stop(EventListener::FocusLost, move |_| {
+            data.finish_naming();
+            data.naming.set(Naming::None);
+        })
+        .style(move |s| {
+            s.width_full()
+                .height(ui_line_height.get())
+                .padding(0.0)
+                .margin(0.0)
+                .border_radius(6.0)
+                .border(1.0)
+                .border_color(config.get().color(LapceColor::LAPCE_BORDER))
+        });
 
     let text_input_id = text_input_view.id();
     text_input_id.request_focus();

--- a/lapce-app/src/global_search.rs
+++ b/lapce-app/src/global_search.rs
@@ -107,7 +107,7 @@ impl VirtualVector<(PathBuf, SearchMatchData)> for GlobalSearchData {
 impl GlobalSearchData {
     pub fn new(cx: Scope, main_split: MainSplitData) -> Self {
         let common = main_split.common.clone();
-        let editor = EditorData::new_local(cx, main_split.editors, common.clone());
+        let editor = main_split.editors.make_local(cx, common.clone());
         let search_result = cx.create_rw_signal(IndexMap::new());
 
         let global_search = Self {

--- a/lapce-app/src/keymap.rs
+++ b/lapce-app/src/keymap.rs
@@ -9,8 +9,8 @@ use floem::{
     style::CursorStyle,
     view::View,
     views::{
-        container, dyn_stack, editor::id::EditorId, label, scroll, stack, text,
-        virtual_stack, Decorators, VirtualDirection, VirtualItemSize,
+        container, dyn_stack, label, scroll, stack, text, virtual_stack, Decorators,
+        VirtualDirection, VirtualItemSize,
     },
 };
 use lapce_core::mode::Modes;
@@ -20,6 +20,7 @@ use crate::{
     config::{color::LapceColor, LapceConfig},
     editor::EditorData,
     keypress::{keymap::KeyMap, KeyPress, KeyPressData},
+    main_split::Editors,
     text_input::text_input,
     window_tab::CommonData,
 };
@@ -31,10 +32,7 @@ pub struct KeymapPicker {
     keys: RwSignal<Vec<(KeyPress, bool)>>,
 }
 
-pub fn keymap_view(
-    editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
-    common: Rc<CommonData>,
-) -> impl View {
+pub fn keymap_view(editors: Editors, common: Rc<CommonData>) -> impl View {
     let config = common.config;
     let keypress = common.keypress;
     let ui_line_height_memo = common.ui_line_height;

--- a/lapce-app/src/keymap.rs
+++ b/lapce-app/src/keymap.rs
@@ -18,10 +18,9 @@ use lapce_core::mode::Modes;
 use crate::{
     command::LapceCommand,
     config::{color::LapceColor, LapceConfig},
-    editor::EditorData,
     keypress::{keymap::KeyMap, KeyPress, KeyPressData},
     main_split::Editors,
-    text_input::text_input,
+    text_input::TextInputBuilder,
     window_tab::CommonData,
 };
 
@@ -45,8 +44,8 @@ pub fn keymap_view(editors: Editors, common: Rc<CommonData>) -> impl View {
     };
 
     let cx = Scope::current();
-    let editor = EditorData::new_local(cx, editors, common.clone());
-    let doc = editor.doc_signal();
+    let text_input_view = TextInputBuilder::new().build(cx, editors, common.clone());
+    let doc = text_input_view.doc_signal();
 
     let items = move || {
         let doc = doc.get();
@@ -279,7 +278,7 @@ pub fn keymap_view(editors: Editors, common: Rc<CommonData>) -> impl View {
 
     stack((
         container(
-            text_input(editor, || false)
+            text_input_view
                 .placeholder(|| "Search Key Bindings".to_string())
                 .keyboard_navigatable()
                 .style(move |s| {

--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -86,6 +86,36 @@ impl KeyPressFocus for () {
 
     fn receive_char(&self, _c: &str) {}
 }
+impl KeyPressFocus for Box<dyn KeyPressFocus> {
+    fn get_mode(&self) -> Mode {
+        (**self).get_mode()
+    }
+
+    fn check_condition(&self, condition: Condition) -> bool {
+        (**self).check_condition(condition)
+    }
+
+    fn run_command(
+        &self,
+        command: &LapceCommand,
+        count: Option<usize>,
+        mods: ModifiersState,
+    ) -> CommandExecuted {
+        (**self).run_command(command, count, mods)
+    }
+
+    fn expect_char(&self) -> bool {
+        (**self).expect_char()
+    }
+
+    fn focus_only(&self) -> bool {
+        (**self).focus_only()
+    }
+
+    fn receive_char(&self, c: &str) {
+        (**self).receive_char(c)
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum EventRef<'a> {

--- a/lapce-app/src/palette.rs
+++ b/lapce-app/src/palette.rs
@@ -91,7 +91,7 @@ pub struct PaletteData {
     pub input: RwSignal<PaletteInput>,
     kind: RwSignal<PaletteKind>,
     pub input_editor: EditorData,
-    pub preview_editor: Rc<EditorData>,
+    pub preview_editor: EditorData,
     pub has_preview: RwSignal<bool>,
     pub keypress: ReadSignal<KeyPressData>,
     /// Listened on for which entry in the palette has been clicked
@@ -128,7 +128,6 @@ impl PaletteData {
             EditorData::new_local(cx, main_split.editors, common.clone());
         let preview_editor =
             EditorData::new_local(cx, main_split.editors, common.clone());
-        let preview_editor = Rc::new(preview_editor);
         let has_preview = cx.create_rw_signal(false);
         let run_id = cx.create_rw_signal(0);
         let run_id_counter = Arc::new(AtomicU64::new(0));

--- a/lapce-app/src/palette.rs
+++ b/lapce-app/src/palette.rs
@@ -124,10 +124,8 @@ impl PaletteData {
             kind: PaletteKind::File,
         });
         let kind = cx.create_rw_signal(PaletteKind::File);
-        let input_editor =
-            EditorData::new_local(cx, main_split.editors, common.clone());
-        let preview_editor =
-            EditorData::new_local(cx, main_split.editors, common.clone());
+        let input_editor = main_split.editors.make_local(cx, common.clone());
+        let preview_editor = main_split.editors.make_local(cx, common.clone());
         let has_preview = cx.create_rw_signal(false);
         let run_id = cx.create_rw_signal(0);
         let run_id_counter = Arc::new(AtomicU64::new(0));

--- a/lapce-app/src/panel/global_search_view.rs
+++ b/lapce-app/src/panel/global_search_view.rs
@@ -21,7 +21,7 @@ use crate::{
     focus_text::focus_text,
     global_search::{GlobalSearchData, SearchMatchData},
     listener::Listener,
-    text_input::text_input,
+    text_input::TextInputBuilder,
     window_tab::{Focus, WindowTabData},
     workspace::LapceWorkspace,
 };
@@ -45,7 +45,10 @@ pub fn global_search_panel(
     stack((
         container(
             stack((
-                text_input(editor, is_focused).style(|s| s.width_pct(100.0)),
+                TextInputBuilder::new()
+                    .is_focused(is_focused)
+                    .build_editor(editor.clone())
+                    .style(|s| s.width_pct(100.0)),
                 clickable_icon(
                     || LapceIcons::SEARCH_CASE_SENSITIVE,
                     move || {

--- a/lapce-app/src/panel/plugin_view.rs
+++ b/lapce-app/src/panel/plugin_view.rs
@@ -20,7 +20,7 @@ use crate::{
     command::InternalCommand,
     config::{color::LapceColor, icon::LapceIcons},
     plugin::{AvailableVoltData, InstalledVoltData, PluginData, VoltIcon},
-    text_input::text_input,
+    text_input::TextInputBuilder,
     window_tab::{Focus, WindowTabData},
 };
 
@@ -319,7 +319,9 @@ fn available_view(plugin: PluginData) -> impl View {
     stack((
         container({
             scroll(
-                text_input(editor, is_focused)
+                TextInputBuilder::new()
+                    .is_focused(is_focused)
+                    .build_editor(editor.clone())
                     .on_cursor_pos(move |point| {
                         cursor_x.set(point.x);
                     })

--- a/lapce-app/src/plugin.rs
+++ b/lapce-app/src/plugin.rs
@@ -155,7 +155,7 @@ impl PluginData {
             volts: cx.create_rw_signal(IndexMap::new()),
             total: cx.create_rw_signal(0),
             query_id: cx.create_rw_signal(0),
-            query_editor: EditorData::new_local(cx, editors, common.clone()),
+            query_editor: editors.make_local(cx, common.clone()),
         };
         let disabled = cx.create_rw_signal(disabled);
         let workspace_disabled = cx.create_rw_signal(workspace_disabled);

--- a/lapce-app/src/plugin.rs
+++ b/lapce-app/src/plugin.rs
@@ -17,8 +17,8 @@ use floem::{
     style::CursorStyle,
     view::View,
     views::{
-        container, dyn_container, dyn_stack, editor::id::EditorId, empty, img,
-        label, rich_text, scroll, stack, svg, text, Decorators,
+        container, dyn_container, dyn_stack, empty, img, label, rich_text, scroll,
+        stack, svg, text, Decorators,
     },
 };
 use indexmap::IndexMap;
@@ -34,6 +34,7 @@ use crate::{
     db::LapceDb,
     editor::EditorData,
     keypress::{condition::Condition, KeyPressFocus},
+    main_split::Editors,
     markdown::{parse_markdown, MarkdownContent},
     panel::plugin_view::VOLT_DEFAULT_PNG,
     web_link::web_link,
@@ -145,7 +146,7 @@ impl PluginData {
         cx: Scope,
         disabled: HashSet<VoltID>,
         workspace_disabled: HashSet<VoltID>,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+        editors: Editors,
         common: Rc<CommonData>,
     ) -> Self {
         let installed = cx.create_rw_signal(IndexMap::new());

--- a/lapce-app/src/rename.rs
+++ b/lapce-app/src/rename.rs
@@ -5,7 +5,6 @@ use floem::{
     keyboard::ModifiersState,
     peniko::kurbo::Rect,
     reactive::{RwSignal, Scope},
-    views::editor::id::EditorId,
 };
 use lapce_core::{command::FocusCommand, mode::Mode, selection::Selection};
 use lapce_rpc::proxy::ProxyResponse;
@@ -16,6 +15,7 @@ use crate::{
     command::{CommandExecuted, CommandKind, InternalCommand, LapceCommand},
     editor::EditorData,
     keypress::{condition::Condition, KeyPressFocus},
+    main_split::Editors,
     window_tab::{CommonData, Focus},
 };
 
@@ -67,11 +67,7 @@ impl KeyPressFocus for RenameData {
 }
 
 impl RenameData {
-    pub fn new(
-        cx: Scope,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
-        common: Rc<CommonData>,
-    ) -> Self {
+    pub fn new(cx: Scope, editors: Editors, common: Rc<CommonData>) -> Self {
         let active = cx.create_rw_signal(false);
         let start = cx.create_rw_signal(0);
         let position = cx.create_rw_signal(Position::default());

--- a/lapce-app/src/rename.rs
+++ b/lapce-app/src/rename.rs
@@ -73,7 +73,7 @@ impl RenameData {
         let position = cx.create_rw_signal(Position::default());
         let layout_rect = cx.create_rw_signal(Rect::ZERO);
         let path = cx.create_rw_signal(PathBuf::new());
-        let editor = EditorData::new_local(cx, editors, common.clone());
+        let editor = editors.make_local(cx, common.clone());
         Self {
             active,
             editor,

--- a/lapce-app/src/settings.rs
+++ b/lapce-app/src/settings.rs
@@ -15,7 +15,6 @@ use floem::{
     },
     style::CursorStyle,
     view::View,
-    views::editor::id::EditorId,
     views::{
         container, dyn_stack, empty, label, scroll, stack, svg, text, virtual_stack,
         Decorators, VirtualDirection, VirtualItemSize, VirtualVector,
@@ -36,6 +35,7 @@ use crate::{
     },
     editor::EditorData,
     keypress::KeyPressFocus,
+    main_split::Editors,
     plugin::InstalledVoltData,
     text_input::text_input,
     window_tab::CommonData,
@@ -308,7 +308,7 @@ impl SettingsData {
 
 pub fn settings_view(
     installed_plugins: RwSignal<IndexMap<VoltID, InstalledVoltData>>,
-    editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+    editors: Editors,
     common: Rc<CommonData>,
 ) -> impl View {
     let config = common.config;
@@ -526,7 +526,7 @@ pub fn settings_view(
 }
 
 fn settings_item_view(
-    editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+    editors: Editors,
     settings_data: SettingsData,
     item: SettingsItem,
 ) -> impl View {
@@ -901,7 +901,7 @@ fn color_section_list(
     list: impl Fn() -> BTreeMap<String, String> + 'static,
     max_width: Memo<f64>,
     text_height: Memo<f64>,
-    editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+    editors: Editors,
     common: Rc<CommonData>,
 ) -> impl View {
     let config = common.config;
@@ -1113,7 +1113,7 @@ fn color_section_list(
 }
 
 pub fn theme_color_settings_view(
-    editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
+    editors: Editors,
     common: Rc<CommonData>,
 ) -> impl View {
     let config = common.config;

--- a/lapce-app/src/settings.rs
+++ b/lapce-app/src/settings.rs
@@ -33,11 +33,10 @@ use crate::{
         color::LapceColor, core::CoreConfig, editor::EditorConfig, icon::LapceIcons,
         terminal::TerminalConfig, ui::UIConfig, DropdownInfo, LapceConfig,
     },
-    editor::EditorData,
     keypress::KeyPressFocus,
     main_split::Editors,
     plugin::InstalledVoltData,
-    text_input::text_input,
+    text_input::TextInputBuilder,
     window_tab::CommonData,
 };
 
@@ -318,7 +317,7 @@ pub fn settings_view(
     let view_settings_data = settings_data.clone();
     let plugin_kinds = settings_data.plugin_kinds;
 
-    let search_editor = EditorData::new_local(cx, editors, common);
+    let search_editor = editors.make_local(cx, common);
     let doc = search_editor.doc_signal();
 
     let items = settings_data.items.clone();
@@ -471,7 +470,8 @@ pub fn settings_view(
         }),
         stack((
             container({
-                text_input(search_editor, || false)
+                TextInputBuilder::new()
+                    .build_editor(search_editor)
                     .placeholder(|| "Search Settings".to_string())
                     .keyboard_navigatable()
                     .style(move |s| {
@@ -554,15 +554,17 @@ fn settings_item_view(
         move || {
             let cx = Scope::current();
             if let Some(editor_value) = editor_value {
-                let editor =
-                    EditorData::new_local(cx, editors, settings_data.common);
-                let doc = editor.doc();
-                doc.reload(Rope::from(editor_value), true);
+                let text_input_view = TextInputBuilder::new()
+                    .value(editor_value)
+                    .build(cx, editors, settings_data.common);
+
+                let doc = text_input_view.doc_signal();
 
                 let kind = item.kind.clone();
                 let field = item.field.clone();
                 let item_value = item.value.clone();
                 create_effect(move |last| {
+                    let doc = doc.get_untracked();
                     let rev = doc.buffer.with(|b| b.rev());
                     if last.is_none() {
                         return rev;
@@ -617,13 +619,12 @@ fn settings_item_view(
                     rev
                 });
 
-                container(text_input(editor, || false).keyboard_navigatable().style(
-                    move |s| {
-                        s.width(300.0).border(1.0).border_radius(6.0).border_color(
-                            config.get().color(LapceColor::LAPCE_BORDER),
-                        )
-                    },
-                ))
+                container(text_input_view.keyboard_navigatable().style(move |s| {
+                    s.width(300.0)
+                        .border(1.0)
+                        .border_radius(6.0)
+                        .border_color(config.get().color(LapceColor::LAPCE_BORDER))
+                }))
             } else if let SettingsValue::Dropdown(dropdown) = item.value {
                 let expanded = create_rw_signal(false);
                 let current_value = dropdown
@@ -921,15 +922,17 @@ fn color_section_list(
             move |(key, _)| (key.to_owned()),
             move |(key, value)| {
                 let cx = Scope::current();
-                let editor = EditorData::new_local(cx, editors, common.clone());
-                let doc = editor.doc();
-                doc.reload(Rope::from(value.clone()), true);
+                let text_input_view = TextInputBuilder::new()
+                    .value(value.clone())
+                    .build(cx, editors, common.clone());
+                let doc = text_input_view.doc_signal();
 
                 {
                     let kind = kind.clone();
                     let key = key.clone();
-                    let doc = doc.clone();
+                    let doc = text_input_view.doc_signal();
                     create_effect(move |_| {
+                        let doc = doc.get_untracked();
                         let config = config.get();
                         let current = doc.buffer.with_untracked(|b| b.to_string());
 
@@ -952,8 +955,9 @@ fn color_section_list(
                     let timer = create_rw_signal(TimerToken::INVALID);
                     let kind = kind.clone();
                     let field = key.clone();
-                    let doc = doc.clone();
                     create_effect(move |last| {
+                        let doc = doc.get_untracked();
+
                         let rev = doc.buffer.with(|b| b.rev());
                         if last.is_none() {
                             return rev;
@@ -1024,17 +1028,15 @@ fn color_section_list(
                     text(&key).style(move |s| {
                         s.width(max_width.get()).margin_left(20).margin_right(10)
                     }),
-                    text_input(editor, || false).keyboard_navigatable().style(
-                        move |s| {
-                            s.width(150.0)
-                                .margin_vert(6)
-                                .border(1)
-                                .border_radius(6)
-                                .border_color(
-                                    config.get().color(LapceColor::LAPCE_BORDER),
-                                )
-                        },
-                    ),
+                    text_input_view.keyboard_navigatable().style(move |s| {
+                        s.width(150.0)
+                            .margin_vert(6)
+                            .border(1)
+                            .border_radius(6)
+                            .border_color(
+                                config.get().color(LapceColor::LAPCE_BORDER),
+                            )
+                    }),
                     empty().style(move |s| {
                         let size = text_height.get() + 12.0;
                         let config = config.get();
@@ -1066,6 +1068,7 @@ fn color_section_list(
                                 );
                             })
                             .style(move |s| {
+                                let doc = doc.get_untracked();
                                 let config = config.get();
                                 let buffer = doc.buffer;
                                 let content = buffer.with(|b| b.to_string());

--- a/lapce-app/src/source_control.rs
+++ b/lapce-app/src/source_control.rs
@@ -3,7 +3,6 @@ use std::{path::PathBuf, rc::Rc};
 use floem::{
     keyboard::ModifiersState,
     reactive::{RwSignal, Scope},
-    views::editor::id::EditorId,
 };
 use indexmap::IndexMap;
 use lapce_core::mode::Mode;
@@ -13,6 +12,7 @@ use crate::{
     command::{CommandExecuted, CommandKind},
     editor::EditorData,
     keypress::{condition::Condition, KeyPressFocus},
+    main_split::Editors,
     window_tab::CommonData,
 };
 
@@ -23,7 +23,7 @@ pub struct SourceControlData {
     pub branch: RwSignal<String>,
     pub branches: RwSignal<im::Vector<String>>,
     pub tags: RwSignal<im::Vector<String>>,
-    pub editor: Rc<EditorData>,
+    pub editor: EditorData,
     pub common: Rc<CommonData>,
 }
 
@@ -61,17 +61,13 @@ impl KeyPressFocus for SourceControlData {
 }
 
 impl SourceControlData {
-    pub fn new(
-        cx: Scope,
-        editors: RwSignal<im::HashMap<EditorId, Rc<EditorData>>>,
-        common: Rc<CommonData>,
-    ) -> Self {
+    pub fn new(cx: Scope, editors: Editors, common: Rc<CommonData>) -> Self {
         Self {
             file_diffs: cx.create_rw_signal(IndexMap::new()),
             branch: cx.create_rw_signal("".to_string()),
             branches: cx.create_rw_signal(im::Vector::new()),
             tags: cx.create_rw_signal(im::Vector::new()),
-            editor: Rc::new(EditorData::new_local(cx, editors, common.clone())),
+            editor: EditorData::new_local(cx, editors, common.clone()),
             common,
         }
     }

--- a/lapce-app/src/source_control.rs
+++ b/lapce-app/src/source_control.rs
@@ -67,7 +67,7 @@ impl SourceControlData {
             branch: cx.create_rw_signal("".to_string()),
             branches: cx.create_rw_signal(im::Vector::new()),
             tags: cx.create_rw_signal(im::Vector::new()),
-            editor: EditorData::new_local(cx, editors, common.clone()),
+            editor: editors.make_local(cx, common.clone()),
             common,
         }
     }

--- a/lapce-app/src/status.rs
+++ b/lapce-app/src/status.rs
@@ -420,7 +420,7 @@ fn progress_view(
 
 fn status_text<S: std::fmt::Display + 'static>(
     config: ReadSignal<Arc<LapceConfig>>,
-    editor: Memo<Option<Rc<EditorData>>>,
+    editor: Memo<Option<EditorData>>,
     text: impl Fn() -> S + 'static,
 ) -> impl View {
     label(text).style(move |s| {

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -707,7 +707,7 @@ impl WindowTabData {
             }
 
             SaveAll => {
-                self.main_split.editors.with_untracked(|editors| {
+                self.main_split.editors.with_editors_untracked(|editors| {
                     let mut paths = HashSet::new();
                     for (_, editor_data) in editors.iter() {
                         let doc = editor_data.doc();
@@ -1373,7 +1373,7 @@ impl WindowTabData {
                             // file the renamed directory is an ancestor of is open to use the
                             // file's new path.
                             let renamed_editors_content: Vec<_> = editors
-                                .with_untracked(|editors| {
+                                .with_editors_untracked(|editors| {
                                     editors
                                         .values()
                                         .map(|editor| editor.doc().content)
@@ -1726,11 +1726,9 @@ impl WindowTabData {
                 });
 
                 let completion = self.common.completion.get_untracked();
-                let editor_data = completion.latest_editor_id.and_then(|id| {
-                    self.main_split
-                        .editors
-                        .with_untracked(|tabs| tabs.get(&id).cloned())
-                });
+                let editor_data = completion
+                    .latest_editor_id
+                    .and_then(|id| self.main_split.editors.editor_untracked(id));
                 if let Some(editor_data) = editor_data {
                     let cursor_offset =
                         editor_data.cursor().with_untracked(|c| c.offset());
@@ -1986,10 +1984,7 @@ impl WindowTabData {
         }
 
         let editor_id = self.common.hover.editor_id.get_untracked();
-        let editor_data = self
-            .main_split
-            .editors
-            .with(|editors| editors.get(&editor_id).cloned())?;
+        let editor_data = self.main_split.editors.editor(editor_id)?;
 
         let (window_origin, viewport, editor) = (
             editor_data.window_origin(),


### PR DESCRIPTION
~~- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users~~

Adds `Editors` structure instead of passing around a `RwSignal<im::Hashmap<EditorId, Rc<EditorData>>>` everywhere. Also removes that inner `Rc` as its unneeded because `EditorData` shares the held information.  
  
Second commit adds functions to `Editors` to construct the actual editors. All callers should use those instead, and are modified to use that. This fixes multiple bugs that occur due to unregistered editors.  
Text inputs are also modified to have a `TextInputBuilder` for auto-registration/deregistration for inputs that are created when the view is created (like in settings), while also supporting stored editors (like search panel input). I think the builder is better than adding more utility functions for various possible sets of parameters.  
Text inputs are added to the `Editors` structure now, but since they don't have a tab their inputs are handled the same way as before.