### PR TITLE
Add debug names, trim extra containers

### DIFF
--- a/lapce-app/src/about.rs
+++ b/lapce-app/src/about.rs
@@ -157,6 +157,7 @@ pub fn about_popup(window_tab_data: Rc<WindowTabData>) -> impl View {
         ))
         .style(|s| s.flex_col().items_center())
     })
+    .debug_name("About Popup")
 }
 
 fn exclusive_popup<V: View + 'static>(

--- a/lapce-app/src/alert.rs
+++ b/lapce-app/src/alert.rs
@@ -170,4 +170,5 @@ pub fn alert_box(alert_data: AlertBoxData) -> impl View {
                     .with_alpha_factor(0.5),
             )
     })
+    .debug_name("Alert Box")
 }

--- a/lapce-app/src/editor/diff.rs
+++ b/lapce-app/src/editor/diff.rs
@@ -544,4 +544,5 @@ pub fn diff_show_more_section_view(
         .style(|s| s.size_pct(100.0, 100.0)),
     ))
     .style(|s| s.absolute().flex_col().size_pct(100.0, 100.0))
+    .debug_name("Diff Show More Section")
 }

--- a/lapce-app/src/editor/gutter.rs
+++ b/lapce-app/src/editor/gutter.rs
@@ -187,4 +187,8 @@ impl View for EditorGutterView {
         self.paint_head_changes(cx, &self.editor, viewport, kind_is_normal, &config);
         self.paint_sticky_headers(cx, kind_is_normal, &config);
     }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Editor Gutter".into()
+    }
 }

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -1263,8 +1263,7 @@ pub fn editor_container_view(
         container(
             stack((
                 editor_gutter(window_tab_data.clone(), editor, is_active),
-                container(editor_content(editor, debug_breakline, is_active))
-                    .style(move |s| s.size_pct(100.0, 100.0)),
+                editor_content(editor, debug_breakline, is_active),
                 empty().style(move |s| {
                     let config = config.get();
                     s.absolute()
@@ -1322,6 +1321,7 @@ pub fn editor_container_view(
         }
     })
     .style(|s| s.flex_col().absolute().size_pct(100.0, 100.0))
+    .debug_name("Editor Container")
 }
 
 fn editor_gutter(
@@ -1478,6 +1478,7 @@ fn editor_gutter(
             }),
             empty().style(move |s| s.width(padding_right)),
         ))
+        .debug_name("Centered Last Line Count")
         .style(|s| s.height_pct(100.0)),
         clip(
             stack((
@@ -1495,7 +1496,8 @@ fn editor_gutter(
                             % config.get().editor.line_height() as f64)
                             as f32,
                     )
-                }),
+                })
+                .debug_name("Breakpoint Stack"),
                 dyn_stack(
                     move || {
                         let e_data = e_data.get();
@@ -1565,54 +1567,51 @@ fn editor_gutter(
                         }
                     })
                     .style(|s| s.size_pct(100.0, 100.0)),
-                container(
-                    svg(move || config.get().ui_svg(LapceIcons::LIGHTBULB)).style(
-                        move |s| {
-                            let config = config.get();
-                            let size = config.ui.icon_size() as f32;
-                            s.size(size, size)
-                                .color(config.color(LapceColor::LAPCE_WARN))
-                        },
-                    ),
-                )
-                .on_click_stop(move |_| {
-                    e_data.get_untracked().show_code_actions(true);
-                })
-                .style(move |s| {
-                    let config = config.get();
-                    let viewport = viewport.get();
-                    let gutter_width = gutter_width.get();
-                    let code_action_vline = code_action_vline.get();
-                    let size = config.ui.icon_size() as f32;
-                    let margin_left =
-                        gutter_width as f32 + (padding_right - size) / 2.0 - 4.0;
-                    let line_height = config.editor.line_height();
-                    let margin_top = if let Some(vline) = code_action_vline {
-                        (vline.get() * line_height) as f32 - viewport.y0 as f32
-                            + (line_height as f32 - size) / 2.0
-                            - 4.0
-                    } else {
-                        0.0
-                    };
-                    s.absolute()
-                        .padding(4.0)
-                        .border_radius(6.0)
-                        .margin_left(margin_left)
-                        .margin_top(margin_top)
-                        .apply_if(code_action_vline.is_none(), |s| s.hide())
-                        .hover(|s| {
-                            s.cursor(CursorStyle::Pointer).background(
-                                config.color(LapceColor::PANEL_HOVERED_BACKGROUND),
-                            )
-                        })
-                        .active(|s| {
-                            s.background(
-                                config.color(
+                svg(move || config.get().ui_svg(LapceIcons::LIGHTBULB))
+                    .style(move |s| {
+                        let config = config.get();
+                        let size = config.ui.icon_size() as f32;
+                        s.size(size, size)
+                            .color(config.color(LapceColor::LAPCE_WARN))
+                    })
+                    .on_click_stop(move |_| {
+                        e_data.get_untracked().show_code_actions(true);
+                    })
+                    .style(move |s| {
+                        let config = config.get();
+                        let viewport = viewport.get();
+                        let gutter_width = gutter_width.get();
+                        let code_action_vline = code_action_vline.get();
+                        let size = config.ui.icon_size() as f32;
+                        let margin_left =
+                            gutter_width as f32 + (padding_right - size) / 2.0 - 4.0;
+                        let line_height = config.editor.line_height();
+                        let margin_top = if let Some(vline) = code_action_vline {
+                            (vline.get() * line_height) as f32 - viewport.y0 as f32
+                                + (line_height as f32 - size) / 2.0
+                                - 4.0
+                        } else {
+                            0.0
+                        };
+                        s.absolute()
+                            .padding(4.0)
+                            .border_radius(6.0)
+                            .margin_left(margin_left)
+                            .margin_top(margin_top)
+                            .apply_if(code_action_vline.is_none(), |s| s.hide())
+                            .hover(|s| {
+                                s.cursor(CursorStyle::Pointer).background(
+                                    config
+                                        .color(LapceColor::PANEL_HOVERED_BACKGROUND),
+                                )
+                            })
+                            .active(|s| {
+                                s.background(config.color(
                                     LapceColor::PANEL_HOVERED_ACTIVE_BACKGROUND,
-                                ),
-                            )
-                        })
-                }),
+                                ))
+                            })
+                    })
+                    .debug_name("Code Action LightBulb"),
             ))
             .style(|s| s.size_pct(100.0, 100.0)),
         )
@@ -1624,6 +1623,7 @@ fn editor_gutter(
         }),
     ))
     .style(|s| s.height_pct(100.0))
+    .debug_name("Editor Gutter")
 }
 
 fn editor_breadcrumbs(
@@ -1737,6 +1737,7 @@ fn editor_breadcrumbs(
             .height(line_height as f32)
             .apply_if(doc_path.get().is_none(), |s| s.hide())
     })
+    .debug_name("Editor BreadCrumbs")
 }
 
 fn editor_content(
@@ -1879,11 +1880,8 @@ fn editor_content(
             rect
         }
     })
-    .style(|s| {
-        s.absolute()
-            .size_pct(100.0, 100.0)
-            .set(PropagatePointerWheel, false)
-    })
+    .style(|s| s.size_full().set(PropagatePointerWheel, false))
+    .debug_name("Editor Content")
 }
 
 fn search_editor_view(

--- a/lapce-app/src/panel/view.rs
+++ b/lapce-app/src/panel/view.rs
@@ -433,6 +433,7 @@ pub fn panel_container_view(
             .border_color(config.color(LapceColor::LAPCE_BORDER))
             .color(config.color(LapceColor::PANEL_FOREGROUND))
     })
+    .debug_name(format!("{:?} Pannel Container View", position))
 }
 
 fn panel_view(

--- a/lapce-app/src/status.rs
+++ b/lapce-app/src/status.rs
@@ -390,6 +390,7 @@ pub fn status(
             .height(config.ui.status_height() as f32)
             .align_items(Some(AlignItems::Center))
     })
+    .debug_name("Status/Bottom Bar")
 }
 
 fn progress_view(

--- a/lapce-app/src/title.rs
+++ b/lapce-app/src/title.rs
@@ -153,6 +153,7 @@ fn left(
             .flex_grow(1.0)
             .items_center()
     })
+    .debug_name("Left Side of Top Bar")
 }
 
 fn middle(
@@ -298,6 +299,7 @@ fn middle(
             .align_items(Some(AlignItems::Center))
             .justify_content(Some(JustifyContent::Center))
     })
+    .debug_name("Middle of Top Bar")
 }
 
 fn right(
@@ -409,6 +411,7 @@ fn right(
             .flex_grow(1.0)
             .justify_content(Some(JustifyContent::FlexEnd))
     })
+    .debug_name("Right of top bar")
 }
 
 pub fn title(window_tab_data: Rc<WindowTabData>) -> impl View {
@@ -463,6 +466,7 @@ pub fn title(window_tab_data: Rc<WindowTabData>) -> impl View {
             .border_bottom(1.0)
             .border_color(config.color(LapceColor::LAPCE_BORDER))
     })
+    .debug_name("Title / Top Bar")
 }
 
 pub fn window_controls_view(


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

I also trimmed a few extra containers that were there from when floem couldn't stack styles. I checked that both sets of styles weren't conflicting and removed the extra container. There are probably quite a few more of these that can be removed.

<img width="1415" alt="Screenshot 2024-06-08 at 3 00 55 AM" src="https://github.com/lapce/lapce/assets/13090441/5c24a6c3-aa31-4397-a8a3-76b3f9baa165">
