### PR TITLE
1. Add the field 'config_source' to 'RunDebugConfig' to indicate wher…

### DIFF
--- a/lapce-app/src/code_lens.rs
+++ b/lapce-app/src/code_lens.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use lapce_rpc::dap_types::RunDebugConfig;
+use lapce_rpc::dap_types::{ConfigSource, RunDebugConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -90,6 +90,7 @@ impl CodeLensData {
                 debug_command: None,
                 dap_id: Default::default(),
                 tracing_output: mode == RunDebugMode::Debug,
+                config_source: ConfigSource::CodeLens,
             })
         } else {
             tracing::error!("no args");

--- a/lapce-app/src/terminal/panel.rs
+++ b/lapce-app/src/terminal/panel.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     id::TerminalTabId,
     keypress::{EventRef, KeyPressData, KeyPressFocus, KeyPressHandle},
+    main_split::MainSplitData,
     panel::kind::PanelKind,
     window_tab::{CommonData, Focus},
     workspace::LapceWorkspace,
@@ -39,6 +40,7 @@ pub struct TerminalPanelData {
     pub debug: RunDebugData,
     pub breakline: Memo<Option<(usize, PathBuf)>>,
     pub common: Rc<CommonData>,
+    pub main_split: MainSplitData,
 }
 
 impl TerminalPanelData {
@@ -46,6 +48,7 @@ impl TerminalPanelData {
         workspace: Arc<LapceWorkspace>,
         profile: Option<TerminalProfile>,
         common: Rc<CommonData>,
+        main_split: MainSplitData,
     ) -> Self {
         let terminal_tab =
             TerminalTabData::new(workspace.clone(), profile, common.clone());
@@ -108,6 +111,7 @@ impl TerminalPanelData {
             debug,
             breakline,
             common,
+            main_split,
         }
     }
 

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -32,7 +32,7 @@ use lapce_core::{
 };
 use lapce_rpc::{
     core::CoreNotification,
-    dap_types::RunDebugConfig,
+    dap_types::{ConfigSource, RunDebugConfig},
     file::{Naming, PathObject},
     plugin::PluginId,
     proxy::{ProxyResponse, ProxyRpcHandler, ProxyStatus},
@@ -482,6 +482,7 @@ impl WindowTabData {
             workspace.clone(),
             common.config.get_untracked().terminal.get_default_profile(),
             common.clone(),
+            main_split.clone(),
         );
         if let Some(workspace_info) = workspace_info.as_ref() {
             terminal.debug.breakpoints.set(
@@ -1492,6 +1493,7 @@ impl WindowTabData {
                             debug_command: None,
                             dap_id: Default::default(),
                             tracing_output: false,
+                            config_source: ConfigSource::RunInTerminal,
                         };
                         self.common
                             .internal_command

--- a/lapce-rpc/src/dap_types.rs
+++ b/lapce-rpc/src/dap_types.rs
@@ -59,6 +59,21 @@ pub struct RunDebugConfig {
     pub dap_id: DapId,
     #[serde(default)]
     pub tracing_output: bool,
+    #[serde(default)]
+    pub config_source: ConfigSource,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+pub enum ConfigSource {
+    #[default]
+    Palette,
+    RunInTerminal,
+    CodeLens,
+}
+impl ConfigSource {
+    pub fn from_palette(&self) -> bool {
+        *self == Self::Palette
+    }
 }
 
 pub trait Request {


### PR DESCRIPTION
1. This is part of the 'reload configuration' feature.
2. Add the field 'config_source' to 'RunDebugConfig' to indicate where the configuration is from.
3. Add the field  'main_split' to'TerminalPanelData'