### PR TITLE
fix: correct issue reference in dev.lapce.lapce.metainfo.xml (#3786)

### DIFF
--- a/extra/linux/dev.lapce.lapce.metainfo.xml
+++ b/extra/linux/dev.lapce.lapce.metainfo.xml
@@ -53,7 +53,7 @@
         <release version="0.4.4" date="2025-08-30">
             <url type="details">https://github.com/lapce/lapce/releases/tag/v0.4.4</url>
             <issues>
-                <issue url="https://github.com/lapce/lapce/issues/3786">#3795</issue>
+                <issue url="https://github.com/lapce/lapce/issues/3786">#3786</issue>
             </issues>
         </release>
         <release version="0.4.3" date="2024-06-27">


### PR DESCRIPTION
Update the AppStream metainfo by replacing the incorrect issue reference (#3795) with the correct one (#3786) for the v0.4.6 release notes.