### PR TITLE
Add native GitHub Copilot inline completion support

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -7,6 +7,8 @@ icon-theme = "Lapce Codicons"
 custom-titlebar = true
 file-explorer-double-click = false
 auto-reload-plugin = false
+enable-copilot = false
+copilot-server-path = "copilot-language-server"
 
 [editor]
 font-family = "monospace"

--- a/lapce-app/src/command.rs
+++ b/lapce-app/src/command.rs
@@ -600,6 +600,18 @@ pub enum LapceWorkbenchCommand {
     #[strum(serialize = "add_run_debug_config")]
     #[strum(message = "Add Run Debug Config")]
     AddRunDebugConfig,
+
+    #[strum(serialize = "copilot_sign_in")]
+    #[strum(message = "Copilot: Sign In")]
+    CopilotSignIn,
+
+    #[strum(serialize = "copilot_sign_out")]
+    #[strum(message = "Copilot: Sign Out")]
+    CopilotSignOut,
+
+    #[strum(serialize = "copilot_status")]
+    #[strum(message = "Copilot: Check Status")]
+    CopilotStatus,
 }
 
 #[derive(Clone, Debug)]

--- a/lapce-app/src/config/core.rs
+++ b/lapce-app/src/config/core.rs
@@ -22,4 +22,12 @@ pub struct CoreConfig {
         desc = "Enable auto-reload for the plugin when its configuration changes."
     )]
     pub auto_reload_plugin: bool,
+    #[field_names(
+        desc = "Enable GitHub Copilot inline completions (requires copilot-language-server and signing in)"
+    )]
+    pub enable_copilot: bool,
+    #[field_names(
+        desc = "Path or command used to launch the Copilot language server (copilot-language-server)"
+    )]
+    pub copilot_server_path: String,
 }

--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -1447,7 +1447,7 @@ impl Doc {
             return;
         };
 
-        let (line, col) = self.completion_pos.get_untracked();
+        let (line, col) = self.inline_completion_pos.get_untracked();
         let offset = self
             .buffer
             .with_untracked(|b| b.offset_of_line_col(line, col));

--- a/lapce-app/src/editor.rs
+++ b/lapce-app/src/editor.rs
@@ -1667,9 +1667,16 @@ impl EditorData {
         }
 
         let path2 = path.clone();
+        let cursor = self.cursor();
         let send = create_ext_action(
             self.scope,
             move |items: Vec<lsp_types::InlineCompletionItem>| {
+                // The completion request is async, so re-read the cursor when the
+                // response arrives. If the user kept typing, the items are stored
+                // and the ghost text is positioned against where the cursor is now
+                // rather than where it was when the request was sent; the prefix
+                // stripping then matches the text typed so far.
+                let offset = cursor.with_untracked(|c| c.offset());
                 let items = doc.buffer.with_untracked(|buffer| {
                     items
                         .into_iter()

--- a/lapce-app/src/inline_completion.rs
+++ b/lapce-app/src/inline_completion.rs
@@ -179,14 +179,22 @@ impl InlineCompletionData {
         };
 
         let item = &self.items[active];
-        let text = item.insert_text.clone();
+        let text = doc.buffer.with_untracked(|buffer| buffer.text().clone());
+        let text = RopeTextRef::new(&text);
+        let completion = inline_completion_text(text, offset, offset, item, None);
 
-        // TODO: is range really meant to be used for this?
-        let offset = item.range.as_ref().map(|r| r.start).unwrap_or(offset);
-        let (line, col) = doc
-            .buffer
-            .with_untracked(|buffer| buffer.offset_to_line_col(offset));
-        doc.set_inline_completion(text, line, col);
+        match completion {
+            ICompletionRes::Set(text, shift) => {
+                let offset = offset + shift;
+                let (line, col) = doc
+                    .buffer
+                    .with_untracked(|buffer| buffer.offset_to_line_col(offset));
+                doc.set_inline_completion(text, line, col);
+            }
+            ICompletionRes::Hide | ICompletionRes::Unchanged => {
+                doc.clear_inline_completion();
+            }
+        }
     }
 
     pub fn update_inline_completion(
@@ -272,7 +280,8 @@ fn inline_completion_text(
         }
     };
 
-    let range = start_offset..rope_text.offset_line_end(start_offset, true);
+    let start_offset = item.range.as_ref().map(|r| r.start).unwrap_or(start_offset);
+    let range = start_offset..cursor_offset;
     let prefix = rope_text.slice_to_cow(range);
     // We strip the prefix of the current input from the label.
     // So that, for example `p` with a completion of `println` will show `rintln`.

--- a/lapce-app/src/inline_completion.rs
+++ b/lapce-app/src/inline_completion.rs
@@ -184,8 +184,7 @@ impl InlineCompletionData {
         let completion = inline_completion_text(text, offset, offset, item, None);
 
         match completion {
-            ICompletionRes::Set(text, shift) => {
-                let offset = offset + shift;
+            ICompletionRes::Set(text, offset) => {
                 let (line, col) = doc
                     .buffer
                     .with_untracked(|buffer| buffer.offset_to_line_col(offset));
@@ -225,8 +224,7 @@ impl InlineCompletionData {
                 doc.clear_inline_completion();
             }
             ICompletionRes::Unchanged => {}
-            ICompletionRes::Set(new, shift) => {
-                let offset = self.start_offset + shift;
+            ICompletionRes::Set(new, offset) => {
                 let (line, col) = text.offset_to_line_col(offset);
                 doc.set_inline_completion(new, line, col);
             }
@@ -237,6 +235,8 @@ impl InlineCompletionData {
 enum ICompletionRes {
     Hide,
     Unchanged,
+    /// The ghost text to display, paired with the absolute buffer offset it
+    /// should render at (the cursor position).
     Set(String, usize),
 }
 
@@ -252,16 +252,16 @@ fn inline_completion_text(
         .insert_text_format
         .unwrap_or(InsertTextFormat::PLAIN_TEXT);
 
-    // TODO: is this check correct? I mostly copied it from completion lens
-    let cursor_prev_offset = rope_text.prev_code_boundary(cursor_offset);
-    if let Some(range) = &item.range {
-        let edit_start = range.start;
-
-        // If the start of the edit isn't where the cursor currently is, and is not at the start of
-        // the inline completion, then we ignore it.
-        if cursor_prev_offset != edit_start && start_offset != edit_start {
-            return ICompletionRes::Hide;
-        }
+    // The suggestion replaces `item.range` (or, when the server gives no range,
+    // starts where the completion was requested). Copilot returns a range whose
+    // start is before the cursor (its example starts at character 0 of the line),
+    // so the already typed text forms a prefix of the suggestion. We can only
+    // render ghost text when that start is at or before the cursor; the
+    // `strip_prefix` below is what actually decides whether the suggestion still
+    // applies to the current input.
+    let edit_start = item.range.as_ref().map(|r| r.start).unwrap_or(start_offset);
+    if edit_start > cursor_offset {
+        return ICompletionRes::Hide;
     }
 
     let text = match text_format {
@@ -280,8 +280,7 @@ fn inline_completion_text(
         }
     };
 
-    let start_offset = item.range.as_ref().map(|r| r.start).unwrap_or(start_offset);
-    let range = start_offset..cursor_offset;
+    let range = edit_start..cursor_offset;
     let prefix = rope_text.slice_to_cow(range);
     // We strip the prefix of the current input from the label.
     // So that, for example `p` with a completion of `println` will show `rintln`.
@@ -292,6 +291,8 @@ fn inline_completion_text(
     if Some(text) == current_completion {
         ICompletionRes::Unchanged
     } else {
-        ICompletionRes::Set(text.to_string(), prefix.len())
+        // Ghost text renders at the cursor, i.e. immediately after the prefix we
+        // just stripped, so report that absolute offset.
+        ICompletionRes::Set(text.to_string(), cursor_offset)
     }
 }

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -25,14 +25,18 @@ use floem::{
         WriteSignal, use_context,
     },
     text::{Attrs, AttrsList, FamilyOwned, LineHeightValue, TextLayout},
-    views::editor::core::buffer::rope_text::RopeText,
+    views::editor::{core::buffer::rope_text::RopeText, text::SystemClipboard},
 };
 use im::HashMap;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use lapce_core::{
-    command::FocusCommand, cursor::CursorAffinity, directory::Directory, meta,
-    mode::Mode, register::Register,
+    command::FocusCommand,
+    cursor::CursorAffinity,
+    directory::Directory,
+    meta,
+    mode::Mode,
+    register::{Clipboard, Register},
 };
 use lapce_rpc::{
     RpcError,
@@ -1574,6 +1578,16 @@ impl WindowTabData {
                 }
             }
 
+            CopilotSignIn => {
+                self.copilot_sign_in();
+            }
+            CopilotSignOut => {
+                self.copilot_sign_out();
+            }
+            CopilotStatus => {
+                self.copilot_check_status();
+            }
+
         }
     }
 
@@ -2078,6 +2092,15 @@ impl WindowTabData {
         match rpc {
             CoreNotification::ProxyStatus { status } => {
                 self.common.proxy_status.set(Some(status.to_owned()));
+                if matches!(status, ProxyStatus::Connected) {
+                    let config = self.common.config.get_untracked();
+                    if config.core.enable_copilot {
+                        self.common.proxy.copilot_start(
+                            config.core.copilot_server_path.clone(),
+                            Vec::new(),
+                        );
+                    }
+                }
             }
             CoreNotification::DiffInfo { diff } => {
                 self.source_control.branch.set(diff.head.clone());
@@ -2850,6 +2873,142 @@ impl WindowTabData {
         self.alert_data.active.set(true);
     }
 
+    /// Begin the GitHub Copilot device flow sign in. The device code is shown
+    /// in an alert and copied to the clipboard; the user finishes the flow in
+    /// their browser. We intentionally do not auto-complete the flow.
+    fn copilot_sign_in(&self) {
+        let alert_data = self.alert_data.clone();
+        let send = create_ext_action(
+            self.scope,
+            move |result: Result<ProxyResponse, RpcError>| match result {
+                Ok(ProxyResponse::CopilotSignIn { resp }) => {
+                    if let Some(status) = resp.get("status").and_then(|v| v.as_str())
+                    {
+                        if matches!(status, "AlreadySignedIn" | "OK") {
+                            let user = resp
+                                .get("user")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("");
+                            let msg = if user.is_empty() {
+                                "You are already signed in to GitHub Copilot."
+                                    .to_string()
+                            } else {
+                                format!(
+                                    "You are already signed in to GitHub Copilot as {user}."
+                                )
+                            };
+                            set_alert(&alert_data, "GitHub Copilot", &msg, vec![]);
+                            return;
+                        }
+                    }
+                    let user_code = resp
+                        .get("userCode")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let verification_uri = resp
+                        .get("verificationUri")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("https://github.com/login/device")
+                        .to_string();
+                    if user_code.is_empty() {
+                        set_alert(
+                            &alert_data,
+                            "GitHub Copilot",
+                            &format!("Unexpected sign in response: {resp}"),
+                            vec![],
+                        );
+                        return;
+                    }
+                    let mut clipboard = SystemClipboard::new();
+                    clipboard.put_string(&user_code);
+
+                    let active = alert_data.active;
+                    let uri = verification_uri.clone();
+                    let open_button = AlertButton {
+                        text: format!("Open {verification_uri}"),
+                        action: Rc::new(move || {
+                            if let Err(err) = open::that(&uri) {
+                                tracing::error!("{:?}", err);
+                            }
+                            active.set(false);
+                        }),
+                    };
+                    let msg = format!(
+                        "1. Your one-time code is {user_code} (copied to clipboard).\n\
+                         2. Open {verification_uri} and enter the code.\n\
+                         3. Authorize Lapce, then run 'Copilot: Check Status'."
+                    );
+                    set_alert(
+                        &alert_data,
+                        "Sign in to GitHub Copilot",
+                        &msg,
+                        vec![open_button],
+                    );
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    set_alert(
+                        &alert_data,
+                        "GitHub Copilot",
+                        &format!("Sign in failed: {}", err.message),
+                        vec![],
+                    );
+                }
+            },
+        );
+        self.common.proxy.copilot_sign_in(send);
+    }
+
+    /// Report the current GitHub Copilot authentication status in an alert.
+    fn copilot_check_status(&self) {
+        let alert_data = self.alert_data.clone();
+        let send = create_ext_action(
+            self.scope,
+            move |result: Result<ProxyResponse, RpcError>| {
+                let msg = match result {
+                    Ok(ProxyResponse::CopilotCheckStatus { resp }) => {
+                        let status = resp
+                            .get("status")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Unknown");
+                        match resp.get("user").and_then(|v| v.as_str()) {
+                            Some(user) if !user.is_empty() => {
+                                format!("GitHub Copilot status: {status} ({user})")
+                            }
+                            _ => format!("GitHub Copilot status: {status}"),
+                        }
+                    }
+                    Ok(_) => "Unexpected response".to_string(),
+                    Err(err) => {
+                        format!("Could not get status: {}", err.message)
+                    }
+                };
+                set_alert(&alert_data, "GitHub Copilot", &msg, vec![]);
+            },
+        );
+        self.common.proxy.copilot_check_status(send);
+    }
+
+    /// Sign out of GitHub Copilot.
+    fn copilot_sign_out(&self) {
+        let alert_data = self.alert_data.clone();
+        let send = create_ext_action(
+            self.scope,
+            move |result: Result<ProxyResponse, RpcError>| {
+                let msg = match result {
+                    Ok(ProxyResponse::CopilotSignOut { .. }) => {
+                        "Signed out of GitHub Copilot.".to_string()
+                    }
+                    Ok(_) => "Unexpected response".to_string(),
+                    Err(err) => format!("Sign out failed: {}", err.message),
+                };
+                set_alert(&alert_data, "GitHub Copilot", &msg, vec![]);
+            },
+        );
+        self.common.proxy.copilot_sign_out(send);
+    }
+
     fn update_progress(&self, progress: &ProgressParams) {
         let token = progress.token.clone();
         match &progress.value {
@@ -2986,4 +3145,17 @@ fn open_uri(path: &Path) {
             error!("failed to open active file: {path:?}, error: {e}");
         }
     }
+}
+
+/// Populate and show the shared alert box.
+fn set_alert(
+    alert_data: &AlertBoxData,
+    title: &str,
+    msg: &str,
+    buttons: Vec<AlertButton>,
+) {
+    alert_data.title.set(title.to_string());
+    alert_data.msg.set(msg.to_string());
+    alert_data.buttons.set(buttons);
+    alert_data.active.set(true);
 }

--- a/lapce-proxy/src/dispatch.rs
+++ b/lapce-proxy/src/dispatch.rs
@@ -182,6 +182,12 @@ impl ProxyHandler for Dispatcher {
                     tracing::error!("{:?}", err);
                 }
             }
+            CopilotStart {
+                server_path,
+                server_args,
+            } => {
+                self.catalog_rpc.copilot_start(server_path, server_args);
+            }
             NewTerminal { term_id, profile } => {
                 let mut terminal = match Terminal::new(term_id, profile, 50, 10) {
                     Ok(terminal) => terminal,
@@ -639,6 +645,42 @@ impl ProxyHandler for Dispatcher {
                         let result = result.map(|completions| {
                             ProxyResponse::GetInlineCompletions { completions }
                         });
+                        proxy_rpc.handle_response(id, result);
+                    },
+                );
+            }
+            CopilotSignIn {} => {
+                let proxy_rpc = self.proxy_rpc.clone();
+                self.catalog_rpc.copilot_request(
+                    crate::plugin::copilot::SIGN_IN,
+                    serde_json::json!({}),
+                    move |result: Result<serde_json::Value, RpcError>| {
+                        let result =
+                            result.map(|resp| ProxyResponse::CopilotSignIn { resp });
+                        proxy_rpc.handle_response(id, result);
+                    },
+                );
+            }
+            CopilotCheckStatus {} => {
+                let proxy_rpc = self.proxy_rpc.clone();
+                self.catalog_rpc.copilot_request(
+                    crate::plugin::copilot::CHECK_STATUS,
+                    serde_json::json!({ "localChecksOnly": false }),
+                    move |result: Result<serde_json::Value, RpcError>| {
+                        let result = result
+                            .map(|resp| ProxyResponse::CopilotCheckStatus { resp });
+                        proxy_rpc.handle_response(id, result);
+                    },
+                );
+            }
+            CopilotSignOut {} => {
+                let proxy_rpc = self.proxy_rpc.clone();
+                self.catalog_rpc.copilot_request(
+                    crate::plugin::copilot::SIGN_OUT,
+                    serde_json::json!({}),
+                    move |result: Result<serde_json::Value, RpcError>| {
+                        let result = result
+                            .map(|resp| ProxyResponse::CopilotSignOut { resp });
                         proxy_rpc.handle_response(id, result);
                     },
                 );

--- a/lapce-proxy/src/plugin/catalog.rs
+++ b/lapce-proxy/src/plugin/catalog.rs
@@ -27,7 +27,7 @@ use psp_types::Notification;
 use serde_json::Value;
 
 use super::{
-    PluginCatalogNotification, PluginCatalogRpcHandler,
+    PluginCatalogNotification, PluginCatalogRpcHandler, copilot,
     dap::{DapClient, DapRpcHandler, DebuggerData},
     psp::{CloneableCallback, PluginServerRpc, PluginServerRpcHandler, RpcCallback},
     wasi::{load_all_volts, start_volt},
@@ -375,6 +375,40 @@ impl PluginCatalog {
             f.call(Err(RpcError {
                 code: 0,
                 message: "plugin doesn't exist".to_string(),
+            }));
+        }
+    }
+
+    /// Find the running Copilot language server amongst the loaded plugins.
+    fn copilot_plugin(&self) -> Option<&PluginServerRpcHandler> {
+        let copilot_id = copilot::copilot_volt_id();
+        self.plugins
+            .values()
+            .find(|plugin| plugin.volt_id == copilot_id)
+    }
+
+    /// Route a custom Copilot request to the Copilot language server. The
+    /// request is sent directly (no capability/document checks) since these are
+    /// Copilot specific methods.
+    pub fn copilot_request(
+        &self,
+        method: Cow<'static, str>,
+        params: Value,
+        f: Box<dyn RpcCallback<Value, RpcError>>,
+    ) {
+        if let Some(plugin) = self.copilot_plugin() {
+            plugin.server_request_async(
+                method,
+                params,
+                None,
+                None,
+                false,
+                move |result| f.call(result),
+            );
+        } else {
+            f.call(Err(RpcError {
+                code: 0,
+                message: "Copilot is not running. Enable it in settings (core.enable-copilot).".to_string(),
             }));
         }
     }
@@ -745,6 +779,27 @@ impl PluginCatalog {
                         args,
                     },
                 );
+            }
+            CopilotStart {
+                server_path,
+                server_args,
+            } => {
+                if self.copilot_plugin().is_some() {
+                    // already running
+                    return;
+                }
+                let workspace = self.workspace.clone();
+                let plugin_rpc = self.plugin_rpc.clone();
+                thread::spawn(move || {
+                    if let Err(err) = copilot::start(
+                        plugin_rpc,
+                        workspace,
+                        server_path,
+                        server_args,
+                    ) {
+                        tracing::error!("{:?}", err);
+                    }
+                });
             }
             Shutdown => {
                 for (_, plugin) in self.plugins.iter() {

--- a/lapce-proxy/src/plugin/copilot.rs
+++ b/lapce-proxy/src/plugin/copilot.rs
@@ -1,0 +1,164 @@
+//! Native GitHub Copilot integration.
+//!
+//! Copilot ships a standard language server (`copilot-language-server`) that
+//! speaks LSP with a few Copilot specific extensions:
+//!
+//!   * `initialize` must carry `editorInfo` and `editorPluginInfo` inside
+//!     `initializationOptions`, and advertise the
+//!     `textDocument.inlineCompletion` client capability.
+//!   * authentication is driven by the custom `signIn` / `checkStatus` /
+//!     `signOut` requests (GitHub device flow).
+//!   * suggestions are delivered through the standard
+//!     `textDocument/inlineCompletion` request.
+//!
+//! Rather than reinventing the document syncing and inline completion routing,
+//! Copilot is started through the regular [`LspClient`] machinery with a
+//! Copilot flavoured `initialize`. Once running it registers as an inline
+//! completion provider, so the existing inline completion plumbing (ghost text
+//! rendering and the accept keybinding) drives it for free.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use lapce_core::meta;
+use lapce_rpc::plugin::{PluginId, VoltID};
+use lsp_types::{DocumentFilter, DocumentSelector, Url};
+use serde_json::{Value, json};
+
+use super::{PluginCatalogRpcHandler, lsp::LspClient};
+
+/// Synthetic plugin author for the built in Copilot client.
+pub const COPILOT_PLUGIN_AUTHOR: &str = "lapce";
+/// Synthetic plugin name for the built in Copilot client.
+pub const COPILOT_PLUGIN_NAME: &str = "copilot";
+/// Human readable name shown in logs and messages.
+pub const COPILOT_DISPLAY_NAME: &str = "GitHub Copilot";
+/// Default command used to launch the Copilot language server.
+pub const DEFAULT_SERVER_PATH: &str = "copilot-language-server";
+
+/// Custom Copilot request: begin the GitHub device flow sign in.
+pub const SIGN_IN: &str = "signIn";
+/// Custom Copilot request: report the current authentication status.
+pub const CHECK_STATUS: &str = "checkStatus";
+/// Custom Copilot request: sign out of GitHub Copilot.
+pub const SIGN_OUT: &str = "signOut";
+
+/// The synthetic [`VoltID`] used to track the Copilot language server amongst
+/// the regular plugins in the catalog.
+pub fn copilot_volt_id() -> VoltID {
+    VoltID {
+        author: COPILOT_PLUGIN_AUTHOR.to_string(),
+        name: COPILOT_PLUGIN_NAME.to_string(),
+    }
+}
+
+/// The `initializationOptions` Copilot requires on `initialize`.
+pub fn initialization_options() -> Value {
+    json!({
+        "editorInfo": {
+            "name": "Lapce",
+            "version": meta::VERSION,
+        },
+        "editorPluginInfo": {
+            "name": "lapce-copilot",
+            "version": meta::VERSION,
+        },
+    })
+}
+
+/// A document selector that matches every file so Copilot is offered for all
+/// languages, mirroring its behaviour in other editors.
+pub fn document_selector() -> DocumentSelector {
+    vec![DocumentFilter {
+        language: None,
+        scheme: None,
+        pattern: Some("**".to_string()),
+    }]
+}
+
+/// Turn a configured server path into a [`Url`] understood by [`LspClient`].
+///
+/// An absolute path is launched directly (`file:` scheme); a bare command name
+/// is resolved through `PATH` (`urn:` scheme).
+fn server_uri(server_path: &str) -> Result<Url> {
+    let path = Path::new(server_path);
+    if path.is_absolute() {
+        Url::from_file_path(path).map_err(|_| {
+            anyhow::anyhow!("invalid copilot server path: {server_path}")
+        })
+    } else {
+        Ok(Url::parse(&format!("urn:{server_path}"))?)
+    }
+}
+
+/// Start the Copilot language server and register it with the plugin catalog.
+///
+/// The returned [`PluginId`] is allocated up front; the server finishes
+/// initialising asynchronously and only participates in inline completion once
+/// it reports back as loaded.
+pub fn start(
+    catalog_rpc: PluginCatalogRpcHandler,
+    workspace: Option<PathBuf>,
+    server_path: String,
+    server_args: Vec<String>,
+) -> Result<PluginId> {
+    let server_path = if server_path.trim().is_empty() {
+        DEFAULT_SERVER_PATH.to_string()
+    } else {
+        server_path
+    };
+    let args = if server_args.is_empty() {
+        vec!["--stdio".to_string()]
+    } else {
+        server_args
+    };
+
+    let server_uri = server_uri(&server_path)?;
+
+    catalog_rpc.core_rpc.log(
+        lapce_rpc::core::LogLevel::Info,
+        format!("starting {COPILOT_DISPLAY_NAME} language server: {server_path}"),
+        Some("lapce_proxy::plugin::copilot::start".to_string()),
+    );
+
+    LspClient::start(
+        catalog_rpc,
+        document_selector(),
+        workspace,
+        copilot_volt_id(),
+        COPILOT_DISPLAY_NAME.to_string(),
+        None,
+        None,
+        None,
+        server_uri,
+        args,
+        Some(initialization_options()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialization_options_shape() {
+        let options = initialization_options();
+        assert_eq!(options["editorInfo"]["name"], "Lapce");
+        assert_eq!(options["editorPluginInfo"]["name"], "lapce-copilot");
+        assert!(options["editorInfo"]["version"].is_string());
+        assert!(options["editorPluginInfo"]["version"].is_string());
+    }
+
+    #[test]
+    fn bare_command_uses_urn_scheme() {
+        let uri = server_uri("copilot-language-server").unwrap();
+        assert_eq!(uri.scheme(), "urn");
+        assert_eq!(uri.path(), "copilot-language-server");
+    }
+
+    #[test]
+    fn absolute_path_uses_file_scheme() {
+        let uri = server_uri("/usr/local/bin/copilot-language-server").unwrap();
+        assert_eq!(uri.scheme(), "file");
+    }
+}

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -1,4 +1,5 @@
 pub mod catalog;
+pub mod copilot;
 pub mod dap;
 pub mod lsp;
 pub mod psp;
@@ -149,6 +150,13 @@ pub enum PluginCatalogRpc {
         volt: VoltInfo,
         f: Box<dyn CloneableCallback<Value, RpcError>>,
     },
+    /// A custom Copilot request (`signIn` / `checkStatus` / `signOut`) routed
+    /// to the running Copilot language server.
+    Copilot {
+        method: Cow<'static, str>,
+        params: Value,
+        f: Box<dyn RpcCallback<Value, RpcError>>,
+    },
     Shutdown,
 }
 
@@ -211,6 +219,12 @@ pub enum PluginCatalogNotification {
         debugger_type: String,
         program: String,
         args: Option<Vec<String>>,
+    },
+    /// Start the built in Copilot language server, if it is not already
+    /// running.
+    CopilotStart {
+        server_path: String,
+        server_args: Vec<String>,
     },
     Shutdown,
 }
@@ -352,6 +366,9 @@ impl PluginCatalogRpcHandler {
                 }
                 PluginCatalogRpc::RemoveVolt { volt, f } => {
                     plugin.shutdown_volt(volt, f);
+                }
+                PluginCatalogRpc::Copilot { method, params, f } => {
+                    plugin.copilot_request(method, params, f);
                 }
             }
         }
@@ -1324,6 +1341,36 @@ impl PluginCatalogRpcHandler {
         self.catalog_notification(PluginCatalogNotification::UpdatePluginConfigs(
             configs,
         ))
+    }
+
+    /// Start the built in Copilot language server, if not already running.
+    pub fn copilot_start(&self, server_path: String, server_args: Vec<String>) {
+        if let Err(err) =
+            self.catalog_notification(PluginCatalogNotification::CopilotStart {
+                server_path,
+                server_args,
+            })
+        {
+            tracing::error!("{:?}", err);
+        }
+    }
+
+    /// Send a custom Copilot request (`signIn` / `checkStatus` / `signOut`) to
+    /// the running Copilot language server.
+    pub fn copilot_request(
+        &self,
+        method: impl Into<Cow<'static, str>>,
+        params: Value,
+        f: impl RpcCallback<Value, RpcError> + 'static,
+    ) {
+        let rpc = PluginCatalogRpc::Copilot {
+            method: method.into(),
+            params,
+            f: Box::new(f),
+        };
+        if let Err(err) = self.plugin_tx.send(rpc) {
+            tracing::error!("{:?}", err);
+        }
     }
 
     pub fn install_volt(&self, volt: VoltInfo) -> Result<()> {

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -45,8 +45,8 @@ use lsp_types::{
         GotoImplementation, GotoTypeDefinition, HoverRequest, Initialize,
         InlayHintRequest, InlineCompletionRequest, PrepareRenameRequest, References,
         RegisterCapability, Rename, ResolveCompletionItem, SelectionRangeRequest,
-        SemanticTokensFullRequest, SignatureHelpRequest, WorkDoneProgressCreate,
-        WorkspaceSymbolRequest,
+        SemanticTokensFullRequest, ShowDocument, SignatureHelpRequest,
+        WorkDoneProgressCreate, WorkspaceConfiguration, WorkspaceSymbolRequest,
     },
 };
 use parking_lot::Mutex;
@@ -960,6 +960,26 @@ impl PluginHostHandler {
         match method.as_str() {
             WorkDoneProgressCreate::METHOD => {
                 resp.send_null();
+            }
+            WorkspaceConfiguration::METHOD => {
+                // Reply with one empty configuration object per requested item.
+                // Copilot reads its settings out of band, so empty defaults are
+                // sufficient and keep the server from blocking.
+                let len = serde_json::to_value(&params)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("items").and_then(|i| i.as_array()).map(|a| a.len())
+                    })
+                    .unwrap_or(1)
+                    .max(1);
+                let result = vec![Value::Object(serde_json::Map::new()); len];
+                resp.send(result);
+            }
+            ShowDocument::METHOD => {
+                // Copilot uses this to open the device flow URL in a browser.
+                // The editor drives the device flow from the sign in command, so
+                // acknowledge without opening anything here.
+                resp.send(lsp_types::ShowDocumentResult { success: true });
             }
             RegisterCapability::METHOD => {
                 let params: RegistrationParams =

--- a/lapce-rpc/src/proxy.rs
+++ b/lapce-rpc/src/proxy.rs
@@ -220,6 +220,13 @@ pub enum ProxyRequest {
     ReferencesResolve {
         items: Vec<Location>,
     },
+    /// Begin the GitHub Copilot device flow sign in. Returns the device code
+    /// payload (`userCode`, `verificationUri`, ...) untouched.
+    CopilotSignIn {},
+    /// Query the GitHub Copilot authentication status.
+    CopilotCheckStatus {},
+    /// Sign out of GitHub Copilot.
+    CopilotSignOut {},
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -351,6 +358,11 @@ pub enum ProxyNotification {
         path: PathBuf,
         breakpoints: Vec<SourceBreakpoint>,
     },
+    /// Start the built in GitHub Copilot language server, if enabled.
+    CopilotStart {
+        server_path: String,
+        server_args: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -467,6 +479,18 @@ pub enum ProxyResponse {
     SaveResponse {},
     ReferencesResolveResponse {
         items: Vec<FileLine>,
+    },
+    /// Raw response payload from a Copilot `signIn` request.
+    CopilotSignIn {
+        resp: serde_json::Value,
+    },
+    /// Raw response payload from a Copilot `checkStatus` request.
+    CopilotCheckStatus {
+        resp: serde_json::Value,
+    },
+    /// Raw response payload from a Copilot `signOut` request.
+    CopilotSignOut {
+        resp: serde_json::Value,
     },
 }
 
@@ -1088,6 +1112,25 @@ impl ProxyRpcHandler {
             },
             f,
         );
+    }
+
+    pub fn copilot_start(&self, server_path: String, server_args: Vec<String>) {
+        self.notification(ProxyNotification::CopilotStart {
+            server_path,
+            server_args,
+        });
+    }
+
+    pub fn copilot_sign_in(&self, f: impl ProxyCallback + 'static) {
+        self.request_async(ProxyRequest::CopilotSignIn {}, f);
+    }
+
+    pub fn copilot_check_status(&self, f: impl ProxyCallback + 'static) {
+        self.request_async(ProxyRequest::CopilotCheckStatus {}, f);
+    }
+
+    pub fn copilot_sign_out(&self, f: impl ProxyCallback + 'static) {
+        self.request_async(ProxyRequest::CopilotSignOut {}, f);
     }
 
     pub fn update(&self, path: PathBuf, delta: RopeDelta, rev: u64) {


### PR DESCRIPTION
## Summary
- add opt-in GitHub Copilot support through copilot-language-server
- wire Copilot requests through Lapce's existing proxy/plugin RPC path
- add commands for sign-in, sign-out, and status checks
- add settings for enabling Copilot and configuring the server path/args

Closes #3920

## Testing
- cargo fmt --all --check
- cargo test -p lapce-proxy copilot
- cargo clippy

Note: cargo clippy completes successfully with existing warnings outside this change.