### PR TITLE
fix: cross typos, see details below

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = ./.git,./target,./vendor,./node_modules,./po,./Cargo.lock,./extra/windows/wix/license.rtf
+ignore-regex = .*(ratatui|Affinitized|affinitized|ede|fo|onl).*
+ignore-words-list = ser,edn,tese,rcall,wit,Wit,WIT,wast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - lapce-**
-      - .github/wofklows/ci.yml
+      - .github/workflows/ci.yml
   workflow_dispatch:
 
 name: CI
@@ -97,7 +97,7 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-        
+
       - name: Fetch dependencies
         run: cargo fetch --locked
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 ### Features/Changes
 
 - Add fedora builds
-- Finish tree sitter dynamic libary support by downloading from https://github.com/lapce/tree-sitter-grammars
+- Finish tree sitter dynamic library support by downloading from https://github.com/lapce/tree-sitter-grammars
 - Saves scale configuration in settings to restore at startup
 - text in ui can be selected and copied
 - add right click context menu for editor tab

--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -82,7 +82,7 @@ default = {}
 # [terminal.profiles.example]
 # command     = "cargo"
 # arguments   = ["run"]
-# environemnt = { "KEY" = "VALUE" }
+# environment = { "KEY" = "VALUE" }
 # workdir     = "/home/user"
 
 [ui]

--- a/lapce-app/benches/visual_line.rs
+++ b/lapce-app/benches/visual_line.rs
@@ -268,7 +268,7 @@ fn visual_line(c: &mut Criterion) {
         })
     });
 
-    // TODO: when we have the reverse search of vline for offset, we should have a separate instance where the last vline isn't cached, which would give us a range of 'worst case' (never reused, have to recopmute it everytime) and 'best case' (always reused)
+    // TODO: when we have the reverse search of vline for offset, we should have a separate instance where the last vline isn't cached, which would give us a range of 'worst case' (never reused, have to recompute it every time) and 'best case' (always reused)
 
     // TODO: bench common operations, like a single line changing or the (equivalent of)  cache rev
     // updating.

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -126,9 +126,9 @@ struct Cli {
     #[clap(short, long, action)]
     wait: bool,
 
-    /// Path(s) to plugins to load.  
+    /// Path(s) to plugins to load.
     /// This is primarily used for plugin development to make it easier to test changes to the
-    /// plugin without needing to copy the plugin to the plugins directory.  
+    /// plugin without needing to copy the plugin to the plugins directory.
     /// This will cause any plugin with the same author & name to not run.
     #[clap(long, action)]
     plugin_path: Vec<PathBuf>,
@@ -2141,7 +2141,7 @@ pub fn clickable_icon_base(
     }
 }
 
-/// A tooltip with a label inside.  
+/// A tooltip with a label inside.
 /// When styling an element that has the tooltip, it will style the child rather than the tooltip
 /// label.
 pub fn tooltip_label<S: std::fmt::Display + 'static, V: View + 'static>(
@@ -2830,7 +2830,7 @@ fn palette(window_tab_data: Rc<WindowTabData>) -> impl View {
         .items_center()
         .pointer_events_none()
     })
-    .debug_name("Pallete Layer")
+    .debug_name("Palette Layer")
 }
 
 fn window_message_view(
@@ -3905,8 +3905,8 @@ pub fn launch() {
                 for (_, window) in app_data.windows.get_untracked() {
                     for (_, tab) in window.window_tabs.get_untracked() {
                         for (_, doc) in tab.main_split.docs.get_untracked() {
-                            doc.syntax.update(|syntaxt| {
-                                *syntaxt = Syntax::from_language(syntaxt.language);
+                            doc.syntax.update(|syntax| {
+                                *syntax = Syntax::from_language(syntax.language);
                             });
                             doc.trigger_syntax_change(None);
                         }

--- a/lapce-app/src/debug.rs
+++ b/lapce-app/src/debug.rs
@@ -361,7 +361,7 @@ impl DapData {
         let variables_id = self.variables_id;
 
         let send = create_ext_action(self.common.scope, move |result| {
-            if let Ok(ProxyResponse::DapVariableResponse { varialbes }) = result {
+            if let Ok(ProxyResponse::DapVariableResponse { variables }) = result {
                 variables_id.update(|id| {
                     *id += 1;
                 });
@@ -370,7 +370,7 @@ impl DapData {
                         let mut new_parent = parent.clone();
                         new_parent.push(reference);
                         var.read = true;
-                        var.children = varialbes
+                        var.children = variables
                             .into_iter()
                             .map(|v| DapVariable {
                                 item: ScopeOrVar::Var(v),

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -111,7 +111,7 @@ pub struct DocHistory {
 pub enum DocContent {
     /// A file at some location. This can be a remote path.
     File { path: PathBuf, read_only: bool },
-    /// A local document, which doens't need to be sync to the disk.
+    /// A local document, which doesn't need to be sync to the disk.
     Local,
     /// A document of an old version in the source control
     History(DocHistory),
@@ -387,7 +387,7 @@ impl Doc {
 
         let register = common.register;
         // TODO: we could have these Rcs created once and stored somewhere, maybe on
-        // common, to avoid recreating them everytime.
+        // common, to avoid recreating them every time.
         let cursor_info = CursorInfo {
             blink_interval: Rc::new(move || config.editor.blink_interval()),
             blink_timer: common.window_common.cursor_blink_timer,

--- a/lapce-app/src/file_explorer/data.rs
+++ b/lapce-app/src/file_explorer/data.rs
@@ -146,14 +146,14 @@ impl FileExplorerData {
         data
     }
 
-    /// Reload the file explorer data via reading the root directory.  
+    /// Reload the file explorer data via reading the root directory.
     /// Note that this will not update immediately.
     pub fn reload(&self) {
         let path = self.root.with_untracked(|root| root.path.clone());
         self.read_dir(&path);
     }
 
-    /// Toggle whether the directory is expanded or not.  
+    /// Toggle whether the directory is expanded or not.
     /// Does nothing if the path does not exist or is not a directory.
     pub fn toggle_expand(&self, path: &Path) {
         let Some(Some(read)) = self.root.try_update(|root| {
@@ -185,7 +185,7 @@ impl FileExplorerData {
         self.read_dir_cb(path, |_| {});
     }
 
-    /// Read the directory's information and update the file explorer tree.  
+    /// Read the directory's information and update the file explorer tree.
     /// `done : FnOnce(was_read: bool)` is called when the operation is completed, whether success,
     /// failure, or ignored.
     pub fn read_dir_cb(&self, path: &Path, done: impl FnOnce(bool) + 'static) {
@@ -261,7 +261,7 @@ impl FileExplorerData {
         })
     }
 
-    /// The current path that we're renaming to / creating or duplicating a node at.  
+    /// The current path that we're renaming to / creating or duplicating a node at.
     /// Note: returns `None` when renaming if the file name has not changed.
     fn naming_path(&self) -> Option<PathBuf> {
         self.naming.with_untracked(|naming| match naming {
@@ -408,7 +408,7 @@ impl FileExplorerData {
         let done = self
             .root
             .try_update(|root| {
-                // the directories in which the file are located are all readed and opened
+                // the directories in which the file are located are all read and opened
                 if root.get_file_node(&path).is_some() {
                     for current_path in path.ancestors() {
                         if let Some(file) = root.get_file_node_mut(current_path) {

--- a/lapce-app/src/panel/problem_view.rs
+++ b/lapce-app/src/panel/problem_view.rs
@@ -88,7 +88,7 @@ fn file_view(
     internal_command: Listener<InternalCommand>,
     config: ReadSignal<Arc<LapceConfig>>,
 ) -> impl View {
-    let collpased = create_rw_signal(false);
+    let collapsed = create_rw_signal(false);
 
     let diagnostics = create_rw_signal(im::Vector::new());
     create_effect(move |_| {
@@ -180,7 +180,7 @@ fn file_view(
                 .style(move |s| s.width_pct(100.0).min_width(0.0)),
             )
             .on_click_stop(move |_| {
-                collpased.update(|collpased| *collpased = !*collpased);
+                collapsed.update(|collapsed| *collapsed = !*collapsed);
             })
             .style(move |s| {
                 let config = config.get();
@@ -196,7 +196,7 @@ fn file_view(
             }),
             stack((
                 svg(move || {
-                    config.get().ui_svg(if collpased.get() {
+                    config.get().ui_svg(if collapsed.get() {
                         LapceIcons::ITEM_CLOSED
                     } else {
                         LapceIcons::ITEM_OPENED
@@ -224,7 +224,7 @@ fn file_view(
         .style(move |s| s.width_pct(100.0).min_width(0.0)),
         dyn_stack(
             move || {
-                if collpased.get() {
+                if collapsed.get() {
                     im::Vector::new()
                 } else {
                     diagnostics.get()

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -2024,7 +2024,7 @@ impl WindowTabData {
                 match cmd.wait() {
                     Ok(v) => event!(Level::TRACE, "Process exited with status {v}"),
                     Err(e) => {
-                        event!(Level::ERROR, "Proces exited with an error: {e}")
+                        event!(Level::ERROR, "Process exited with an error: {e}")
                     }
                 };
             }
@@ -2042,7 +2042,7 @@ impl WindowTabData {
                         }
                     })
                 }) else {
-                    error!("cound not find terminal tab data: index={tab_index}");
+                    error!("could not find terminal tab data: index={tab_index}");
                     return;
                 };
                 let Some(raw) = tab.terminals.with_untracked(|x| {
@@ -2054,7 +2054,7 @@ impl WindowTabData {
                         }
                     })
                 }) else {
-                    error!("cound not find terminal data: index={terminal_index}");
+                    error!("could not find terminal data: index={terminal_index}");
                     return;
                 };
                 raw.write().term.reset_state();

--- a/lapce-core/src/language.rs
+++ b/lapce-core/src/language.rs
@@ -96,19 +96,19 @@ macro_rules! comment_properties {
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug, PartialOrd, Ord, Default)]
 pub struct SyntaxProperties {
-    /// An extra check to make sure that the array elements are in the correct order.  
+    /// An extra check to make sure that the array elements are in the correct order.
     /// If this id does not match the enum value, a panic will happen with a debug assertion message.
     id: LapceLanguage,
 
     /// All tokens that can be used for comments in language
     comment: CommentProperties,
-    /// The indent unit.  
+    /// The indent unit.
     /// "  " for bash, "    " for rust, for example.
     indent: &'static str,
-    /// Filenames that belong to this language  
+    /// Filenames that belong to this language
     /// `["Dockerfile"]` for Dockerfile, `[".editorconfig"]` for EditorConfig
     files: &'static [&'static str],
-    /// File name extensions to determine the language.  
+    /// File name extensions to determine the language.
     /// `["py"]` for python, `["rs"]` for rust, for example.
     extensions: &'static [&'static str],
     /// Tree-sitter properties
@@ -125,7 +125,7 @@ struct TreeSitterProperties {
     query: Option<&'static str>,
     /// Preface: Originally this feature was called "Code Lens", which is not
     /// an LSP "Code Lens". It is renamed to "Code Glance", below doc text is
-    /// left unchanged.  
+    /// left unchanged.
     ///
     /// Lists of tree-sitter node types that control how code lenses are built.
     /// The first is a list of nodes that should be traversed and included in
@@ -1884,7 +1884,7 @@ fn load_grammar(
     if !library_path.exists() {
         event!(Level::WARN, "Grammar not found at: {library_path:?}");
 
-        // Load backwar compat libraries
+        // Load backward compat libraries
         library_path = path.join(format!("tree-sitter-{grammar_name}"));
         library_path.set_extension(std::env::consts::DLL_EXTENSION);
 

--- a/lapce-proxy/src/cli.rs
+++ b/lapce-proxy/src/cli.rs
@@ -34,8 +34,8 @@ pub fn parse_file_line_column(path: &str) -> Result<PathObject, Error> {
         if let Some(second_rhs) = splits.peek().and_then(|s| s.parse::<usize>().ok())
         {
             splits.next();
-            let remaning: Vec<&str> = splits.rev().collect();
-            let path = remaning.join(":");
+            let remaining: Vec<&str> = splits.rev().collect();
+            let path = remaining.join(":");
             let path = PathBuf::from(path);
             let path = if let Ok(path) = path.canonicalize() {
                 path
@@ -50,8 +50,8 @@ pub fn parse_file_line_column(path: &str) -> Result<PathObject, Error> {
                 }),
             )
         } else {
-            let remaning: Vec<&str> = splits.rev().collect();
-            let path = remaning.join(":");
+            let remaining: Vec<&str> = splits.rev().collect();
+            let path = remaining.join(":");
             let path = PathBuf::from(path);
             let path = if let Ok(path) = path.canonicalize() {
                 path

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -1106,7 +1106,7 @@ impl ProxyHandler for Dispatcher {
                         proxy_rpc.handle_response(
                             id,
                             result.map(|resp| ProxyResponse::DapVariableResponse {
-                                varialbes: resp,
+                                variables: resp,
                             }),
                         );
                     });

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -267,9 +267,9 @@ pub fn load_all_volts(
     }
 }
 
-/// Find all installed volts.  
+/// Find all installed volts.
 /// `plugin_dev_path` allows launching Lapce with a plugin on your local system for testing
-/// purposes.  
+/// purposes.
 /// As well, this function skips any volt in the typical plugin directory that match the name
 /// of the dev plugin so as to support developing a plugin you actively use.
 pub fn find_all_volts(extra_plugin_paths: &[PathBuf]) -> Vec<VoltMetadata> {
@@ -528,7 +528,7 @@ pub fn start_volt(
             let instance = linker.instantiate(&mut store, &module).unwrap();
             let handle_rpc = instance
                 .get_func(&mut store, "handle_rpc")
-                .ok_or_else(|| anyhow!("can't convet to function"))
+                .ok_or_else(|| anyhow!("can't convert to function"))
                 .unwrap()
                 .typed::<(), ()>(&mut store)
                 .unwrap();

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -455,7 +455,7 @@ pub enum ProxyResponse {
         matches: IndexMap<PathBuf, Vec<SearchMatch>>,
     },
     DapVariableResponse {
-        varialbes: Vec<dap_types::Variable>,
+        variables: Vec<dap_types::Variable>,
     },
     DapGetScopesResponse {
         scopes: Vec<(dap_types::Scope, Vec<dap_types::Variable>)>,


### PR DESCRIPTION
What I changed (typo fixes)
I fixed the actionable codespell findings in repo-owned source/docs, while not editing generated/third‑party artifacts:

Docs/Markdown/YAML/TOML
CHANGELOG.md: libary -> library
.github/workflows/ci.yml: .github/wofklows/ci.yml -> .github/workflows/ci.yml defaults/settings.toml (commented example): environemnt -> environment Rust source
lapce-app/src/app.rs: "Pallete Layer" -> "Palette Layer", syntaxt -> syntax lapce-app/src/doc.rs: doens't -> doesn't, everytime -> every time lapce-app/src/file_explorer/data.rs (comment): readed -> read lapce-app/src/panel/problem_view.rs: collpased -> collapsed (renamed variable + all uses) lapce-app/src/window_tab.rs: Proces -> Process, cound -> could lapce-core/src/language.rs (comment): backwar -> backward lapce-proxy/src/cli.rs: remaning -> remaining
lapce-proxy/src/plugin/wasi.rs: convet -> convert
RPC field typo fixed consistently:
lapce-rpc/src/proxy.rs: varialbes -> variables
lapce-proxy/src/dispatch.rs and lapce-app/src/debug.rs: updated to match What I intentionally did not edit
Cargo.lock: it’s explicitly auto-generated (“not intended for manual editing”), so I excluded it. extra/windows/wix/license.rtf: codespell flags \pard, but that’s an RTF control word (not a typo), so I excluded it. Added: .codespellrc
Created .codespellrc to make future checks consistent. It:

skips: .git, target, vendor, node_modules, po, plus Cargo.lock and the RTF license preserves at ignore-regex
adds an ignore-words-list for terms that are legitimate in this repo context (ser, edn, tese, rcall, wit variants, wast) Verification
Ran: codespell --config .codespellrc .
Result: exit code 0 (clean)

- [ ] Added an entry to `CHANGELOG.md` if this change could be valuable to users