### PR TITLE
Fix panic when dragging the terminal panel to another dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Fix panic when dragging the terminal panel to another dock area (<https://github.com/lapce/lapce/issues/3338>)
+
 ## 0.4.6
 
 ### Features/Changes

--- a/lapce-app/src/panel/terminal_view.rs
+++ b/lapce-app/src/panel/terminal_view.rs
@@ -274,7 +274,6 @@ fn terminal_tab_split(
     let internal_command = terminal_panel_data.common.internal_command;
     let workspace = terminal_panel_data.workspace.clone();
     let active = terminal_tab_data.active;
-    let terminal_tab_scope = terminal_tab_data.scope;
     dyn_stack(
         move || {
             let terminals = terminal_tab_data.terminals.get();
@@ -288,7 +287,6 @@ fn terminal_tab_split(
         |(_, terminal)| terminal.term_id,
         move |(index, terminal)| {
             let terminal_panel_data = terminal_panel_data.clone();
-            let terminal_scope = terminal.scope;
             container({
                 let terminal_view = terminal_view(
                     terminal.term_id,
@@ -325,9 +323,6 @@ fn terminal_tab_split(
                             EventPropagation::Continue
                         }
                     })
-                    .on_cleanup(move || {
-                        terminal_scope.dispose();
-                    })
                     .style(|s| s.size_pct(100.0, 100.0))
             })
             .style(move |s| {
@@ -342,9 +337,6 @@ fn terminal_tab_split(
             })
         },
     )
-    .on_cleanup(move || {
-        terminal_tab_scope.dispose();
-    })
     .style(|s| s.size_pct(100.0, 100.0))
 }
 

--- a/lapce-app/src/terminal/panel.rs
+++ b/lapce-app/src/terminal/panel.rs
@@ -224,39 +224,27 @@ impl TerminalPanelData {
     }
 
     pub fn close_tab(&self, terminal_tab_id: Option<TerminalTabId>) {
-        if let Some(close_tab) = self
+        let closed_tab = self
             .tab_info
             .try_update(|info| {
-                let mut close_tab = None;
-                if let Some(terminal_tab_id) = terminal_tab_id {
-                    if let Some(index) =
-                        info.tabs.iter().enumerate().find_map(|(index, (_, t))| {
-                            if t.terminal_tab_id == terminal_tab_id {
-                                Some(index)
-                            } else {
-                                None
-                            }
-                        })
-                    {
-                        close_tab = Some(
-                            info.tabs.remove(index).1.terminals.get_untracked(),
-                        );
-                    }
+                let closed_tab = if let Some(terminal_tab_id) = terminal_tab_id {
+                    info.tabs
+                        .iter()
+                        .position(|(_, t)| t.terminal_tab_id == terminal_tab_id)
+                        .map(|index| info.tabs.remove(index).1)
                 } else {
                     let active = info.active.min(info.tabs.len().saturating_sub(1));
-                    if !info.tabs.is_empty() {
-                        info.tabs.remove(active);
-                    }
-                }
-                let new_active = info.active.min(info.tabs.len().saturating_sub(1));
-                info.active = new_active;
-                close_tab
+                    (!info.tabs.is_empty()).then(|| info.tabs.remove(active).1)
+                };
+                info.active = info.active.min(info.tabs.len().saturating_sub(1));
+                closed_tab
             })
-            .flatten()
-        {
-            for (_, data) in close_tab {
+            .flatten();
+        if let Some(tab) = closed_tab {
+            for (_, data) in tab.terminals.get_untracked() {
                 data.stop();
             }
+            tab.scope.dispose();
         }
         self.update_debug_active_term();
     }
@@ -356,16 +344,17 @@ impl TerminalPanelData {
     pub fn close_terminal(&self, term_id: &TermId) {
         if let Some((_, tab, index, _)) = self.get_terminal_in_tab(term_id) {
             let active = tab.active.get_untracked();
-            let len = tab
+            let (len, removed) = tab
                 .terminals
                 .try_update(|terminals| {
-                    terminals.remove(index);
-                    terminals.len()
+                    let removed = terminals.remove(index);
+                    (terminals.len(), removed)
                 })
                 .unwrap();
             if len == 0 {
                 self.close_tab(Some(tab.terminal_tab_id));
             } else {
+                removed.1.scope.dispose();
                 let new_active = active.min(len.saturating_sub(1));
                 if new_active != active {
                     tab.active.set(new_active);


### PR DESCRIPTION
## Summary

Dragging the terminal panel from one dock to another (e.g. bottom → right) crashes Lapce with `called Option::unwrap() on a None value` in floem's reactive layer. Fixes #3338 (open since June 2024).

## Cause

The terminal view's `on_cleanup` disposes scopes that are owned by the persistent terminal *data* model (`TerminalTabData::scope` and `TerminalData::scope`), not by the view itself. floem runs `on_cleanup` whenever a view leaves the tree — including when it is re-parented. Moving the terminal panel to another dock therefore disposes the scope of still-live data, and rebuilding the panel in its new dock reads signals from the now-disposed scope, panicking.

## Fix

Tie scope disposal to the data lifecycle instead of the view lifecycle:

- Dispose the terminal scope in `close_terminal`, and the tab scope in `close_tab` (the tab scope is the parent of its terminals' scopes, so disposing it cascades).
- Stop disposing those scopes from the terminal view's `on_cleanup`.

This also makes the no-id branch of `close_tab` stop its terminals before dropping them, which it previously skipped.

## Verification

- On `master`: dragging the terminal panel bottom → right crashes with `Option::unwrap() on a None value` (floem `reactive/src/read.rs`), matching #3338.
- With this change: the same drag relocates the panel without crashing.

- [x] Added an entry to `CHANGELOG.md`

## Notes

- There appears to be a separate, pre-existing issue where the terminal contents don't repaint until interaction after relocating; that looks like a floem compositing matter and is out of scope here.
- While investigating I looked at bumping floem to current `master` — it's a sizeable port (~368 compile errors from API changes across events, menus, layout, scroll and the renderer split). If a floem upgrade is on the roadmap, I'm happy to help with the migration.
