### PR TITLE
Only render the styling without displaying messages, provided that `E…

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -43,6 +43,7 @@ enable-inlay-hints = true
 inlay-hint-font-family = ""
 inlay-hint-font-size = 0
 enable-error-lens = true
+only-render-error-styling = true
 error-lens-end-of-line = true
 error-lens-font-family = ""
 error-lens-font-size = 0

--- a/lapce-app/src/config/editor.rs
+++ b/lapce-app/src/config/editor.rs
@@ -159,6 +159,11 @@ pub struct EditorConfig {
     pub inlay_hint_font_size: usize,
     #[field_names(desc = "If diagnostics should be displayed inline")]
     pub enable_error_lens: bool,
+
+    #[field_names(
+        desc = "Only render the styling without displaying messages, provided that `Enable ErrorLens` is enabled"
+    )]
+    pub only_render_error_styling: bool,
     #[field_names(
         desc = "Whether error lens should go to the end of view line, or only to the end of the diagnostic"
     )]

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -1743,15 +1743,18 @@ impl DocumentPhantom for Doc {
                                         config.color(theme_prop)
                                     };
 
-                                    let text = if config.editor.error_lens_multiline
-                                    {
-                                        format!("    {}", diag.message)
-                                    } else {
-                                        format!(
-                                            "    {}",
-                                            diag.message.lines().join(" ")
-                                        )
-                                    };
+                                    let text =
+                                        if config.editor.only_render_error_styling {
+                                            "".to_string()
+                                        } else if config.editor.error_lens_multiline
+                                        {
+                                            format!("    {}", diag.message)
+                                        } else {
+                                            format!(
+                                                "    {}",
+                                                diag.message.lines().join(" ")
+                                            )
+                                        };
                                     Some(PhantomText {
                                         kind: PhantomTextKind::Diagnostic,
                                         col: end_offset - start_offset,


### PR DESCRIPTION
Only render the styling without displaying messages, provided that `Enable ErrorLens` is enabled

![1727771351061](https://github.com/user-attachments/assets/b06b97c5-0c2b-4d2f-a114-821ef01cdcb7)
