### PR TITLE
cargo-deny: init

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,15 @@
+[licenses]
+# use SPDX short identifiers
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]


### PR DESCRIPTION
* this add support for checking licenses with cargo deny check
* cargo deny can also check for security issues and unmaintained/yanked crates

see also: https://github.com/lapce/structdesc/pull/2

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users