### PR TITLE
fix(plugin): Fix the issue where the plugin status does not change when disabled or uninstalled

### DIFF
--- a/lapce-app/src/plugin.rs
+++ b/lapce-app/src/plugin.rs
@@ -309,6 +309,13 @@ impl PluginData {
             installed.swap_remove(&id);
         });
 
+        // Reset the installing state in the available list
+        self.available.volts.update(|volts| {
+            if let Some(volt_data) = volts.get_mut(&id) {
+                volt_data.installing.set(false);
+            }
+        });
+
         if self.disabled.with_untracked(|d| d.contains(&id)) {
             self.disabled.update(|d| {
                 d.remove(&id);

--- a/lapce-proxy/src/plugin/catalog.rs
+++ b/lapce-proxy/src/plugin/catalog.rs
@@ -182,8 +182,10 @@ impl PluginCatalog {
         f: Box<dyn ClonableCallback<Value, RpcError>>,
     ) {
         let id = volt.id();
+        let mut found = false;
         for (plugin_id, plugin) in self.plugins.iter() {
             if plugin.volt_id == id {
+                found = true;
                 let f = dyn_clone::clone_box(&*f);
                 let plugin_id = *plugin_id;
                 plugin.server_request_async(
@@ -198,6 +200,11 @@ impl PluginCatalog {
                 );
                 plugin.shutdown();
             }
+        }
+        // If plugin is not found (it might be disabled), still call the callback
+        if !found {
+            let f = dyn_clone::clone_box(&*f);
+            f(PluginId(0), Ok(Value::Null));
         }
     }
 


### PR DESCRIPTION
Detailed issue resolution:
1.After the extension tool is installed, click uninstall. There is no update status in the extension store; it is still 'installing'.
2.Fix the issue where disabled extensions cannot be uninstalled