### PR TITLE
Store confirmed state in the app database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix mouse wheel scrolling when viewing diff (<https://github.com/lapce/lapce/issues/3821>)
 - Fix editor tabs not selectable while appearing selectable
 - Fix flickering when reordering editor tabs
+- (Un)confirmed state of the editor is properly (re)stored
 
 ## 0.4.5
 

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -105,6 +105,7 @@ pub struct EditorInfo {
     pub unsaved: Option<String>,
     pub offset: usize,
     pub scroll_offset: (f64, f64),
+    pub confirmed: Option<bool>,
 }
 
 impl EditorInfo {
@@ -124,7 +125,8 @@ impl EditorInfo {
                     doc,
                     Some(editor_tab_id),
                     None,
-                    None,
+                    self.confirmed
+                        .map(|confirmed| data.scope.create_rw_signal(confirmed)),
                     common,
                 );
                 editor.go_to_location(
@@ -362,6 +364,7 @@ impl EditorData {
             unsaved,
             offset,
             scroll_offset: (scroll_offset.x, scroll_offset.y),
+            confirmed: Some(self.confirmed.get_untracked()),
         }
     }
 


### PR DESCRIPTION
It fixes a slightly annoying behaviour when lapce loads workspace, all editors suddenly become "unconfirmed" (tab is in italics).

This also makes them eligible for replacement when other unconfirmed editor opens.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users