### PR TITLE
Improve editor tabs

### DIFF
--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -648,15 +648,21 @@ fn editor_tab_header(
 
             let tab_icon = container({
                 svg(move || info.with(|info| info.icon.clone())).style(move |s| {
-                    let size = config.get().ui.icon_size() as f32;
+                    let config = config.get();
+                    let size = config.ui.icon_size() as f32;
                     s.size(size, size)
                         .apply_opt(info.with(|info| info.color), |s, c| s.color(c))
+                        .apply_if(
+                            !info.with(|info| info.is_pristine)
+                                && config.ui.tab_close_button == TabCloseButton::Off,
+                            |s| s.color(config.color(LapceColor::LAPCE_WARN)),
+                        )
                 })
             })
             .style(|s| s.padding(4.));
 
-            let tab_content = label(move || info.with(|info| info.path.clone()))
-                .style(move |s| {
+            let tab_content = tooltip(
+                label(move || info.with(|info| info.name.clone())).style(move |s| {
                     s.apply_if(
                         !info
                             .with(|info| info.confirmed)
@@ -665,7 +671,19 @@ fn editor_tab_header(
                         |s| s.font_style(FontStyle::Italic),
                     )
                     .selectable(false)
-                });
+                }),
+                move || {
+                    tooltip_tip(
+                        config,
+                        text(info.with(|info| {
+                            info.path
+                                .clone()
+                                .map(|path| path.display().to_string())
+                                .unwrap_or("local".to_string())
+                        })),
+                    )
+                },
+            );
 
             let tab_close_button = clickable_icon(
                 move || {
@@ -900,7 +918,15 @@ fn editor_tab_header(
         .on_resize(move |rect| {
             layout_rect.set(rect);
         })
-        .style(|s| s.height_full().flex_col().items_center().justify_center())
+        .style(move |s| {
+            let config = config.get();
+            s.height_full()
+                .flex_col()
+                .items_center()
+                .justify_center()
+                .cursor(CursorStyle::Pointer)
+                .hover(|s| s.background(config.color(LapceColor::HOVER_BACKGROUND)))
+        })
         .debug_name("Tab and Active Indicator")
     };
 
@@ -1078,6 +1104,7 @@ fn editor_tab_header(
             .border_bottom(1.0)
             .border_color(config.color(LapceColor::LAPCE_BORDER))
             .background(config.color(LapceColor::PANEL_BACKGROUND))
+            .height(config.ui.header_height() as i32)
     })
     .debug_name("Editor Tab Header")
 }

--- a/lapce-app/src/editor_tab.rs
+++ b/lapce-app/src/editor_tab.rs
@@ -144,7 +144,8 @@ pub enum EditorTabChild {
 pub struct EditorTabChildViewInfo {
     pub icon: String,
     pub color: Option<Color>,
-    pub path: String,
+    pub name: String,
+    pub path: Option<PathBuf>,
     pub confirmed: Option<RwSignal<bool>>,
     pub is_pristine: bool,
 }
@@ -225,8 +226,8 @@ impl EditorTabChild {
                 } else {
                     None
                 };
-                let (icon, color, path, confirmed, is_pristine) = match path {
-                    Some((path, confirmed, is_pritine)) => {
+                let (icon, color, name, confirmed, is_pristine) = match path {
+                    Some((ref path, confirmed, is_pritine)) => {
                         let (svg, color) = config.file_svg(&path);
                         (
                             svg,
@@ -250,7 +251,8 @@ impl EditorTabChild {
                 EditorTabChildViewInfo {
                     icon,
                     color,
-                    path,
+                    name,
+                    path: path.map(|opt| opt.0),
                     confirmed: Some(confirmed),
                     is_pristine,
                 }
@@ -328,7 +330,8 @@ impl EditorTabChild {
                 EditorTabChildViewInfo {
                     icon,
                     color,
-                    path,
+                    name: path,
+                    path: None,
                     confirmed,
                     is_pristine,
                 }
@@ -338,7 +341,8 @@ impl EditorTabChild {
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::SETTINGS),
                     color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
-                    path: "Settings".to_string(),
+                    name: "Settings".to_string(),
+                    path: None,
                     confirmed: None,
                     is_pristine: true,
                 }
@@ -348,7 +352,8 @@ impl EditorTabChild {
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::SYMBOL_COLOR),
                     color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
-                    path: "Theme Colors".to_string(),
+                    name: "Theme Colors".to_string(),
+                    path: None,
                     confirmed: None,
                     is_pristine: true,
                 }
@@ -358,7 +363,8 @@ impl EditorTabChild {
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::KEYBOARD),
                     color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
-                    path: "Keyboard Shortcuts".to_string(),
+                    name: "Keyboard Shortcuts".to_string(),
+                    path: None,
                     confirmed: None,
                     is_pristine: true,
                 }
@@ -381,7 +387,8 @@ impl EditorTabChild {
                 EditorTabChildViewInfo {
                     icon: config.ui_svg(LapceIcons::EXTENSIONS),
                     color: Some(config.color(LapceColor::LAPCE_ICON_ACTIVE)),
-                    path: display_name,
+                    name: display_name,
+                    path: None,
                     confirmed: None,
                     is_pristine: true,
                 }

--- a/lapce-app/src/file_explorer/view.rs
+++ b/lapce-app/src/file_explorer/view.rs
@@ -485,7 +485,7 @@ fn open_editors_view(window_tab_data: Rc<WindowTabData>) -> impl View {
                 },
             ))
             .style(|s| s.padding_horiz(6.0)),
-            label(move || info.with(|info| info.path.clone())).style(move |s| {
+            label(move || info.with(|info| info.name.clone())).style(move |s| {
                 s.apply_if(
                     !info
                         .with(|info| info.confirmed)


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users

- If the editor tab close button is set to off, the file icon will now show the warn color to represent the pristine state
- Editor tab content has a tooltip that will show the full file path
- tabs now have cursor Pointer and apply HOVER_BACKGROUND on hover

Also fixed:
- Editor tab height was not connected to the config