### PR TITLE
Terminal ctrl + click to jump: Support path contains '-' and toml file

### DIFF
--- a/lapce-app/src/terminal/view.rs
+++ b/lapce-app/src/terminal/view.rs
@@ -124,7 +124,7 @@ pub fn terminal_view(
     });
 
     // for rust
-    let reg = regex::Regex::new("[\\w\\\\/]+\\.rs:\\d+(:\\d+)?").unwrap();
+    let reg = regex::Regex::new("[\\w\\\\/-]+\\.(rs)?(toml)?:\\d+(:\\d+)?").unwrap();
 
     TerminalView {
         id,


### PR DESCRIPTION
- [ ] ctrl + click a similar text (_Cargo.toml:1:1_, examples/one-two.rs:2:5) in the terminal to jump to the corresponding file

The effect is as follows:


https://github.com/user-attachments/assets/285aeb43-5462-43d0-957f-7812ccccb740


