### PR TITLE
Update package list for Fedora build instructions

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -12,7 +12,7 @@ sudo apt install clang libxkbcommon-x11-dev pkg-config libvulkan-dev libwayland-
 ```
 #### Fedora
 ```sh
-sudo dnf install clang libxkbcommon-x11-devel libxcb-devel vulkan-loader-devel wayland-devel openssl-devel pkgconf
+sudo dnf install clang libxkbcommon-x11-devel libxcb-devel vulkan-loader-devel wayland-devel openssl-devel pkgconf perl-FindBin perl-IPC-Cmd perl-File-Compare
 ```
 #### Void Linux
 ```sh


### PR DESCRIPTION
Add perl package dependencies that are required to build openssl-sys.