### PR TITLE
feat: add keyboard shortcut to toggle word wrap

### DIFF
--- a/defaults/keymaps-common.toml
+++ b/defaults/keymaps-common.toml
@@ -4,6 +4,10 @@
 key = "F1"
 command = "palette.command"
 
+[[keymaps]]
+key = "alt+z"
+command = "toggle_word_wrap"
+
 # [[keymaps]]
 # key = "ctrl+q"
 # command = "quit"

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -544,6 +544,10 @@ pub enum LapceWorkbenchCommand {
     #[strum(message = "Toggle Inlay Hints")]
     ToggleInlayHints,
 
+    #[strum(serialize = "toggle_word_wrap")]
+    #[strum(message = "Toggle Word Wrap")]
+    ToggleWordWrap,
+
     #[strum(serialize = "restart_to_update")]
     RestartToUpdate,
 

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -60,7 +60,7 @@ use crate::{
         LapceWorkbenchCommand, WindowCommand,
     },
     completion::{CompletionData, CompletionStatus},
-    config::LapceConfig,
+    config::{editor::WrapStyle, LapceConfig},
     db::LapceDb,
     debug::{DapData, LapceBreakpoint, RunDebugMode, RunDebugProcess},
     doc::DocContent,
@@ -926,6 +926,19 @@ impl WindowTabData {
                 self.main_split.export_theme();
             }
             ToggleInlayHints => {}
+            ToggleWordWrap => {
+                let wrap_style =
+                    self.common.config.get_untracked().editor.wrap_style;
+                let new_wrap_style = match wrap_style {
+                    WrapStyle::None => WrapStyle::EditorWidth,
+                    _ => WrapStyle::None,
+                };
+                LapceConfig::update_file(
+                    "editor",
+                    "wrap-style",
+                    toml_edit::Value::from(new_wrap_style.as_str()),
+                );
+            }
 
             // ==== Window ====
             ReloadWindow => {


### PR DESCRIPTION
## Summary
Adds a `toggle_word_wrap` workbench command bound to <kbd>Alt</kbd>+<kbd>Z</kbd> that flips the editor wrap style between `none` and `editor-width`. The command is also discoverable via the command palette ("Toggle Word Wrap").

## Details
- `lapce-app/src/command.rs` — new `ToggleWordWrap` workbench command.
- `lapce-app/src/window_tab.rs` — handler reads the current `editor.wrap_style` and toggles it (`None` → `EditorWidth`, otherwise → `None`), persisting the change to the user settings file. The config file is watched, so it applies live.
- `defaults/keymaps-common.toml` — binds <kbd>Alt</kbd>+<kbd>Z</kbd> to `toggle_word_wrap` (matches VS Code; no conflict with existing bindings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)