### PR TITLE
fix! bash Syntax highlighting

### DIFF
--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -495,7 +495,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         id: LapceLanguage::Bash,
         indent: Indent::space(2),
         files: &[],
-        extensions: &["bash"],
+        extensions: &["bash","sh"],
         comment: comment_properties!("#"),
         tree_sitter: TreeSitterProperties::DEFAULT,
     },


### PR DESCRIPTION
- added sh extension to bash Syntax highlighting
- sh extension is what most bash scripts use

- initially this is how it is implemented #690
- was removed in [6c85e94]

fixes #3621