### PR TITLE
LSP document highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features/Changes
+- Added document highlight for LSPs which support this feature
 
 ### Bug Fixes
 

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -600,6 +600,14 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "add_run_debug_config")]
     #[strum(message = "Add Run Debug Config")]
     AddRunDebugConfig,
+
+    #[strum(serialize = "jump_highlight_next")]
+    #[strum(message = "Jump to next document highlight")]
+    JumpHighlightNext,
+
+    #[strum(serialize = "jump_highlight_prev")]
+    #[strum(message = "Jump to previous document highlight")]
+    JumpHighlightPrev,
 }
 
 #[derive(Clone, Debug)]

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -64,7 +64,10 @@ use crate::{
     db::LapceDb,
     debug::{DapData, LapceBreakpoint, RunDebugMode, RunDebugProcess},
     doc::DocContent,
-    editor::location::{EditorLocation, EditorPosition},
+    editor::{
+        InlineFindDirection,
+        location::{EditorLocation, EditorPosition},
+    },
     editor_tab::EditorTabChild,
     file_explorer::data::FileExplorerData,
     find::Find,
@@ -1580,6 +1583,20 @@ impl WindowTabData {
                 }
             }
 
+            JumpHighlightNext => {
+                if let Some(editor_data) =
+                    self.main_split.active_editor.get_untracked()
+                {
+                    editor_data.jump_highlight(InlineFindDirection::Right);
+                }
+            }
+            JumpHighlightPrev => {
+                if let Some(editor_data) =
+                    self.main_split.active_editor.get_untracked()
+                {
+                    editor_data.jump_highlight(InlineFindDirection::Left);
+                }
+            }
         }
     }
 

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -1204,6 +1204,19 @@ impl ProxyHandler for Dispatcher {
                 let resp = ProxyResponse::ReferencesResolveResponse { items };
                 self.proxy_rpc.handle_response(id, Ok(resp));
             }
+            GetDocumentHighlights { path, position } => {
+                let proxy_rpc = self.proxy_rpc.clone();
+                self.catalog_rpc.get_document_highlights(
+                    &path,
+                    position,
+                    move |_, result| {
+                        let result = result.map(|highlights| {
+                            ProxyResponse::GetDocumentHighlights { highlights }
+                        });
+                        proxy_rpc.handle_response(id, result);
+                    },
+                );
+            }
         }
     }
 }

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -41,12 +41,12 @@ use lsp_types::{
     request::{
         CallHierarchyIncomingCalls, CallHierarchyPrepare, CodeActionRequest,
         CodeActionResolveRequest, CodeLensRequest, CodeLensResolve, Completion,
-        DocumentSymbolRequest, FoldingRangeRequest, Formatting, GotoDefinition,
-        GotoImplementation, GotoTypeDefinition, HoverRequest, Initialize,
-        InlayHintRequest, InlineCompletionRequest, PrepareRenameRequest, References,
-        RegisterCapability, Rename, ResolveCompletionItem, SelectionRangeRequest,
-        SemanticTokensFullRequest, SignatureHelpRequest, WorkDoneProgressCreate,
-        WorkspaceSymbolRequest,
+        DocumentHighlightRequest, DocumentSymbolRequest, FoldingRangeRequest,
+        Formatting, GotoDefinition, GotoImplementation, GotoTypeDefinition,
+        HoverRequest, Initialize, InlayHintRequest, InlineCompletionRequest,
+        PrepareRenameRequest, References, RegisterCapability, Rename,
+        ResolveCompletionItem, SelectionRangeRequest, SemanticTokensFullRequest,
+        SignatureHelpRequest, WorkDoneProgressCreate, WorkspaceSymbolRequest,
     },
 };
 use parking_lot::Mutex;
@@ -858,6 +858,10 @@ impl PluginHostHandler {
             CallHierarchyIncomingCalls::METHOD => {
                 self.server_capabilities.call_hierarchy_provider.is_some()
             }
+            DocumentHighlightRequest::METHOD => self
+                .server_capabilities
+                .document_highlight_provider
+                .is_some(),
             _ => false,
         }
     }

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -12,10 +12,11 @@ use indexmap::IndexMap;
 use lapce_xi_rope::RopeDelta;
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyItem, CodeAction, CodeActionResponse,
-    CodeLens, CompletionItem, Diagnostic, DocumentSymbolResponse, FoldingRange,
-    GotoDefinitionResponse, Hover, InlayHint, InlineCompletionResponse,
-    InlineCompletionTriggerKind, Location, Position, PrepareRenameResponse,
-    SelectionRange, SymbolInformation, TextDocumentItem, TextEdit, WorkspaceEdit,
+    CodeLens, CompletionItem, Diagnostic, DocumentHighlight, DocumentSymbolResponse,
+    FoldingRange, GotoDefinitionResponse, Hover, InlayHint,
+    InlineCompletionResponse, InlineCompletionTriggerKind, Location, Position,
+    PrepareRenameResponse, SelectionRange, SymbolInformation, TextDocumentItem,
+    TextEdit, WorkspaceEdit,
     request::{GotoImplementationResponse, GotoTypeDefinitionResponse},
 };
 use parking_lot::Mutex;
@@ -219,6 +220,10 @@ pub enum ProxyRequest {
     },
     ReferencesResolve {
         items: Vec<Location>,
+    },
+    GetDocumentHighlights {
+        path: PathBuf,
+        position: Position,
     },
 }
 
@@ -467,6 +472,9 @@ pub enum ProxyResponse {
     SaveResponse {},
     ReferencesResolveResponse {
         items: Vec<FileLine>,
+    },
+    GetDocumentHighlights {
+        highlights: Option<Vec<DocumentHighlight>>,
     },
 }
 
@@ -1025,6 +1033,18 @@ impl ProxyRpcHandler {
         f: impl ProxyCallback + 'static,
     ) {
         self.request_async(ProxyRequest::GetDocumentSymbols { path }, f);
+    }
+
+    pub fn get_document_highlights(
+        &self,
+        path: PathBuf,
+        position: Position,
+        f: impl ProxyCallback + 'static,
+    ) {
+        self.request_async(
+            ProxyRequest::GetDocumentHighlights { path, position },
+            f,
+        );
     }
 
     pub fn get_workspace_symbols(


### PR DESCRIPTION
Automatically highlight symbol under the cursor (if LSP supports it) and commands to jump between occurrences

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

This is my first PR to this project, so please be patient and guide me to match guidelines :).
Apparently this is feature I lack most and it helps me analyzing the code - an extremely quick "find references".

The communication with LSP is pretty straight-forward, while integration with the editor required fewer decisions.

1. Highlighting in the view was modeled mostly after search. I thought it could be a generic "highlights", but it's probably not worth it because origin of each highlights pack needs to be tracked or different provides should just override each other (e.g. search cancels LSP highlights, however I like to see both and highlight different things with searching).
2. Initiating request is connected to cursor movement (the signals model is quite interesting to work with). I decided to not add wait timer, but there is a limit of 1 request in flight to LSP. This is also quite similar to how Find stores occurrences per-document.
3. I had to go via `LapceWorkbenchCommand` because everything else is in floem repo and it doesn't feel like a generic edit command.
4. Maybe a setting is needed to allow opt-out or better handling if LSP doesn't support this feature. As well as updating highlights when LSP is finally initialized, but I'm not that fluent in lapce's data model. All in all it works pretty well on my machine™ (and I finished writing this code using this feature getting a productivity boost :D ).