### PR TITLE
Add a space to the right of the colon (:) to improve code readability.

### DIFF
--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -1724,12 +1724,15 @@ impl DocumentPhantom for Doc {
                     let (_, col) = b.offset_to_line_col(interval.start);
                     (col, affinity)
                 });
-                let text = match &inlay_hint.label {
+                let mut text = match &inlay_hint.label {
                     InlayHintLabel::String(label) => label.to_string(),
                     InlayHintLabel::LabelParts(parts) => {
                         parts.iter().map(|p| &p.value).join("")
                     }
                 };
+                if text.ends_with(':') {
+                    text.push(' ');
+                }
                 PhantomText {
                     kind: PhantomTextKind::InlayHint,
                     col,


### PR DESCRIPTION
The left side shows the new style.

![1727787988101](https://github.com/user-attachments/assets/670ba01b-d676-4992-8379-00726097f859)
