### PR TITLE
Two small `itertools` simplifications

### DIFF
--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -3147,20 +3147,16 @@ fn parse_hover_resp(
                 config,
             ),
         },
-        HoverContents::Array(array) => {
-            let entries = array
-                .into_iter()
-                .map(|t| from_marked_string(t, config))
-                .rev();
-
-            // TODO: It'd be nice to avoid this vec
-            itertools::Itertools::intersperse(
-                entries,
-                vec![MarkdownContent::Separator],
-            )
-            .flatten()
-            .collect()
-        }
+        HoverContents::Array(array) => array
+            .into_iter()
+            .map(|t| from_marked_string(t, config))
+            .rev()
+            .reduce(|mut contents, more| {
+                contents.push(MarkdownContent::Separator);
+                contents.extend(more);
+                contents
+            })
+            .unwrap_or_default(),
         HoverContents::Markup(content) => match content.kind {
             MarkupKind::PlainText => from_plaintext(&content.value, 1.5, config),
             MarkupKind::Markdown => parse_markdown(&content.value, 1.5, config),

--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -545,9 +545,7 @@ impl KeyPressData {
             if !keys.is_empty() {
                 array.get_mut(index)?.insert(
                     "key",
-                    toml_edit::value(toml_edit::Value::from(
-                        keys.iter().map(|k| k.to_string()).join(" "),
-                    )),
+                    toml_edit::value(toml_edit::Value::from(keys.iter().join(" "))),
                 );
             } else {
                 array.remove(index);
@@ -576,9 +574,7 @@ impl KeyPressData {
             if !keys.is_empty() {
                 table.insert(
                     "key",
-                    toml_edit::value(toml_edit::Value::from(
-                        keys.iter().map(|k| k.to_string()).join(" "),
-                    )),
+                    toml_edit::value(toml_edit::Value::from(keys.iter().join(" "))),
                 );
                 array.push(table.clone());
             }
@@ -587,7 +583,7 @@ impl KeyPressData {
                 table.insert(
                     "key",
                     toml_edit::value(toml_edit::Value::from(
-                        keymap.key.iter().map(|k| k.to_string()).join(" "),
+                        keymap.key.iter().join(" "),
                     )),
                 );
                 table.insert(


### PR DESCRIPTION
Hi, I just heard of **lapce** and I am gonna give it a try.
As a maintainer of itertools, I was curious of your usage of itertools and eventually found two small simplifications related to it:
- Remove a TODO. I suppose a method `concat_with_separator(sep)` could be useful.
- Remove 3 needless `.to_string()`.