### PR TITLE
fix: update schannel lapce/lapce#3290

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,12 +4513,10 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+version = "0.1.21"
+source = "git+https://github.com/steffengy/schannel-rs?tag=v0.1.21#e93c3bcf588630717bc592fe9f36fc4b740589b5"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6730,6 +6728,21 @@ dependencies = [
  "windows_i686_msvc 0.36.1",
  "windows_x86_64_gnu 0.36.1",
  "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ floem-editor-core = { git = "https://github.com/lapce/floem", rev = "c9e3d6a131c
 # Temporarily patch lsp-types with a version that supports inline-completion
 lsp-types = { git = "https://github.com/lapce/lsp-types", rev = "feaa1e2ec80975c9dadd400a238ceacf071058e6" }
 regalloc2 = { rev = "5d79e12d0a93b10fc181f4da409b4671dd365228", git = "https://github.com/bytecodealliance/regalloc2" }
-
+schannel = { git = "https://github.com/steffengy/schannel-rs", tag = "v0.1.21"}
 
 [workspace.dependencies.tracing]
 git     = "https://github.com/tokio-rs/tracing"


### PR DESCRIPTION
The schannel v0.1.20 has a bug but fixed on v0.1.21.
Dependencis tree: lapce-proxy v0.4.0 -> reqwest v0.11.27 -> hyper-tls v0.5.0 -> native-tls v0.2.10 -> schannel v0.1.20 
schannel version is 0.1.17 in the native-tls v0.2.10, but lapce use the 0.1.20 in cargo.lock, it need  larger than 0.1.20 to fix the bug lapce/lapce#3290