### PR TITLE
Remove containers

### DIFF
--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -696,6 +696,8 @@ fn editor_tab_header(
 
             let tab_style = move |s: Style| {
                 s.items_center()
+                    .justify_center()
+                    .height_full()
                     .border_left(if i.get() == 0 { 1.0 } else { 0.0 })
                     .border_right(1.0)
                     .border_color(config.get().color(LapceColor::LAPCE_BORDER))
@@ -818,54 +820,59 @@ fn editor_tab_header(
                         .border_color(config.color(LapceColor::LAPCE_BORDER))
                 })
                 .style(|s| s.align_items(Some(AlignItems::Center)).height_full()),
-            container(empty().style(move |s| {
-                s.size_full()
-                    .border_bottom(if editor_tab_active.get() == i.get() {
-                        2.0
-                    } else {
-                        0.0
-                    })
-                    .border_color(config.get().color(if is_focused() {
-                        LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE
-                    } else {
-                        LapceColor::LAPCE_TAB_INACTIVE_UNDERLINE
-                    }))
-            }))
-            .style(|s| s.absolute().padding_horiz(3.0).size_full()),
-            empty().style(move |s| {
-                let i = i.get();
-                let drag_over_left = drag_over_left.get();
-                s.absolute()
-                    .margin_left(if i == 0 { 0.0 } else { -2.0 })
-                    .height_full()
-                    .width(
-                        header_content_size.get().width as f32
-                            + if i == 0 { 1.0 } else { 3.0 },
-                    )
-                    .apply_if(drag_over_left.is_none(), |s| s.hide())
-                    .apply_if(drag_over_left.is_some(), |s| {
-                        if let Some(drag_over_left) = drag_over_left {
-                            if drag_over_left {
-                                s.border_left(3.0)
-                            } else {
-                                s.border_right(3.0)
-                            }
+            empty()
+                .style(move |s| {
+                    s.size_full()
+                        .border_bottom(if editor_tab_active.get() == i.get() {
+                            2.0
                         } else {
-                            s
-                        }
-                    })
-                    .border_color(
-                        config
-                            .get()
-                            .color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE)
-                            .with_alpha_factor(0.5),
-                    )
-            }),
+                            0.0
+                        })
+                        .border_color(config.get().color(if is_focused() {
+                            LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE
+                        } else {
+                            LapceColor::LAPCE_TAB_INACTIVE_UNDERLINE
+                        }))
+                })
+                .style(|s| s.absolute().padding_horiz(3.0).size_full())
+                .debug_name("Drop Indicator"),
+            empty()
+                .style(move |s| {
+                    let i = i.get();
+                    let drag_over_left = drag_over_left.get();
+                    s.absolute()
+                        .margin_left(if i == 0 { 0.0 } else { -2.0 })
+                        .height_full()
+                        .width(
+                            header_content_size.get().width as f32
+                                + if i == 0 { 1.0 } else { 3.0 },
+                        )
+                        .apply_if(drag_over_left.is_none(), |s| s.hide())
+                        .apply_if(drag_over_left.is_some(), |s| {
+                            if let Some(drag_over_left) = drag_over_left {
+                                if drag_over_left {
+                                    s.border_left(3.0)
+                                } else {
+                                    s.border_right(3.0)
+                                }
+                            } else {
+                                s
+                            }
+                        })
+                        .border_color(
+                            config
+                                .get()
+                                .color(LapceColor::LAPCE_TAB_ACTIVE_UNDERLINE)
+                                .with_alpha_factor(0.5),
+                        )
+                })
+                .debug_name("Active Tab Indicator"),
         ))
         .on_resize(move |rect| {
             layout_rect.set(rect);
         })
         .style(|s| s.height_full())
+        .debug_name("Tab and Active Indicator")
     };
 
     let content_size = create_rw_signal(Size::ZERO);
@@ -924,8 +931,9 @@ fn editor_tab_header(
                 .debug_name("Next/Previoius Tab Buttons")
                 .style(move |s| s.items_center()),
             )
-        }),
-        container({
+        })
+        .style(|s| s.flex_shrink(0.)),
+        container(
             scroll({
                 dyn_stack(items, key, view_fn)
                     .on_resize(move |rect| {
@@ -949,13 +957,12 @@ fn editor_tab_header(
             .style(|s| {
                 s.set(HideBar, true)
                     .set(VerticalScrollAsHorizontal, true)
-                    .position(Position::Absolute)
-                    .height_full()
-                    .max_width_full()
-            })
-        })
-        .debug_name("Tab scroll")
-        .style(|s| s.height_full().flex_grow(1.0).flex_basis(0.0)),
+                    .absolute()
+                    .size_full()
+            }),
+        )
+        .style(|s| s.height_full().flex_grow(1.0).flex_basis(0.).min_width(10.))
+        .debug_name("Tab scroll"),
         stack({
             let size = create_rw_signal(Size::ZERO);
             (
@@ -1023,11 +1030,22 @@ fn editor_tab_header(
                 .style(|s| s.items_center().height_full()),
             )
         })
-        .style(|s| s.height_full()),
+        .debug_name("Split/Close Panel Buttons")
+        .style(move |s| {
+            let content_size = content_size.get();
+            let scroll_offset = scroll_offset.get();
+            s.height_full()
+                .flex_shrink(0.)
+                .margin_left(PxPctAuto::Auto)
+                .apply_if(scroll_offset.x1 < content_size.width, |s| {
+                    s.margin_left(0.)
+                })
+        }),
     ))
     .style(move |s| {
         let config = config.get();
         s.items_center()
+            .max_width_full()
             .border_bottom(1.0)
             .border_color(config.color(LapceColor::LAPCE_BORDER))
             .background(config.color(LapceColor::PANEL_BACKGROUND))
@@ -1977,7 +1995,8 @@ fn workbench(window_tab_data: Rc<WindowTabData>) -> impl View {
     let workbench_size = window_tab_data.common.workbench_size;
     let main_split_width = window_tab_data.main_split.width;
     stack((
-        panel_container_view(window_tab_data.clone(), PanelContainerPosition::Left),
+        panel_container_view(window_tab_data.clone(), PanelContainerPosition::Left)
+            .style(|s| s.border_right(0.)),
         {
             let window_tab_data = window_tab_data.clone();
             stack((

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -695,18 +695,6 @@ impl EditorView {
             return;
         }
 
-        cx.fill(
-            &Rect::ZERO
-                .with_size(Size::new(1.0, viewport.height()))
-                .with_origin(Point::new(
-                    viewport.x0 + viewport.width() - BAR_WIDTH,
-                    viewport.y0,
-                ))
-                .inflate(0.0, 10.0),
-            config.color(LapceColor::LAPCE_SCROLL_BAR),
-            0.0,
-        );
-
         if !self.editor.kind.get_untracked().is_normal() {
             return;
         }
@@ -1114,8 +1102,8 @@ impl View for EditorView {
         let screen_lines = ed.screen_lines.get_untracked();
         FloemEditorView::paint_text(cx, ed, viewport, is_active, &screen_lines);
         let screen_lines = ed.screen_lines.get_untracked();
-        self.paint_sticky_headers(cx, viewport, &screen_lines);
         self.paint_scroll_bar(cx, viewport, is_local, config);
+        self.paint_sticky_headers(cx, viewport, &screen_lines);
     }
 }
 
@@ -1260,39 +1248,36 @@ pub fn editor_container_view(
 
     stack((
         editor_breadcrumbs(workspace, editor.get_untracked(), config),
-        container(
-            stack((
-                editor_gutter(window_tab_data.clone(), editor, is_active),
-                editor_content(editor, debug_breakline, is_active),
-                empty().style(move |s| {
-                    let config = config.get();
-                    s.absolute()
-                        .width_pct(100.0)
-                        .height(sticky_header_height.get() as f32)
-                        // .box_shadow_blur(5.0)
-                        // .border_bottom(1.0)
-                        // .border_color(
-                        //     config.get_color(LapceColor::LAPCE_BORDER),
-                        // )
-                        .apply_if(
-                            !config.editor.sticky_header
-                                || sticky_header_height.get() == 0.0
-                                || !editor_view.get().is_normal(),
-                            |s| s.hide(),
-                        )
-                }),
-                find_view(
-                    editor,
-                    find_editor,
-                    find_focus,
-                    replace_editor,
-                    replace_active,
-                    replace_focus,
-                    is_active,
-                ),
-            ))
-            .style(|s| s.absolute().size_full()),
-        )
+        stack((
+            editor_gutter(window_tab_data.clone(), editor, is_active),
+            editor_content(editor, debug_breakline, is_active),
+            empty().style(move |s| {
+                let config = config.get();
+                s.absolute()
+                    .width_pct(100.0)
+                    .height(sticky_header_height.get() as f32)
+                    // .box_shadow_blur(5.0)
+                    // .border_bottom(1.0)
+                    // .border_color(
+                    //     config.get_color(LapceColor::LAPCE_BORDER),
+                    // )
+                    .apply_if(
+                        !config.editor.sticky_header
+                            || sticky_header_height.get() == 0.0
+                            || !editor_view.get().is_normal(),
+                        |s| s.hide(),
+                    )
+            }),
+            find_view(
+                editor,
+                find_editor,
+                find_focus,
+                replace_editor,
+                replace_active,
+                replace_focus,
+                is_active,
+            ),
+        ))
         .style(|s| s.width_full().flex_basis(0).flex_grow(1.0)),
     ))
     .on_cleanup(move || {
@@ -1736,6 +1721,7 @@ fn editor_breadcrumbs(
             .width_pct(100.0)
             .height(line_height as f32)
             .apply_if(doc_path.get().is_none(), |s| s.hide())
+            .apply_if(!config.editor.show_bread_crumbs, |s| s.hide())
     })
     .debug_name("Editor BreadCrumbs")
 }

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -79,22 +79,20 @@ pub fn file_explorer_panel(
         .add_height_style(
             "Open Editors",
             150.0,
-            container(open_editors_view(window_tab_data.clone()))
-                .style(|s| s.size_full()),
+            open_editors_view(window_tab_data.clone()).style(|s| s.size_full()),
             window_tab_data.panel.section_open(PanelSection::OpenEditor),
-            move |s| s.apply_if(!config.get().ui.open_editors_visible, Style::hide),
+            move |s| s.apply_if(!config.get().ui.open_editors_visible, |s| s.hide()),
         )
         .add(
             "File Explorer",
-            container(
-                new_file_node_view(data, source_control).style(|s| s.absolute()),
-            )
-            .style(|s| s.size_full().line_height(1.6)),
+            new_file_node_view(data, source_control)
+                .style(|s| s.size_full().line_height(1.6)),
             window_tab_data
                 .panel
                 .section_open(PanelSection::FileExplorer),
         )
         .build()
+        .debug_name("File Explorer Panel")
 }
 
 /// Initialize the file explorer's naming (renaming, creating, etc.) editor with the given path.
@@ -419,7 +417,7 @@ fn new_file_node_view(
         )
         .style(|s| s.flex_col().align_items(AlignItems::Stretch).width_full()),
     )
-    .style(|s| s.size_full())
+    .style(|s| s.min_height(0).flex_grow(1.).flex_basis(0.).size_full())
     .on_secondary_click_stop(move |_| {
         if let Naming::None = naming.get_untracked() {
             if let Some(path) = &secondary_click_data.common.workspace.path {
@@ -550,5 +548,12 @@ fn open_editors_view(window_tab_data: Rc<WindowTabData>) -> impl View {
         )
         .style(|s| s.flex_col().width_pct(100.0)),
     )
-    .style(|s| s.absolute().size_pct(100.0, 100.0).line_height(1.6))
+    .style(|s| {
+        s.min_height(0)
+            .flex_grow(1.)
+            .flex_basis(0.)
+            .size_full()
+            .line_height(1.6)
+    })
+    .debug_name("Open Editors")
 }

--- a/lapce-app/src/panel/debug_view.rs
+++ b/lapce-app/src/panel/debug_view.rs
@@ -62,6 +62,7 @@ pub fn debug_panel(
             window_tab_data.panel.section_open(PanelSection::Breakpoint),
         )
         .build()
+        .debug_name("Debug Panel")
 }
 
 fn debug_process_icons(

--- a/lapce-app/src/panel/global_search_view.rs
+++ b/lapce-app/src/panel/global_search_view.rs
@@ -107,6 +107,7 @@ pub fn global_search_panel(
         search_result(workspace, global_search, internal_command, config),
     ))
     .style(|s| s.absolute().size_pct(100.0, 100.0).flex_col())
+    .debug_name("Global Search Panel")
 }
 
 fn search_result(

--- a/lapce-app/src/panel/plugin_view.rs
+++ b/lapce-app/src/panel/plugin_view.rs
@@ -81,6 +81,7 @@ pub fn plugin_panel(
             window_tab_data.panel.section_open(PanelSection::Available),
         )
         .build()
+        .debug_name("Plugin Panel")
 }
 
 fn installed_view(plugin: PluginData) -> impl View {

--- a/lapce-app/src/panel/problem_view.rs
+++ b/lapce-app/src/panel/problem_view.rs
@@ -44,6 +44,7 @@ pub fn problem_panel(
             window_tab_data.panel.section_open(PanelSection::Warn),
         )
         .build()
+        .debug_name("Problem Panel")
 }
 
 fn problem_section(

--- a/lapce-app/src/panel/source_control_view.rs
+++ b/lapce-app/src/panel/source_control_view.rs
@@ -191,6 +191,7 @@ pub fn source_control_panel(
         }
     })
     .style(|s| s.flex_col().size_pct(100.0, 100.0))
+    .debug_name("Source Control Panel")
 }
 
 fn file_diffs_view(source_control: SourceControlData) -> impl View {

--- a/lapce-app/src/panel/terminal_view.rs
+++ b/lapce-app/src/panel/terminal_view.rs
@@ -37,6 +37,7 @@ pub fn terminal_panel(window_tab_data: Rc<WindowTabData>) -> impl View {
         }
     })
     .style(|s| s.absolute().size_pct(100.0, 100.0).flex_col())
+    .debug_name("Terminal Panel")
 }
 
 fn terminal_tab_header(window_tab_data: Rc<WindowTabData>) -> impl View {

--- a/lapce-app/src/panel/view.rs
+++ b/lapce-app/src/panel/view.rs
@@ -458,26 +458,26 @@ fn panel_view(
         move |kind| {
             let view = match kind {
                 PanelKind::Terminal => {
-                    container(terminal_panel(window_tab_data.clone()))
+                    terminal_panel(window_tab_data.clone()).into_any()
                 }
                 PanelKind::FileExplorer => {
-                    container(file_explorer_panel(window_tab_data.clone(), position))
+                    file_explorer_panel(window_tab_data.clone(), position).into_any()
                 }
-                PanelKind::SourceControl => container(source_control_panel(
-                    window_tab_data.clone(),
-                    position,
-                )),
+                PanelKind::SourceControl => {
+                    source_control_panel(window_tab_data.clone(), position)
+                        .into_any()
+                }
                 PanelKind::Plugin => {
-                    container(plugin_panel(window_tab_data.clone(), position))
+                    plugin_panel(window_tab_data.clone(), position).into_any()
                 }
                 PanelKind::Search => {
-                    container(global_search_panel(window_tab_data.clone(), position))
+                    global_search_panel(window_tab_data.clone(), position).into_any()
                 }
                 PanelKind::Problem => {
-                    container(problem_panel(window_tab_data.clone(), position))
+                    problem_panel(window_tab_data.clone(), position).into_any()
                 }
                 PanelKind::Debug => {
-                    container(debug_panel(window_tab_data.clone(), position))
+                    debug_panel(window_tab_data.clone(), position).into_any()
                 }
             };
             view.style(|s| s.size_pct(100.0, 100.0))

--- a/lapce-app/src/plugin.rs
+++ b/lapce-app/src/plugin.rs
@@ -990,4 +990,5 @@ pub fn plugin_info_view(plugin: PluginData, volt: VoltID) -> impl View {
         }
     })
     .style(|s| s.absolute().size_full())
+    .debug_name("Plugin Info")
 }

--- a/lapce-app/src/settings.rs
+++ b/lapce-app/src/settings.rs
@@ -14,10 +14,10 @@ use floem::{
     views::{
         container, dyn_stack, empty, label,
         scroll::{scroll, PropagatePointerWheel},
-        stack, svg, text, virtual_stack, Container, Decorators, VirtualDirection,
+        stack, svg, text, virtual_stack, Decorators, VirtualDirection,
         VirtualItemSize, VirtualVector,
     },
-    View,
+    IntoView, View,
 };
 use indexmap::IndexMap;
 use inflector::Inflector;
@@ -518,6 +518,7 @@ pub fn settings_view(
         .style(|s| s.flex_col().size_pct(100.0, 100.0)),
     ))
     .style(|s| s.absolute().size_pct(100.0, 100.0))
+    .debug_name("Settings")
 }
 
 fn settings_item_view(
@@ -614,12 +615,14 @@ fn settings_item_view(
                     rev
                 });
 
-                container(text_input_view.keyboard_navigatable().style(move |s| {
-                    s.width(300.0)
-                        .border(1.0)
-                        .border_radius(6.0)
-                        .border_color(config.get().color(LapceColor::LAPCE_BORDER))
-                }))
+                text_input_view
+                    .keyboard_navigatable()
+                    .style(move |s| {
+                        s.width(300.0).border(1.0).border_radius(6.0).border_color(
+                            config.get().color(LapceColor::LAPCE_BORDER),
+                        )
+                    })
+                    .into_any()
             } else if let SettingsValue::Dropdown(dropdown) = &item.value {
                 let expanded = create_rw_signal(false);
                 let current_value = dropdown
@@ -638,18 +641,21 @@ fn settings_item_view(
                     settings_data.common.window_common.size,
                     config,
                 )
+                .into_any()
             } else if item.header {
-                container(label(move || item.kind.clone()).style(move |s| {
-                    let config = config.get();
-                    s.line_height(2.0)
-                        .font_bold()
-                        .width_pct(100.0)
-                        .padding_horiz(10.0)
-                        .font_size(config.ui.font_size() as f32 + 2.0)
-                        .background(config.color(LapceColor::PANEL_BACKGROUND))
-                }))
+                label(move || item.kind.clone())
+                    .style(move |s| {
+                        let config = config.get();
+                        s.line_height(2.0)
+                            .font_bold()
+                            .width_pct(100.0)
+                            .padding_horiz(10.0)
+                            .font_size(config.ui.font_size() as f32 + 2.0)
+                            .background(config.color(LapceColor::PANEL_BACKGROUND))
+                    })
+                    .into_any()
             } else {
-                container(empty())
+                empty().into_any()
             }
         }
     };
@@ -1081,6 +1087,7 @@ pub fn theme_color_settings_view(
         .style(|s| s.flex_col()),
     )
     .style(|s| s.absolute().size_full())
+    .debug_name("Theme Color Settings")
 }
 
 fn dropdown_view(
@@ -1090,7 +1097,7 @@ fn dropdown_view(
     expanded: RwSignal<bool>,
     window_size: RwSignal<Size>,
     config: ReadSignal<Arc<LapceConfig>>,
-) -> Container {
+) -> impl View {
     let window_origin = create_rw_signal(Point::ZERO);
     let size = create_rw_signal(Size::ZERO);
     let overlay_id = create_rw_signal(None);
@@ -1126,51 +1133,49 @@ fn dropdown_view(
         });
     }
 
-    container(
-        stack((
-            label(move || current_value.get()).style(move |s| {
-                s.text_ellipsis().width_pct(100.0).padding_horiz(10.0)
+    stack((
+        label(move || current_value.get())
+            .style(move |s| s.text_ellipsis().width_pct(100.0).padding_horiz(10.0)),
+        container(
+            svg(move || {
+                if expanded.get() {
+                    config.get().ui_svg(LapceIcons::CLOSE)
+                } else {
+                    config.get().ui_svg(LapceIcons::DROPDOWN_ARROW)
+                }
+            })
+            .style(move |s| {
+                let config = config.get();
+                let size = config.ui.icon_size() as f32;
+                s.size(size, size)
+                    .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
             }),
-            container(
-                svg(move || {
-                    if expanded.get() {
-                        config.get().ui_svg(LapceIcons::CLOSE)
-                    } else {
-                        config.get().ui_svg(LapceIcons::DROPDOWN_ARROW)
-                    }
-                })
-                .style(move |s| {
-                    let config = config.get();
-                    let size = config.ui.icon_size() as f32;
-                    s.size(size, size)
-                        .color(config.color(LapceColor::LAPCE_ICON_ACTIVE))
-                }),
-            )
-            .style(|s| s.padding_right(4.0)),
-        ))
-        .on_click_stop(move |_| {
-            expanded.update(|expanded| {
-                *expanded = !*expanded;
-            });
-        })
-        .on_move(move |point| {
-            window_origin.set(point);
-            if expanded.get_untracked() {
-                expanded.set(false);
-            }
-        })
-        .on_resize(move |rect| {
-            size.set(rect.size());
-        })
-        .style(move |s| {
-            s.items_center()
-                .width_pct(100.0)
-                .cursor(CursorStyle::Pointer)
-                .border_color(config.get().color(LapceColor::LAPCE_BORDER))
-                .border(1.0)
-                .border_radius(6.0)
-        }),
-    )
+        )
+        .style(|s| s.padding_right(4.0)),
+    ))
+    .on_click_stop(move |_| {
+        expanded.update(|expanded| {
+            *expanded = !*expanded;
+        });
+    })
+    .on_move(move |point| {
+        window_origin.set(point);
+        if expanded.get_untracked() {
+            expanded.set(false);
+        }
+    })
+    .on_resize(move |rect| {
+        size.set(rect.size());
+    })
+    .style(move |s| {
+        s.items_center()
+            .cursor(CursorStyle::Pointer)
+            .border_color(config.get().color(LapceColor::LAPCE_BORDER))
+            .border(1.0)
+            .border_radius(6.0)
+            .width(250.0)
+            .line_height(1.8)
+    })
     .keyboard_navigatable()
     .on_event_stop(EventListener::FocusGained, move |_| {
         dropdown_input_focus.set(true);
@@ -1181,7 +1186,6 @@ fn dropdown_view(
             expanded.set(false);
         }
     })
-    .style(move |s| s.width(250.0).line_height(1.8))
     .on_cleanup(move || {
         if let Some(id) = overlay_id.get_untracked() {
             remove_overlay(id);


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This:
- Removes more of the extra containers
- Adds more debug names
- Removes drawing the scroll bar background in the editor view so that the editor view is consistent with the other tab views. 

I've also made an opinionated change to the design of the border on editor tabs. They now fill the full height of the tab bar. This looks more clear and less busy to me, but that's just my opinion and if people actually prefer the old way I can make it configurable. 
![image](https://github.com/lapce/lapce/assets/13090441/2be53e9e-a452-4ca2-b877-c4d1effbe6f9)


Also fixes #2883 which had been previously implemented but was not responding the config changes.  