### PR TITLE
1. The configuration for the log filter should first be retrieved fro…

### DIFF
--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -101,13 +101,13 @@ pub struct EditorDiagnostic {
     pub diagnostic: Diagnostic,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct DocHistory {
     pub path: PathBuf,
     pub version: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub enum DocContent {
     /// A file at some location. This can be a remote path.
     File { path: PathBuf, read_only: bool },

--- a/lapce-app/src/keypress.rs
+++ b/lapce-app/src/keypress.rs
@@ -335,6 +335,7 @@ impl KeyPressData {
         let mods = keypress.mods;
         match &keymatch {
             KeymapMatch::Full(command) => {
+                tracing::debug!("handle_keymatch {:?}", command);
                 self.pending_keypress
                     .update(|(pending_keypress, last_time)| {
                         last_time.take();

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -41,6 +41,7 @@ use lsp_types::{
     TextDocumentItem, Url,
 };
 use parking_lot::Mutex;
+use tracing::debug;
 
 use crate::{
     buffer::{get_mod_time, load_file, Buffer},
@@ -67,6 +68,7 @@ pub struct Dispatcher {
 impl ProxyHandler for Dispatcher {
     fn handle_notification(&mut self, rpc: ProxyNotification) {
         use ProxyNotification::*;
+        debug!("Dispatcher handle_notification {:?}", rpc);
         match rpc {
             Initialize {
                 workspace,
@@ -392,6 +394,7 @@ impl ProxyHandler for Dispatcher {
 
     fn handle_request(&mut self, id: RequestId, rpc: ProxyRequest) {
         use ProxyRequest::*;
+        tracing::debug!("dispatcher handle_request {:?}", rpc);
         match rpc {
             NewBuffer { buffer_id, path } => {
                 let buffer = Buffer::new(buffer_id, path.clone());


### PR DESCRIPTION
1. The configuration for the log filter should first be retrieved from environment variable
2. Standardize the log filter configuration for both the console and file logs.
3. add some logs