### PR TITLE
1. When receiving a DapStopped event, display the Debug panel.

### DIFF
--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -2105,6 +2105,7 @@ impl WindowTabData {
                 stack_frames,
                 variables,
             } => {
+                self.show_panel(PanelKind::Debug);
                 self.terminal
                     .dap_stopped(dap_id, stopped, stack_frames, variables);
             }


### PR DESCRIPTION
- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users