### PR TITLE
Improve support for `musl` targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,11 @@
 # Link runtime statically so Visual C++ Redist is not required
 [target.'cfg(all(windows, target_env = "msvc"))']
 rustflags = ["-C", "target-feature=+crt-static"]
+
+# `musl` must be linked dynamically instead of statically in order for `dlopen` to work,
+# which is required for `winit` to open X11 or Wayland libraries and spawn a window.
+#
+# See: https://github.com/rust-windowing/winit/issues/1818
+
+[target.'cfg(target_env = "musl")']
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 
 - Add Ubuntu 24.04 LTS (noble) build
+- Improved support for `musl` targets
 
 ### Bug Fixes
 


### PR DESCRIPTION
It is necessary to dynamically link `libc` on `musl` targets in order for a window to spawn when launching `lapce` since `dlopen` won't work without it, which is required by `winit` to load X11 and Wayland libraries. This can be achieved by appending `-C target-feature=-crt-static` to the rust flags.

IIRC, Alpine Linux packages a Rust toolchain that does this by default, but Alpine isn't the only `musl` distro, so it's worth specifying this explicitly.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users