### PR TITLE
RFC: Add `shift+tab` as a keybind to `outdent_line`

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -311,6 +311,12 @@ when = "!in_snippet && !completion_focus && !inline_completion_visible && !searc
 mode = "i"
 
 [[keymaps]]
+key = "shift+tab"
+command = "outdent_line"
+when = "!in_snippet && !completion_focus && !inline_completion_visible && !search_focus && !replace_focus"
+mode = "i"
+
+[[keymaps]]
 key = "ctrl+m"
 command = "insert_new_line"
 when = "!list_focus"


### PR DESCRIPTION
In many editors, `shift+tab` is used to outdent selected lines. This commit adds that keybind.

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users