### PR TITLE
Fix terminal default profile saving incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug Fixes
 - [#2779](https://github.com/lapce/lapce/pull/2779): Fix files detection on fresh git/VCS repository
 - [#3031](https://github.com/lapce/lapce/pull/3031): Fix find not receiving inputs when clicked
+- [#3142](https://github.com/lapce/lapce/pull/3142): Fix terminal default profile saving incorrectly
 
 ## 0.3.1
 

--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -933,6 +933,16 @@ impl LapceConfig {
         key: &str,
         value: toml_edit::Value,
     ) -> Option<()> {
+        // TODO: This is a hack to fix the fact that terminal default profile is saved in a
+        // different manner than other fields. As it is per-operating-system.
+        // Thus we have to instead set the terminal.default-profile.{OS}
+        // It would be better to not need a special hack.
+        let (parent, key) = if parent == "terminal" && key == "default-profile" {
+            ("terminal.default-profile", std::env::consts::OS)
+        } else {
+            (parent, key)
+        };
+
         let mut main_table = Self::get_file_table().unwrap_or_default();
 
         // Find the container table


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

Fixes #3070   
This is a hacky fix which special-cases it.  
I think it would be better to have a more general saving(&loading) setup for fields that need more custom logic, but not implementing it here.