### PR TITLE
Avoid overflow.

### DIFF
--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -3292,7 +3292,7 @@ pub(crate) fn compute_screen_lines(
             let is_right = diff_info.is_right;
 
             let line_y = |info: VLineInfo<()>, vline_y: usize| -> usize {
-                vline_y - info.rvline.line_index * line_height
+                vline_y.saturating_sub(info.rvline.line_index * line_height)
             };
 
             while let Some(change) = changes.next() {


### PR DESCRIPTION
if not, there may be overflow when you click.
![overflow](https://github.com/user-attachments/assets/c528a86d-6ab5-4278-b45d-09c323cf9050)

