### PR TITLE
fix: honour the ui.scroll-width setting again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Fix the `ui.scroll-width` setting being ignored, so the scroll bar can be widened again
+
 ## 0.4.6
 
 ### Features/Changes

--- a/lapce-app/src/config/ui.rs
+++ b/lapce-app/src/config/ui.rs
@@ -141,4 +141,12 @@ impl UIConfig {
             self.palette_width.max(100)
         }
     }
+
+    pub fn scroll_width(&self) -> usize {
+        if self.scroll_width == 0 {
+            10
+        } else {
+            self.scroll_width.max(2)
+        }
+    }
 }

--- a/lapce-app/src/editor/view.rs
+++ b/lapce-app/src/editor/view.rs
@@ -720,7 +720,7 @@ impl EditorView {
         is_local: bool,
         config: Arc<LapceConfig>,
     ) {
-        const BAR_WIDTH: f64 = 10.0;
+        let bar_width = config.ui.scroll_width() as f64;
 
         if is_local {
             return;
@@ -730,7 +730,7 @@ impl EditorView {
             &Rect::ZERO
                 .with_size(Size::new(1.0, viewport.height()))
                 .with_origin(Point::new(
-                    viewport.x0 + viewport.width() - BAR_WIDTH,
+                    viewport.x0 + viewport.width() - bar_width,
                     viewport.y0,
                 ))
                 .inflate(0.0, 10.0),
@@ -762,7 +762,7 @@ impl EditorView {
                 .max(3.0);
             let rect = Rect::ZERO.with_size(Size::new(3.0, height)).with_origin(
                 Point::new(
-                    viewport.x0 + total_width - BAR_WIDTH + 1.0,
+                    viewport.x0 + total_width - bar_width + 1.0,
                     y + viewport.y0,
                 ),
             );
@@ -2144,6 +2144,10 @@ fn editor_content(
             e_data.cancel_inline_completion();
         }
         current_scroll.set(rect);
+    })
+    .scroll_style(move |s| {
+        let width = config.get().ui.scroll_width() as f64;
+        s.handle_thickness(width).track_thickness(width)
     })
     .scroll_to(move || scroll_to.get().map(|s| s.to_point()))
     .scroll_delta(move || scroll_delta.get())


### PR DESCRIPTION
Fixes #3933.

`ui.scroll-width` has not been read since 774008f5 removed `lapce-ui`, where
`scroll.rs` used to size the bars from it. The width is fixed in two places
instead: a `const BAR_WIDTH` in `paint_scroll_bar`, and floem's scroll handle
and track, whose thickness is never set and therefore stays at the default
10px.

## What this does

Re-adds the `scroll_width()` getter that disappeared along with the old
config, and feeds it to all three places that make up the bar:

- floem's handle thickness — the part that is actually visible and draggable
- floem's track thickness, so the groove behind it matches
- `paint_scroll_bar`, which draws the separator line and the git change
  markers into the same strip

A value of zero falls back to the previous 10px, so nothing changes for
anyone who has not touched the setting. The minimum is 2px.

## Verification

Tested on a touch panel, where a 10px bar was the actual problem: with the
setting honoured the bar can be dragged with a finger again, and the git
change markers scale with it. Values from 10 (appearance unchanged) up to 60
behave as expected.

`cargo fmt --all --check` and `cargo clippy --all-targets` both pass on this
branch.

- [x] Added an entry to `CHANGELOG.md` if this change could be valuable to users