### PR TITLE
feat: implement follow system theme with Wayland support

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -7,6 +7,9 @@ icon-theme = "Lapce Codicons"
 custom-titlebar = true
 file-explorer-double-click = false
 auto-reload-plugin = false
+follow-system-theme = false
+color-theme-dark = "Lapce Dark"
+color-theme-light = "Lapce Light"
 
 [editor]
 font-family = "monospace"

--- a/extra/schemas/settings.json
+++ b/extra/schemas/settings.json
@@ -176,6 +176,18 @@
                 },
                 "custom-titlebar": {
                     "type": "boolean"
+                },
+                "follow-system-theme": {
+                    "type": "boolean",
+                    "description": "Automatically switch color theme based on system appearance"
+                },
+                "color-theme-dark": {
+                    "type": "string",
+                    "description": "Color theme to use in dark mode (when follow_system_theme is enabled)"
+                },
+                "color-theme-light": {
+                    "type": "string",
+                    "description": "Color theme to use in light mode (when follow_system_theme is enabled)"
                 }
             },
             "required": [],

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -48,7 +48,7 @@ use floem::{
         scroll::{PropagatePointerWheel, VerticalScrollAsHorizontal, scroll},
         stack, svg, tab, text, tooltip, virtual_stack,
     },
-    window::{ResizeDirection, WindowConfig, WindowId},
+    window::{ResizeDirection, Theme, WindowConfig, WindowId},
 };
 use lapce_core::{
     command::{EditCommand, FocusCommand},
@@ -74,8 +74,8 @@ use crate::{
         WindowCommand,
     },
     config::{
-        LapceConfig, color::LapceColor, icon::LapceIcons, ui::TabSeparatorHeight,
-        watcher::ConfigWatcher,
+        LapceConfig, color::LapceColor, detect_linux_system_theme, icon::LapceIcons,
+        set_system_theme, ui::TabSeparatorHeight, watcher::ConfigWatcher,
     },
     db::LapceDb,
     debug::RunDebugMode,
@@ -169,6 +169,7 @@ pub struct AppData {
     pub watcher: Arc<notify::RecommendedWatcher>,
     pub tracing_handle: Handle<Targets>,
     pub config: RwSignal<Arc<LapceConfig>>,
+    pub os_theme: RwSignal<Option<floem::window::Theme>>,
     /// Paths to extra plugins to load
     pub plugin_paths: Arc<Vec<PathBuf>>,
 }
@@ -185,6 +186,13 @@ impl AppData {
         for (_, window) in windows {
             window.reload_config();
         }
+    }
+
+    pub fn handle_system_theme_change(&self, theme: Theme) {
+        tracing::info!("system theme changed: {:?}", theme);
+        set_system_theme(matches!(theme, Theme::Dark));
+        self.os_theme.set(Some(theme));
+        self.reload_config();
     }
 
     pub fn active_window_tab(&self) -> Option<Rc<WindowTabData>> {
@@ -501,6 +509,7 @@ impl AppData {
         let position = window_data.position;
         let window_scale = window_data.window_scale;
         let app_command = window_data.app_command;
+        let app_data = self.clone();
         let config = window_data.config;
         // The KeyDown and PointerDown event handlers both need ownership of a WindowData object.
         let key_down_window_data = window_data.clone();
@@ -644,6 +653,11 @@ impl AppData {
             .on_event_stop(EventListener::WindowMoved, move |event| {
                 if let Event::WindowMoved(point) = event {
                     position.set(*point);
+                }
+            })
+            .on_event_stop(EventListener::ThemeChanged, move |event| {
+                if let Event::ThemeChanged(theme) = event {
+                    app_data.handle_system_theme_change(*theme);
                 }
             })
             .on_event_stop(EventListener::WindowGotFocus, move |_| {
@@ -3864,12 +3878,20 @@ pub fn launch() {
     }
 
     let windows = scope.create_rw_signal(im::HashMap::new());
+
+    #[cfg(target_os = "linux")]
+    if let Some(dark) = detect_linux_system_theme() {
+        set_system_theme(dark);
+    }
+
     let config = LapceConfig::load(&LapceWorkspace::default(), &[], &plugin_paths);
 
     // Restore scale from config
     window_scale.set(config.ui.scale());
 
     let config = scope.create_rw_signal(Arc::new(config));
+    let os_theme = scope.create_rw_signal(None);
+
     let app_data = AppData {
         windows,
         active_window: scope.create_rw_signal(WindowId::from_raw(0)),
@@ -3880,6 +3902,7 @@ pub fn launch() {
         app_command,
         tracing_handle: reload_handle,
         config,
+        os_theme,
         plugin_paths,
     };
 
@@ -4011,6 +4034,40 @@ pub fn launch() {
         app_data.app_command.listen(move |command| {
             app_data.run_app_command(command);
         });
+    }
+
+    // Poll system theme as fallback for Wayland (Event::ThemeChanged doesn't fire there)
+    #[cfg(target_os = "linux")]
+    {
+        let (tx, rx) = sync_channel(1);
+        let signal = create_signal_from_channel(rx);
+        let app_data = app_data.clone();
+        create_effect(move |_| {
+            if let Some(dark) = signal.get() {
+                if !app_data.config.get_untracked().core.follow_system_theme {
+                    return;
+                }
+                let current = app_data.os_theme.get_untracked();
+                let want = if dark { Theme::Dark } else { Theme::Light };
+                if current != Some(want) {
+                    app_data.handle_system_theme_change(want);
+                }
+            }
+        });
+        std::thread::Builder::new()
+            .name("SystemThemePoller".to_owned())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    let dark = detect_linux_system_theme();
+                    if let Some(dark) = dark {
+                        if tx.send(dark).is_err() {
+                            break;
+                        }
+                    }
+                }
+            })
+            .unwrap();
     }
 
     app.on_event(move |event| match event {

--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
+    sync::atomic::{AtomicU8, Ordering},
 };
 
 use ::core::slice;
@@ -40,6 +41,81 @@ pub mod svg;
 pub mod terminal;
 pub mod ui;
 pub mod watcher;
+
+const THEME_UNKNOWN: u8 = 0;
+const THEME_LIGHT: u8 = 1;
+const THEME_DARK: u8 = 2;
+
+static SYSTEM_THEME: AtomicU8 = AtomicU8::new(THEME_UNKNOWN);
+
+pub fn set_system_theme(dark: bool) {
+    SYSTEM_THEME.store(
+        if dark { THEME_DARK } else { THEME_LIGHT },
+        Ordering::Relaxed,
+    );
+}
+
+fn system_is_dark() -> Option<bool> {
+    match SYSTEM_THEME.load(Ordering::Relaxed) {
+        THEME_DARK => Some(true),
+        THEME_LIGHT => Some(false),
+        _ => None,
+    }
+}
+
+/// Detect system dark/light preference on Linux (Wayland compat).
+/// Tries: gsettings, GTK settings.ini, GTK theme name.
+pub fn detect_linux_system_theme() -> Option<bool> {
+    let home = std::env::var("HOME").ok()?;
+
+    // gsettings (GNOME)
+    if let Ok(output) = std::process::Command::new("gsettings")
+        .args(["get", "org.gnome.desktop.interface", "color-scheme"])
+        .output()
+    {
+        let s = String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .trim_matches('\'')
+            .to_string();
+        match s.as_str() {
+            "prefer-dark" => return Some(true),
+            "prefer-light" => return Some(false),
+            _ => {}
+        }
+    }
+
+    // GTK 3/4 settings.ini: gtk-application-prefer-dark-theme
+    for path in [
+        format!("{home}/.config/gtk-4.0/settings.ini"),
+        format!("{home}/.config/gtk-3.0/settings.ini"),
+    ] {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if content.contains("gtk-application-prefer-dark-theme=1") {
+                return Some(true);
+            }
+        }
+    }
+
+    // GTK theme name contains "-dark"
+    for path in [
+        format!("{home}/.config/gtk-4.0/settings.ini"),
+        format!("{home}/.config/gtk-3.0/settings.ini"),
+    ] {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            for line in content.lines() {
+                if line.starts_with("gtk-theme-name") {
+                    let val =
+                        line.split('=').nth(1).unwrap_or("").trim().to_lowercase();
+                    if val.contains("-dark") || val == "adwaita-dark" {
+                        return Some(true);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
 
 pub const LOGO: &str = include_str!("../../extra/images/logo.svg");
 const DEFAULT_SETTINGS: &str = include_str!("../../defaults/settings.toml");
@@ -148,6 +224,20 @@ impl LapceConfig {
         lapce_config.available_icon_themes =
             Self::load_icon_themes(disabled_volts, extra_plugin_paths);
         lapce_config.resolve_theme(workspace);
+
+        if lapce_config.core.follow_system_theme {
+            if let Some(is_dark) = system_is_dark() {
+                let target = if is_dark {
+                    lapce_config.core.color_theme_dark.clone()
+                } else {
+                    lapce_config.core.color_theme_light.clone()
+                };
+                tracing::info!(
+                    "applying system theme override: is_dark={is_dark}, target={target}"
+                );
+                lapce_config.override_color_theme(workspace, &target);
+            }
+        }
 
         lapce_config.color_theme_list = lapce_config
             .available_color_themes
@@ -333,6 +423,14 @@ impl LapceConfig {
     pub fn set_color_theme(&mut self, workspace: &LapceWorkspace, theme: &str) {
         self.core.color_theme = theme.to_string();
         self.resolve_theme(workspace);
+    }
+
+    /// Override the color theme without persisting.
+    /// Used by system theme follow mode.
+    pub fn override_color_theme(&mut self, workspace: &LapceWorkspace, theme: &str) {
+        self.core.color_theme = theme.to_string();
+        self.resolve_theme(workspace);
+        self.core.color_theme = theme.to_string();
     }
 
     /// Set the active icon theme.  

--- a/lapce-app/src/config/core.rs
+++ b/lapce-app/src/config/core.rs
@@ -22,4 +22,16 @@ pub struct CoreConfig {
         desc = "Enable auto-reload for the plugin when its configuration changes."
     )]
     pub auto_reload_plugin: bool,
+    #[field_names(
+        desc = "Automatically switch color theme based on system appearance"
+    )]
+    pub follow_system_theme: bool,
+    #[field_names(
+        desc = "Color theme to use in dark mode (when follow_system_theme is enabled)"
+    )]
+    pub color_theme_dark: String,
+    #[field_names(
+        desc = "Color theme to use in light mode (when follow_system_theme is enabled)"
+    )]
+    pub color_theme_light: String,
 }


### PR DESCRIPTION
## Summary

Adds `follow-system-theme` setting that automatically switches Lapce's color theme based on OS dark/light mode preference. Users can configure which theme to use for each mode via `color-theme-dark` and `color-theme-light`.

## Changes

### New settings (CoreConfig)
- `follow_system_theme` (bool, default `false`) — enables system theme following
- `color_theme_dark` (string, default `"Lapce Dark"`) — theme for dark mode
- `color_theme_light` (string, default `"Lapce Light"`) — theme for light mode

### Theme detection
- **X11/macOS/Windows**: listens for `Event::ThemeChanged` from winit (via floem)
- **Wayland (Linux)**: polls GTK settings every 5s (`gsettings` or `~/.config/gtk-{3,4}.0/settings.ini`)
- Initial detection at startup via Linux GTK config parsing
- Atomic static `SYSTEM_THEME` stores detected state; all `LapceConfig::load()` calls automatically apply override

### Config plumbing
- `override_color_theme()` — in-memory theme switch without persisting to settings file
- Modified `LapceConfig::load()` to apply system theme override after normal resolution
- `AppData::handle_system_theme_change()` — handles theme change events
- `AppData::os_theme` signal tracks current OS theme

## Related Issues

Closes #3900 — Feature request: Follow system theme
Closes #1324 — Feature request: match system theme (duplicate)
Refs #3903 — PRD: Follow system theme (auto mode)
Refs #3904 — System theme detection module
Refs #3905 — Auto-mode theme resolution + 'auto' in theme picker
Refs #3906 — Runtime system theme watcher in app.rs
Related: #502 — Window border is white in dark mode on Fedora 36 (Wayland)
Related: #2386 — titlebar color not changing
Related: #3626 — Font colors in Lapce Light mode

## Testing
1. Set `follow-system-theme = true` in settings, optionally `color-theme-dark`/`color-theme-light`
2. Change system dark/light mode — Lapce follows
3. Tested on Wayland via GTK config polling
4. Works alongside existing theme picker (follow mode overrides in-memory)