### PR TITLE
Fix pointer events getting ignored in the plugin info view.

### DIFF
--- a/lapce-app/src/plugin.rs
+++ b/lapce-app/src/plugin.rs
@@ -922,7 +922,7 @@ pub fn plugin_info_view(plugin: PluginData, volt: VoltID) -> impl View {
                     }),
                     empty().style(move |s| {
                         let rect = header_rect.get();
-                        s.size(rect.width(), rect.height())
+                        s.size(rect.width(), rect.height()).pointer_events_none()
                     }),
                     empty().style(move |s| {
                         s.margin_vert(6)


### PR DESCRIPTION
It was quite difficult to figure out which view was eating pointer events. Perhaps the author of lapce/floem#761 has a point.

I don't understand why `pointer_events_none()` only has to be set on one of the empty views. Is this behavior really intended?