### PR TITLE
Add "Filter Through Shell Command" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features/Changes
 
+- Add "Filter Through Shell Command" to pipe selection through an external command and replace it with the output
+
 ### Bug Fixes
 
 ## 0.4.6

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -97,6 +97,7 @@ use crate::{
     palette::{
         PaletteStatus,
         item::{PaletteItem, PaletteItemContent},
+        kind::PaletteKind,
     },
     panel::{position::PanelContainerPosition, view::panel_container_view},
     plugin::{PluginData, plugin_info_view},
@@ -2565,7 +2566,8 @@ fn palette_item(
         | PaletteItemContent::ColorTheme { .. }
         | PaletteItemContent::SCMReference { .. }
         | PaletteItemContent::TerminalProfile { .. }
-        | PaletteItemContent::IconTheme { .. } => {
+        | PaletteItemContent::IconTheme { .. }
+        | PaletteItemContent::ShellFilterCommand { .. } => {
             let text = item.filter_text;
             let indices = item.indices;
             container(
@@ -2784,6 +2786,81 @@ fn palette_preview(window_tab_data: Rc<WindowTabData>) -> impl View {
     })
 }
 
+fn palette_shell_filter_options(
+    window_tab_data: Rc<WindowTabData>,
+) -> impl View {
+    let palette_data = window_tab_data.palette.clone();
+    let kind = palette_data.kind;
+    let config = palette_data.common.config;
+
+    let new_doc = palette_data.shell_filter_new_doc;
+    let timeout = palette_data.shell_filter_timeout;
+
+    container(
+        stack((
+            label(move || {
+                if new_doc.get() {
+                    "[x] New document".to_string()
+                } else {
+                    "[ ] New document".to_string()
+                }
+            })
+            .on_click_stop(move |_| {
+                new_doc.update(|v| *v = !*v);
+            })
+            .style(move |s| {
+                let config = config.get();
+                s.padding_horiz(6.0)
+                    .padding_vert(2.0)
+                    .border_radius(3.0)
+                    .cursor(CursorStyle::Pointer)
+                    .color(if new_doc.get() {
+                        config.color(LapceColor::EDITOR_FOCUS)
+                    } else {
+                        config.color(LapceColor::EDITOR_DIM)
+                    })
+            }),
+            label(move || format!("Timeout: {}s", timeout.get()))
+                .on_click_stop(move |_| {
+                    timeout.update(|v| {
+                        *v = match *v {
+                            5 => 10,
+                            10 => 30,
+                            30 => 60,
+                            _ => 5,
+                        };
+                    });
+                })
+                .style(move |s| {
+                    let config = config.get();
+                    s.padding_horiz(6.0)
+                        .padding_vert(2.0)
+                        .border_radius(3.0)
+                        .cursor(CursorStyle::Pointer)
+                        .color(config.color(LapceColor::EDITOR_DIM))
+                }),
+        ))
+        .style(|s| {
+            s.flex_row()
+                .gap(4.0)
+                .items_center()
+                .padding_horiz(10.0)
+                .padding_vert(4.0)
+        }),
+    )
+    .style(move |s| {
+        let config = config.get();
+        s.width_full()
+            .border_bottom(1.0)
+            .border_color(config.color(LapceColor::LAPCE_BORDER))
+            .display(if kind.get() == PaletteKind::ShellFilter {
+                Display::Flex
+            } else {
+                Display::None
+            })
+    })
+}
+
 fn palette(window_tab_data: Rc<WindowTabData>) -> impl View {
     let layout_rect = window_tab_data.layout_rect.read_only();
     let palette_data = window_tab_data.palette.clone();
@@ -2793,6 +2870,7 @@ fn palette(window_tab_data: Rc<WindowTabData>) -> impl View {
     container(
         stack((
             palette_input(window_tab_data.clone()),
+            palette_shell_filter_options(window_tab_data.clone()),
             palette_content(window_tab_data.clone(), layout_rect),
             palette_preview(window_tab_data.clone()),
         ))

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -600,6 +600,10 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "add_run_debug_config")]
     #[strum(message = "Add Run Debug Config")]
     AddRunDebugConfig,
+
+    #[strum(serialize = "filter_through_shell")]
+    #[strum(message = "Filter Through Shell Command")]
+    FilterThroughShell,
 }
 
 #[derive(Clone, Debug)]
@@ -796,6 +800,17 @@ pub enum InternalCommand {
     },
     RestartTerminal {
         term_id: TermId,
+    },
+    FilterThroughShell {
+        command: String,
+        new_document: bool,
+        timeout_secs: u64,
+    },
+    FilterThroughShellResult {
+        output: String,
+        new_document: bool,
+        selection_start: usize,
+        selection_end: usize,
     },
 }
 

--- a/lapce-app/src/palette.rs
+++ b/lapce-app/src/palette.rs
@@ -93,7 +93,7 @@ pub struct PaletteData {
     pub items: RwSignal<im::Vector<PaletteItem>>,
     pub filtered_items: ReadSignal<im::Vector<PaletteItem>>,
     pub input: RwSignal<PaletteInput>,
-    kind: RwSignal<PaletteKind>,
+    pub kind: RwSignal<PaletteKind>,
     pub input_editor: EditorData,
     pub preview_editor: EditorData,
     pub has_preview: RwSignal<bool>,
@@ -107,6 +107,9 @@ pub struct PaletteData {
     pub source_control: SourceControlData,
     pub common: Rc<CommonData>,
     left_diff_path: RwSignal<Option<PathBuf>>,
+    pub shell_filter_history: Rc<RefCell<Vec<String>>>,
+    pub shell_filter_new_doc: RwSignal<bool>,
+    pub shell_filter_timeout: RwSignal<u64>,
 }
 
 impl std::fmt::Debug for PaletteData {
@@ -214,6 +217,8 @@ impl PaletteData {
 
         let clicked_index = cx.create_rw_signal(Option::<usize>::None);
         let left_diff_path = cx.create_rw_signal(None);
+        let shell_filter_new_doc = cx.create_rw_signal(false);
+        let shell_filter_timeout = cx.create_rw_signal(5);
 
         let palette = Self {
             run_id_counter,
@@ -238,6 +243,9 @@ impl PaletteData {
             source_control,
             common,
             left_diff_path,
+            shell_filter_history: Rc::new(RefCell::new(Vec::new())),
+            shell_filter_new_doc,
+            shell_filter_timeout,
         };
 
         {
@@ -354,6 +362,9 @@ impl PaletteData {
                     "Seleft left file"
                 }
             }
+            PaletteKind::ShellFilter => {
+                "Type a shell command or select from history"
+            }
             _ => "",
         }
     }
@@ -416,6 +427,7 @@ impl PaletteData {
                 self.get_scm_references();
             }
             PaletteKind::TerminalProfile => self.get_terminal_profiles(),
+            PaletteKind::ShellFilter => self.get_shell_filter_commands(),
         }
     }
 
@@ -818,6 +830,42 @@ impl PaletteData {
             })
             .collect();
         self.items.set(items);
+    }
+
+    fn get_shell_filter_commands(&self) {
+        let history = self.shell_filter_history.borrow();
+        let items = history
+            .iter()
+            .map(|cmd| PaletteItem {
+                content: PaletteItemContent::ShellFilterCommand {
+                    command: cmd.clone(),
+                },
+                filter_text: cmd.clone(),
+                score: 0,
+                indices: vec![],
+            })
+            .collect();
+        self.items.set(items);
+    }
+
+    fn execute_shell_filter(&self, command: String) {
+        {
+            let mut history = self.shell_filter_history.borrow_mut();
+            history.retain(|c| c != &command);
+            history.insert(0, command.clone());
+            history.truncate(50);
+        }
+
+        let new_document = self.shell_filter_new_doc.get_untracked();
+        let timeout_secs = self.shell_filter_timeout.get_untracked();
+
+        self.common.internal_command.send(
+            InternalCommand::FilterThroughShell {
+                command,
+                new_document,
+                timeout_secs,
+            },
+        );
     }
 
     #[cfg(windows)]
@@ -1329,6 +1377,9 @@ impl PaletteData {
                     .send(InternalCommand::NewTerminal {
                         profile: Some(profile.to_owned()),
                     }),
+                PaletteItemContent::ShellFilterCommand { command } => {
+                    self.execute_shell_filter(command.clone());
+                }
             }
         } else if self.kind.get_untracked() == PaletteKind::SshHost {
             let input = self.input.with_untracked(|input| input.input.clone());
@@ -1342,6 +1393,11 @@ impl PaletteData {
                     },
                 },
             );
+        } else if self.kind.get_untracked() == PaletteKind::ShellFilter {
+            let input = self.input.with_untracked(|input| input.input.clone());
+            if !input.is_empty() {
+                self.execute_shell_filter(input);
+            }
         }
     }
 
@@ -1461,6 +1517,7 @@ impl PaletteData {
                     }),
                 PaletteItemContent::SCMReference { .. } => {}
                 PaletteItemContent::TerminalProfile { .. } => {}
+                PaletteItemContent::ShellFilterCommand { .. } => {}
             }
         }
     }

--- a/lapce-app/src/palette/item.rs
+++ b/lapce-app/src/palette/item.rs
@@ -84,4 +84,7 @@ pub enum PaletteItemContent {
         name: String,
         profile: lapce_rpc::terminal::TerminalProfile,
     },
+    ShellFilterCommand {
+        command: String,
+    },
 }

--- a/lapce-app/src/palette/kind.rs
+++ b/lapce-app/src/palette/kind.rs
@@ -24,6 +24,7 @@ pub enum PaletteKind {
     TerminalProfile,
     DiffFiles,
     HelpAndFile,
+    ShellFilter,
 }
 
 impl PaletteKind {
@@ -48,7 +49,8 @@ impl PaletteKind {
             | PaletteKind::LineEnding
             | PaletteKind::SCMReferences
             | PaletteKind::HelpAndFile
-            | PaletteKind::DiffFiles => "",
+            | PaletteKind::DiffFiles
+            | PaletteKind::ShellFilter => "",
             #[cfg(windows)]
             PaletteKind::WslHost => "",
         }
@@ -103,6 +105,9 @@ impl PaletteKind {
             }
             PaletteKind::TerminalProfile => None, // InternalCommand::NewTerminal
             PaletteKind::DiffFiles => Some(LapceWorkbenchCommand::DiffFiles),
+            PaletteKind::ShellFilter => {
+                Some(LapceWorkbenchCommand::FilterThroughShell)
+            }
         }
     }
 
@@ -130,7 +135,8 @@ impl PaletteKind {
             | PaletteKind::Language
             | PaletteKind::LineEnding
             | PaletteKind::SCMReferences | PaletteKind::HelpAndFile
-            | PaletteKind::DiffFiles => input,
+            | PaletteKind::DiffFiles
+            | PaletteKind::ShellFilter => input,
             PaletteKind::PaletteHelp
             | PaletteKind::Command
             | PaletteKind::Workspace

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -31,9 +31,11 @@ use im::HashMap;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use lapce_core::{
-    command::FocusCommand, cursor::CursorAffinity, directory::Directory, meta,
-    mode::Mode, register::Register,
+    command::FocusCommand, cursor::CursorAffinity, cursor::CursorMode,
+    directory::Directory, editor::EditType, meta, mode::Mode, register::Register,
+    selection::Selection,
 };
+use lapce_xi_rope::Rope;
 use lapce_rpc::{
     RpcError,
     core::CoreNotification,
@@ -1573,6 +1575,9 @@ impl WindowTabData {
                     editor_data.receive_char(DEFAULT_RUN_TOML);
                 }
             }
+            FilterThroughShell => {
+                self.palette.run(PaletteKind::ShellFilter);
+            }
 
         }
     }
@@ -2069,6 +2074,132 @@ impl WindowTabData {
             }
             InternalCommand::CallHierarchyIncoming { item_id } => {
                 self.call_hierarchy_incoming(item_id);
+            }
+            InternalCommand::FilterThroughShell {
+                command,
+                new_document,
+                timeout_secs,
+            } => {
+                let editor = match self.main_split.active_editor.get_untracked() {
+                    Some(e) => e,
+                    None => return,
+                };
+                let doc = editor.doc();
+                let cursor = editor.cursor().get_untracked();
+
+                let (selection_text, sel_start, sel_end) = match &cursor.mode {
+                    CursorMode::Insert(sel) => {
+                        let regions = sel.regions();
+                        if regions.len() != 1 {
+                            return;
+                        }
+                        let region = &regions[0];
+                        if region.is_caret() {
+                            (String::new(), region.start, region.start)
+                        } else {
+                            let text = doc.buffer.with_untracked(|b| {
+                                b.slice_to_cow(region.min()..region.max())
+                                    .to_string()
+                            });
+                            (text, region.min(), region.max())
+                        }
+                    }
+                    CursorMode::Normal(offset) => {
+                        (String::new(), *offset, *offset)
+                    }
+                    CursorMode::Visual { start, end, .. } => {
+                        let min = *start.min(end);
+                        let max = doc.buffer.with_untracked(|b| {
+                            b.next_grapheme_offset(
+                                *start.max(end),
+                                1,
+                                b.len(),
+                            )
+                        });
+                        let text = doc.buffer.with_untracked(|b| {
+                            b.slice_to_cow(min..max).to_string()
+                        });
+                        (text, min, max)
+                    }
+                };
+
+                let internal_command = self.common.internal_command;
+                let send = create_ext_action(
+                    cx,
+                    move |result: Result<ProxyResponse, RpcError>| {
+                        match result {
+                            Ok(ProxyResponse::FilterThroughShellResponse {
+                                stdout,
+                                success,
+                            }) => {
+                                if !success {
+                                    internal_command.send(
+                                        InternalCommand::ShowAlert {
+                                            title: "Shell command failed"
+                                                .to_string(),
+                                            msg: "Command exited with non-zero status".to_string(),
+                                            buttons: vec![],
+                                        },
+                                    );
+                                }
+                                let output = stdout;
+                                internal_command.send(
+                                    InternalCommand::FilterThroughShellResult {
+                                        output,
+                                        new_document,
+                                        selection_start: sel_start,
+                                        selection_end: sel_end,
+                                    },
+                                );
+                            }
+                            Err(e) => {
+                                internal_command.send(
+                                    InternalCommand::ShowAlert {
+                                        title: "Shell command error".to_string(),
+                                        msg: e.message,
+                                        buttons: vec![],
+                                    },
+                                );
+                            }
+                            _ => {}
+                        }
+                    },
+                );
+
+                self.common.proxy.filter_through_shell(
+                    command,
+                    selection_text,
+                    timeout_secs,
+                    Box::new(move |result| {
+                        send(result);
+                    }),
+                );
+            }
+            InternalCommand::FilterThroughShellResult {
+                output,
+                new_document,
+                selection_start,
+                selection_end,
+            } => {
+                if new_document {
+                    self.main_split.new_file();
+                    if let Some(editor) =
+                        self.main_split.active_editor.get_untracked()
+                    {
+                        let doc = editor.doc();
+                        doc.reload(Rope::from(&output), true);
+                    }
+                } else if let Some(editor) =
+                    self.main_split.active_editor.get_untracked()
+                {
+                    let doc = editor.doc();
+                    let selection =
+                        Selection::region(selection_start, selection_end);
+                    doc.do_raw_edit(
+                        &[(&selection, output.as_str())],
+                        EditType::Completion,
+                    );
+                }
             }
         }
     }

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -1,7 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
     fs, io,
+    io::Write as _,
     path::{Path, PathBuf},
+    process::Stdio,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -1204,6 +1206,21 @@ impl ProxyHandler for Dispatcher {
                 let resp = ProxyResponse::ReferencesResolveResponse { items };
                 self.proxy_rpc.handle_response(id, Ok(resp));
             }
+            FilterThroughShell {
+                command,
+                stdin_content,
+                timeout_secs,
+            } => {
+                let proxy_rpc = self.proxy_rpc.clone();
+                thread::spawn(move || {
+                    let result = run_shell_filter(
+                        &command,
+                        &stdin_content,
+                        timeout_secs,
+                    );
+                    proxy_rpc.handle_response(id, result);
+                });
+            }
         }
     }
 }
@@ -1758,4 +1775,75 @@ fn search_in_path(
     }
 
     Ok(ProxyResponse::GlobalSearchResponse { matches })
+}
+
+fn run_shell_filter(
+    command: &str,
+    stdin_content: &str,
+    timeout_secs: u64,
+) -> Result<ProxyResponse, RpcError> {
+    #[cfg(not(windows))]
+    let mut child = std::process::Command::new("sh")
+        .args(["-c", command])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| RpcError {
+            code: 0,
+            message: format!("Failed to spawn shell: {e}"),
+        })?;
+
+    #[cfg(windows)]
+    let mut child = std::process::Command::new("cmd")
+        .args(["/C", command])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| RpcError {
+            code: 0,
+            message: format!("Failed to spawn shell: {e}"),
+        })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(stdin_content.as_bytes());
+    }
+
+    let timeout = Duration::from_secs(timeout_secs);
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let output = child.wait_with_output().map_err(|e| RpcError {
+                    code: 0,
+                    message: format!("Failed to read output: {e}"),
+                })?;
+                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                return Ok(ProxyResponse::FilterThroughShellResponse {
+                    stdout,
+                    success: status.success(),
+                });
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(RpcError {
+                        code: 0,
+                        message: format!(
+                            "Command timed out after {timeout_secs} seconds"
+                        ),
+                    });
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                return Err(RpcError {
+                    code: 0,
+                    message: format!("Error waiting for process: {e}"),
+                });
+            }
+        }
+    }
 }

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -220,6 +220,11 @@ pub enum ProxyRequest {
     ReferencesResolve {
         items: Vec<Location>,
     },
+    FilterThroughShell {
+        command: String,
+        stdin_content: String,
+        timeout_secs: u64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -467,6 +472,10 @@ pub enum ProxyResponse {
     SaveResponse {},
     ReferencesResolveResponse {
         items: Vec<FileLine>,
+    },
+    FilterThroughShellResponse {
+        stdout: String,
+        success: bool,
     },
 }
 
@@ -1210,6 +1219,23 @@ impl ProxyRpcHandler {
         f: impl ProxyCallback + 'static,
     ) {
         self.request_async(ProxyRequest::DapGetScopes { dap_id, frame_id }, f);
+    }
+
+    pub fn filter_through_shell(
+        &self,
+        command: String,
+        stdin_content: String,
+        timeout_secs: u64,
+        f: impl ProxyCallback + 'static,
+    ) {
+        self.request_async(
+            ProxyRequest::FilterThroughShell {
+                command,
+                stdin_content,
+                timeout_secs,
+            },
+            f,
+        );
     }
 }
 


### PR DESCRIPTION
- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users

**Summary**

  - Add a command to pipe the current editor selection through an external shell command (stdin → command → stdout replaces selection)
  - Works with local and remote (SSH) workspaces — command execution goes through the proxy RPC
  - Supports single selection only (Insert, Normal, and Visual cursor modes)
  - Palette-based UI with command history and configurable options (output to new document, timeout)

  **Details**

  New command "Filter Through Shell Command" accessible via the command palette. When triggered, a palette opens where the user can type a shell command or pick from previously used ones. The current selection is sent as stdin to the command, and stdout replaces the selection. If nothing is selected, stdout is inserted at the cursor position.

  Options available as toggles in the palette UI:
  - New document — output to a new scratch document instead of replacing the selection
  - Timeout — configurable timeout (5/10/30/60 seconds, default 5s)

  **Files changed**

  - lapce-rpc/src/proxy.rs — new FilterThroughShell request/response in the RPC protocol
  - lapce-proxy/src/dispatch.rs — shell execution handler with timeout (cross-platform: sh -c / cmd /C)
  - lapce-app/src/command.rs — workbench command and internal command variants
  - lapce-app/src/palette/kind.rs, item.rs — new palette kind and item type
  - lapce-app/src/palette.rs — command history, option signals, palette population and selection logic
  - lapce-app/src/window_tab.rs — command dispatch, async RPC bridge, selection replacement / new document creation
  - lapce-app/src/app.rs — palette item rendering and options toggle row