### PR TITLE
feat: Implement folder choosing in remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features/Changes
 
+- Implemented Folder/File choosing in remotes
+
 ### Bug Fixes
 
 - Fix editor tabs not selectable while appearing selectable

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -2572,6 +2572,69 @@ fn palette_item(
                 .style(|s| s.align_items(Some(AlignItems::Center)).max_width_full()),
             )
         }
+        PaletteItemContent::FileChooserEntry { is_dir, .. } => {
+            let file_name = item.filter_text;
+            let indices = item.indices;
+
+            let (svg_path, svg_color) = (
+                config.get().ui_svg(if *is_dir {
+                    LapceIcons::DIRECTORY_CLOSED
+                } else {
+                    LapceIcons::FILE
+                }),
+                Some(config.get().color(LapceColor::LAPCE_ICON_ACTIVE)),
+            );
+            container(
+                stack((
+                    svg(move || svg_path.clone()).style(move |s| {
+                        let config = config.get();
+                        let size = config.ui.icon_size() as f32;
+                        let color = svg_color;
+                        s.min_width(size)
+                            .size(size, size)
+                            .margin_right(5.0)
+                            .apply_opt(color, Style::color)
+                    }),
+                    focus_text(
+                        move || file_name.clone(),
+                        move || indices.clone(),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
+                    )
+                    .style(|s| s.margin_right(6.0).max_width_full()),
+                ))
+                .style(|s| s.align_items(Some(AlignItems::Center)).max_width_full()),
+            )
+        }
+        PaletteItemContent::ConfirmFileChooserEntry { .. } => {
+            let text = format!("Open {}", item.filter_text);
+            let indices = item.indices;
+
+            let (svg_path, svg_color) = (
+                config.get().ui_svg(LapceIcons::ADD),
+                Some(config.get().color(LapceColor::LAPCE_ICON_ACTIVE)),
+            );
+
+            container(
+                stack((
+                    svg(move || svg_path.clone()).style(move |s| {
+                        let config = config.get();
+                        let size = config.ui.icon_size() as f32;
+                        let color = svg_color;
+                        s.min_width(size)
+                            .size(size, size)
+                            .margin_right(5.0)
+                            .apply_opt(color, Style::color)
+                    }),
+                    focus_text(
+                        move || text.clone(),
+                        move || indices.clone(),
+                        move || config.get().color(LapceColor::EDITOR_FOCUS),
+                    )
+                    .style(|s| s.margin_right(6.0).max_width_full()),
+                ))
+                .style(|s| s.align_items(Some(AlignItems::Center)).max_width_full()),
+            )
+        }
         #[cfg(windows)]
         PaletteItemContent::WslHost { .. } => {
             let text = item.filter_text;

--- a/lapce-app/src/file_explorer/data.rs
+++ b/lapce-app/src/file_explorer/data.rs
@@ -27,7 +27,7 @@ use lapce_rpc::{
         Duplicating, FileNodeItem, FileNodeViewKind, Naming, NamingState, NewNode,
         Renaming,
     },
-    proxy::ProxyResponse,
+    proxy::{PathRequest, ProxyResponse},
 };
 
 use crate::{
@@ -195,7 +195,8 @@ impl FileExplorerData {
         let send = {
             let path = path.to_path_buf();
             create_ext_action(self.common.scope, move |result| {
-                let Ok(ProxyResponse::ReadDirResponse { mut items }) = result else {
+                let Ok(ProxyResponse::ReadDirResponse { mut items, .. }) = result
+                else {
                     done(false);
                     return;
                 };
@@ -250,7 +251,9 @@ impl FileExplorerData {
         };
 
         // Ask the proxy for the directory information
-        self.common.proxy.read_dir(path.to_path_buf(), send);
+        self.common
+            .proxy
+            .read_dir(PathRequest::Path(path.to_path_buf()), send);
     }
 
     /// Returns `true` if `path` exists in the file explorer tree and is a directory, `false`

--- a/lapce-app/src/palette/item.rs
+++ b/lapce-app/src/palette/item.rs
@@ -28,6 +28,14 @@ pub enum PaletteItemContent {
         path: PathBuf,
         full_path: PathBuf,
     },
+    FileChooserEntry {
+        path: PathBuf,
+        full_path: PathBuf,
+        is_dir: bool,
+    },
+    ConfirmFileChooserEntry {
+        full_path: PathBuf,
+    },
     Line {
         line: usize,
         content: String,

--- a/lapce-app/src/palette/kind.rs
+++ b/lapce-app/src/palette/kind.rs
@@ -6,6 +6,7 @@ use crate::command::LapceWorkbenchCommand;
 pub enum PaletteKind {
     PaletteHelp,
     File,
+    FileChooser,
     Line,
     Command,
     Workspace,
@@ -39,6 +40,7 @@ impl PaletteKind {
             PaletteKind::Command => ":",
             PaletteKind::TerminalProfile => "<",
             PaletteKind::File
+            | PaletteKind::FileChooser
             | PaletteKind::Reference
             | PaletteKind::SshHost
             | PaletteKind::RunAndDebug
@@ -82,6 +84,7 @@ impl PaletteKind {
             PaletteKind::Workspace => Some(LapceWorkbenchCommand::PaletteWorkspace),
             PaletteKind::Command => Some(LapceWorkbenchCommand::PaletteCommand),
             PaletteKind::File => Some(LapceWorkbenchCommand::Palette),
+            PaletteKind::FileChooser => None,
             PaletteKind::HelpAndFile => {
                 Some(LapceWorkbenchCommand::PaletteHelpAndFile)
             }
@@ -122,6 +125,7 @@ impl PaletteKind {
             #[cfg(windows)]
             PaletteKind::WslHost => input,
             PaletteKind::File
+            | PaletteKind::FileChooser
             | PaletteKind::Reference
             | PaletteKind::SshHost
             | PaletteKind::RunAndDebug

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -759,6 +759,8 @@ impl WindowTabData {
                                 .send(WindowCommand::SetWorkspace { workspace });
                         }
                     });
+                } else {
+                    self.palette.run(PaletteKind::FileChooser);
                 }
             }
             CloseFolder => {
@@ -788,6 +790,8 @@ impl WindowTabData {
                             })
                         }
                     });
+                } else { // TODO: Force only choosing files?
+                    self.palette.run(PaletteKind::FileChooser);
                 }
             }
             NewFile => {
@@ -1110,7 +1114,7 @@ impl WindowTabData {
             }
             Palette => {
                 self.palette.run(PaletteKind::File);
-            }
+            },
             PaletteSymbol => {
                 self.palette.run(PaletteKind::DocumentSymbol);
             }

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -57,6 +57,12 @@ pub struct SearchMatch {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PathRequest {
+    Home,
+    Path(PathBuf),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
 pub enum ProxyRequest {
@@ -173,7 +179,7 @@ pub enum ProxyRequest {
         path: String,
     },
     ReadDir {
-        path: PathBuf,
+        path: PathRequest,
     },
     Save {
         rev: u64,
@@ -369,6 +375,7 @@ pub enum ProxyResponse {
         content: String,
     },
     ReadDirResponse {
+        dir: FileNodeItem,
         items: Vec<FileNodeItem>,
     },
     CompletionResolveResponse {
@@ -830,7 +837,7 @@ impl ProxyRpcHandler {
         self.request(ProxyRequest::GetOpenFilesContent {})
     }
 
-    pub fn read_dir(&self, path: PathBuf, f: impl ProxyCallback + 'static) {
+    pub fn read_dir(&self, path: PathRequest, f: impl ProxyCallback + 'static) {
         self.request_async(ProxyRequest::ReadDir { path }, f);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/lapce/lapce/issues/3650
Fixes: https://github.com/lapce/lapce/issues/3472
Fixes (part of): https://github.com/lapce/lapce/issues/2417

Editors like Visual Studio Code have a pallete-based file picker for remotes. This commit implements that, as the current code just ignores `Open Folder` and `Open File` requests.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

[Screencast_20251122_131738.webm](https://github.com/user-attachments/assets/b9be6bb7-0964-41bc-a631-226c38c7d7b6)

