### PR TITLE
Use Diff syntax for files with .diff/.patch extensions by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features/Changes
 
 - Add Ubuntu 24.04 LTS (noble) build
+- Use Diff syntax for files with .diff/.patch extensions by default.
 
 ### Bug Fixes
 

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -706,7 +706,7 @@ const LANGUAGES: &[SyntaxProperties] = &[
         id: LapceLanguage::Diff,
         indent: Indent::tab(),
         files: &[],
-        extensions: &[],
+        extensions: &["diff", "patch"],
         comment: comment_properties!(),
         tree_sitter: TreeSitterProperties::DEFAULT,
     },


### PR DESCRIPTION
- [X] Added an entry to `CHANGELOG.md` if this change could be valuable to users