### PR TITLE
scm: Only reset commit message if commit succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fix editor tabs not selectable while appearing selectable
 - Fix flickering when reordering editor tabs
+- Fix commit messages being removed on failed git commit (<https://github.com/lapce/lapce/issues/3825>)
 
 ## 0.4.5
 

--- a/lapce-app/src/source_control.rs
+++ b/lapce-app/src/source_control.rs
@@ -98,7 +98,10 @@ impl SourceControlData {
             return;
         }
 
-        self.editor.reset();
         self.common.proxy.git_commit(message.to_string(), diffs);
+    }
+
+    pub fn clear_commit_message(&self) {
+        self.editor.reset();
     }
 }

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -2324,6 +2324,11 @@ impl WindowTabData {
             CoreNotification::WorkspaceFileChange => {
                 self.file_explorer.reload();
             }
+            CoreNotification::GitCommitResult { success } => {
+                if *success {
+                    self.source_control.clear_commit_message();
+                }
+            }
             _ => {}
         }
     }

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -338,7 +338,9 @@ impl ProxyHandler for Dispatcher {
             GitCommit { message, diffs } => {
                 if let Some(workspace) = self.workspace.as_ref() {
                     match git_commit(workspace, &message, diffs) {
-                        Ok(()) => (),
+                        Ok(()) => {
+                            self.core_rpc.git_commit_result(true);
+                        }
                         Err(e) => {
                             self.core_rpc.show_message(
                                 "Git Commit failure".to_owned(),
@@ -347,6 +349,7 @@ impl ProxyHandler for Dispatcher {
                                     message: e.to_string(),
                                 },
                             );
+                            self.core_rpc.git_commit_result(false);
                         }
                     }
                 }

--- a/lapce-rpc/src/core.rs
+++ b/lapce-rpc/src/core.rs
@@ -146,6 +146,9 @@ pub enum CoreNotification {
         path: PathBuf,
         breakpoints: Vec<dap_types::Breakpoint>,
     },
+    GitCommitResult {
+        success: bool,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -401,6 +404,10 @@ impl CoreRpcHandler {
 
     pub fn home_dir(&self, path: PathBuf) {
         self.notification(CoreNotification::HomeDir { path });
+    }
+
+    pub fn git_commit_result(&self, success: bool) {
+        self.notification(CoreNotification::GitCommitResult { success });
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/lapce/lapce/issues/3825

Creates a new notification to signal commit result to the UI. In the future, when we have more options for source control management, we can change this notification to cover more SCM-related notifications.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

[Screencast_20251105_001234.webm](https://github.com/user-attachments/assets/296fc4c4-c35a-4dd2-b4a8-f001f308a4da)
