### PR TITLE
fix environment loading, add windows support, add show env command

### DIFF
--- a/lapce-app/src/app/logging.rs
+++ b/lapce-app/src/app/logging.rs
@@ -27,7 +27,8 @@ pub(super) fn logging() -> (Handle<Targets>, Option<WorkerGuard>) {
     let log_file_filter_targets = filter::Targets::new()
         .with_target("lapce_app", LevelFilter::DEBUG)
         .with_target("lapce_proxy", LevelFilter::DEBUG)
-        .with_target("lapce_core", LevelFilter::DEBUG);
+        .with_target("lapce_core", LevelFilter::DEBUG)
+        .with_default(LevelFilter::from_level(TraceLevel::INFO));
     let (log_file_filter, reload_handle) =
         reload::Subscriber::new(log_file_filter_targets);
 

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -191,6 +191,10 @@ pub enum LapceWorkbenchCommand {
     #[strum(message = "Open Internal UI Inspector")]
     OpenUIInspector,
 
+    #[strum(serialize = "show_env")]
+    #[strum(message = "Show Environment")]
+    ShowEnvironment,
+
     #[strum(serialize = "change_color_theme")]
     #[strum(message = "Change Color Theme")]
     ChangeColorTheme,

--- a/lapce-app/src/main_split.rs
+++ b/lapce-app/src/main_split.rs
@@ -2832,6 +2832,21 @@ impl MainSplitData {
             }
         }
     }
+
+    pub fn show_env(&self) {
+        let child = self.new_file();
+        if let EditorTabChild::Editor(id) = child {
+            if let Some(editor) = self.editors.editor_untracked(id) {
+                let doc = editor.doc();
+                doc.reload(
+                    Rope::from(
+                        std::env::vars().map(|(k, v)| format!("{k}={v}")).join("\n"),
+                    ),
+                    true,
+                );
+            }
+        }
+    }
 }
 
 fn workspace_edits(edit: &WorkspaceEdit) -> Option<HashMap<Url, Vec<TextEdit>>> {

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -1212,6 +1212,9 @@ impl WindowTabData {
             OpenUIInspector => {
                 self.common.view_id.get_untracked().inspect();
             }
+            ShowEnvironment => {
+                self.main_split.show_env();
+            }
 
             // ==== Source Control ====
             SourceControlInit => {


### PR DESCRIPTION
- Fixes loading env on Linux where desktop environment sets PWD envvar
- Add Windows support for load env to support direnv
- Add command to debug loaded environment
- Add default log level to match non lapce crates that can show useful info

Fixes #2923 